### PR TITLE
fix(ci): use rustsec/audit-check for cargo audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,11 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-
       - name: Run cargo audit
-        run: cargo audit
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace manual `cargo install cargo-audit` with `rustsec/audit-check@v2.0.0` action
- Fixes panic on `getrandom 0.4.x` resolution in `cargo-audit 0.22.1`

## Test plan
- [x] Verify security workflow passes on this PR
- [x] Confirm audit results appear as PR check

🤖 Generated with [Claude Code](https://claude.com/claude-code)