### PR TITLE
refactor(engine): rework redaction applicator, add multimodal support

### DIFF
--- a/crates/nvisy-codec/src/document/mod.rs
+++ b/crates/nvisy-codec/src/document/mod.rs
@@ -21,6 +21,7 @@ use crate::handler::{
     TextHandler, TextSpanId, TiffLoader, TiffParams, TxtLoader, TxtParams, WavLoader, WavParams,
     XlsxLoader, XlsxParams,
 };
+use crate::transform::{AudioRedaction, ImageRedaction, TextRedaction};
 
 /// A fully type-erased document that can hold any supported format.
 ///
@@ -136,7 +137,7 @@ impl Document {
     /// [`TextTransform::redact_text`]: crate::transform::TextTransform::redact_text
     pub async fn apply_text_redactions(
         &mut self,
-        redactions: &[crate::transform::TextRedaction<TextSpanId>],
+        redactions: &[TextRedaction<TextSpanId>],
     ) -> Result<(), Error> {
         use crate::transform::TextTransform;
         match self {
@@ -155,7 +156,7 @@ impl Document {
     /// [`ImageTransform::redact_images`]: crate::transform::ImageTransform::redact_images
     pub async fn apply_image_redactions(
         &mut self,
-        redactions: &[crate::transform::ImageRedaction<ImageSpanId>],
+        redactions: &[ImageRedaction<ImageSpanId>],
     ) -> Result<(), Error> {
         use crate::transform::ImageTransform;
         match self {
@@ -174,7 +175,7 @@ impl Document {
     /// [`AudioTransform::redact_audio`]: crate::transform::AudioTransform::redact_audio
     pub async fn apply_audio_redactions(
         &mut self,
-        redactions: &[crate::transform::AudioRedaction<AudioSpanId>],
+        redactions: &[AudioRedaction<AudioSpanId>],
     ) -> Result<(), Error> {
         use crate::transform::AudioTransform;
         match self {

--- a/crates/nvisy-codec/src/document/mod.rs
+++ b/crates/nvisy-codec/src/document/mod.rs
@@ -155,7 +155,7 @@ impl Document {
     /// [`ImageTransform::redact_images`]: crate::transform::ImageTransform::redact_images
     pub async fn apply_image_redactions(
         &mut self,
-        redactions: &[crate::transform::ImageRedaction],
+        redactions: &[crate::transform::ImageRedaction<ImageSpanId>],
     ) -> Result<(), Error> {
         use crate::transform::ImageTransform;
         match self {
@@ -174,7 +174,7 @@ impl Document {
     /// [`AudioTransform::redact_audio`]: crate::transform::AudioTransform::redact_audio
     pub async fn apply_audio_redactions(
         &mut self,
-        redactions: &[crate::transform::AudioRedaction],
+        redactions: &[crate::transform::AudioRedaction<AudioSpanId>],
     ) -> Result<(), Error> {
         use crate::transform::AudioTransform;
         match self {

--- a/crates/nvisy-codec/src/document/mod.rs
+++ b/crates/nvisy-codec/src/document/mod.rs
@@ -165,6 +165,24 @@ impl Document {
         }
     }
 
+    /// Apply a batch of audio redactions to the document.
+    ///
+    /// Delegates to [`AudioTransform::redact_audio`] on the underlying
+    /// audio handler. Returns `Ok(())` for text, image, and rich
+    /// documents (no audio to redact).
+    ///
+    /// [`AudioTransform::redact_audio`]: crate::transform::AudioTransform::redact_audio
+    pub async fn apply_audio_redactions(
+        &mut self,
+        redactions: &[crate::transform::AudioRedaction],
+    ) -> Result<(), Error> {
+        use crate::transform::AudioTransform;
+        match self {
+            Self::Audio(h) => h.redact_audio(redactions).await,
+            Self::Text(_) | Self::Image(_) | Self::Rich(_) => Ok(()),
+        }
+    }
+
     /// Decode [`Content`] into a `Document` using default parameters.
     ///
     /// Format detection uses [`Content::infer_document_type`], which

--- a/crates/nvisy-codec/src/transform/audio/instruction.rs
+++ b/crates/nvisy-codec/src/transform/audio/instruction.rs
@@ -1,15 +1,16 @@
 //! Audio redaction instruction types.
 
+use nvisy_ontology::math::TimeSpan;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// A located audio redaction: pairs a time range with
-/// an [`AudioOutput`] that carries the method-specific parameters.
-pub struct AudioRedaction {
-    /// Start of the redacted segment in seconds.
-    pub start_secs: f64,
-    /// End of the redacted segment in seconds.
-    pub end_secs: f64,
+/// A located audio redaction: pairs a span identifier and time range
+/// with an [`AudioOutput`] that carries the method-specific parameters.
+pub struct AudioRedaction<S> {
+    /// Which audio span this redaction targets.
+    pub span_id: S,
+    /// Time interval of the segment to redact.
+    pub time_span: TimeSpan,
     /// The redaction output that determines the rendering method.
     pub output: AudioOutput,
 }

--- a/crates/nvisy-codec/src/transform/audio/transform.rs
+++ b/crates/nvisy-codec/src/transform/audio/transform.rs
@@ -3,7 +3,7 @@
 use nvisy_core::Error;
 
 use super::instruction::AudioRedaction;
-use crate::handler::AudioHandler;
+use crate::handler::{AudioHandler, AudioSpanId};
 
 const TARGET: &str = "nvisy_codec::transform::audio";
 
@@ -14,12 +14,18 @@ const TARGET: &str = "nvisy_codec::transform::audio";
 #[async_trait::async_trait]
 pub trait AudioTransform: AudioHandler {
     /// Apply a batch of audio redactions, mutating in place.
-    async fn redact_audio(&mut self, redactions: &[AudioRedaction]) -> Result<(), Error>;
+    async fn redact_audio(
+        &mut self,
+        redactions: &[AudioRedaction<AudioSpanId>],
+    ) -> Result<(), Error>;
 }
 
 #[async_trait::async_trait]
 impl<H: AudioHandler> AudioTransform for H {
-    async fn redact_audio(&mut self, redactions: &[AudioRedaction]) -> Result<(), Error> {
+    async fn redact_audio(
+        &mut self,
+        redactions: &[AudioRedaction<AudioSpanId>],
+    ) -> Result<(), Error> {
         tracing::debug!(
             target: TARGET,
             redaction_count = redactions.len(),

--- a/crates/nvisy-codec/src/transform/image/instruction.rs
+++ b/crates/nvisy-codec/src/transform/image/instruction.rs
@@ -4,10 +4,12 @@ use nvisy_ontology::math::BoundingBox;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// A located image redaction: pairs a bounding box with
-/// an [`ImageOutput`] that carries the method-specific parameters.
-pub struct ImageRedaction {
-    /// Bounding box of the region to redact.
+/// A located image redaction: pairs a span identifier, bounding box,
+/// and an [`ImageOutput`] that carries the method-specific parameters.
+pub struct ImageRedaction<S> {
+    /// Which image span this redaction targets.
+    pub span_id: S,
+    /// Bounding box of the region to redact within the span.
     pub bounding_box: BoundingBox,
     /// The redaction output that determines the rendering method.
     pub output: ImageOutput,

--- a/crates/nvisy-codec/src/transform/image/transform.rs
+++ b/crates/nvisy-codec/src/transform/image/transform.rs
@@ -7,7 +7,7 @@ use nvisy_core::Error;
 use super::instruction::{ImageOutput, ImageRedaction};
 use super::ops::ImageOps;
 use crate::document::{Span, SpanStream};
-use crate::handler::{ImageData, ImageHandler};
+use crate::handler::{ImageData, ImageHandler, ImageSpanId};
 
 const TARGET: &str = "nvisy_codec::transform::image";
 
@@ -18,12 +18,18 @@ const TARGET: &str = "nvisy_codec::transform::image";
 #[async_trait::async_trait]
 pub trait ImageTransform: ImageHandler {
     /// Apply a batch of image redactions, mutating in place.
-    async fn redact_images(&mut self, redactions: &[ImageRedaction]) -> Result<(), Error>;
+    async fn redact_images(
+        &mut self,
+        redactions: &[ImageRedaction<ImageSpanId>],
+    ) -> Result<(), Error>;
 }
 
 #[async_trait::async_trait]
 impl<H: ImageHandler> ImageTransform for H {
-    async fn redact_images(&mut self, redactions: &[ImageRedaction]) -> Result<(), Error> {
+    async fn redact_images(
+        &mut self,
+        redactions: &[ImageRedaction<ImageSpanId>],
+    ) -> Result<(), Error> {
         tracing::debug!(
             target: TARGET,
             redaction_count = redactions.len(),

--- a/crates/nvisy-codec/src/transform/text/instruction.rs
+++ b/crates/nvisy-codec/src/transform/text/instruction.rs
@@ -28,6 +28,13 @@ pub enum TextOutput {
 }
 
 impl TextOutput {
+    /// Create a [`Replace`](Self::Replace) output with the given string.
+    pub fn replace(replacement: impl Into<String>) -> Self {
+        Self::Replace {
+            replacement: replacement.into(),
+        }
+    }
+
     /// Returns the text replacement string, regardless of specific method.
     ///
     /// Returns `None` for [`Remove`](Self::Remove) — the caller should

--- a/crates/nvisy-engine/src/operation/encryption/service.rs
+++ b/crates/nvisy-engine/src/operation/encryption/service.rs
@@ -9,6 +9,7 @@ use nvisy_ontology::workflow::EncryptionAlgorithm;
 
 use super::provider::{KeyProvider, SharedKeyProvider};
 use super::wire::{EncryptedContent, WireEnvelope};
+use crate::operation::DocumentEnvelope;
 
 const TARGET: &str = "nvisy_engine::op::encryption";
 
@@ -28,10 +29,7 @@ impl CryptoService {
     }
 
     /// Encrypt a [`DocumentEnvelope`] into an [`EncryptedContent`] blob.
-    pub async fn encrypt(
-        &self,
-        envelope: &crate::operation::DocumentEnvelope,
-    ) -> Result<EncryptedContent> {
+    pub async fn encrypt(&self, envelope: &DocumentEnvelope) -> Result<EncryptedContent> {
         use nvisy_core::ErrorKind;
         use rand::RngExt;
 

--- a/crates/nvisy-engine/src/operation/entity_recognition.rs
+++ b/crates/nvisy-engine/src/operation/entity_recognition.rs
@@ -62,7 +62,7 @@ impl EntityRecognitionOp {
                 entity = entity.with_parent(&span.source);
 
                 if let Some(nvisy_ontology::entity::Location::Text(ref mut loc)) = entity.location {
-                    loc.element_id = Some(span.id.to_string());
+                    loc.span_index = Some(span.id.0);
                 }
 
                 entities.push(entity);

--- a/crates/nvisy-engine/src/operation/pattern_recognition.rs
+++ b/crates/nvisy-engine/src/operation/pattern_recognition.rs
@@ -82,7 +82,7 @@ impl PatternRecognitionOp {
                 entity = entity.with_parent(&span.source);
 
                 if let Some(nvisy_ontology::entity::Location::Text(ref mut loc)) = entity.location {
-                    loc.element_id = Some(span.id.to_string());
+                    loc.span_index = Some(span.id.0);
                 }
 
                 entities.push(entity);

--- a/crates/nvisy-engine/src/operation/redaction/apply.rs
+++ b/crates/nvisy-engine/src/operation/redaction/apply.rs
@@ -6,18 +6,24 @@
 //! writes `replaced_value` into audit records, and applies instructions
 //! to the document.
 
+use std::collections::HashMap;
+
 use nvisy_codec::handler::{AudioSpanId, ImageSpanId, TextSpanId};
 use nvisy_codec::transform::{
     AudioOutput, AudioRedaction, ImageOutput, ImageRedaction, TextOutput, TextRedaction,
 };
 use nvisy_ontology::entity::{Entity, EntityKind, Location};
 use nvisy_ontology::policy::{AudioStrategy, ImageStrategy, Strategy, TextStrategy};
-use nvisy_ontology::provenance::{RedactionDecision, RedactionRecord};
+use nvisy_ontology::provenance::RedactionRecord;
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use crate::operation::DocumentEnvelope;
 
 const TARGET: &str = "nvisy_engine::op::redaction::apply";
+
+const IMAGE_REDACTED: &str = "[IMAGE_REDACTED]";
+const AUDIO_REDACTED: &str = "[AUDIO_REDACTED]";
 
 /// Builds and applies redaction instructions across all modalities.
 ///
@@ -59,12 +65,16 @@ impl<'a> RedactionApplicator<'a> {
     }
 
     fn build_text_redactions(&mut self) -> Vec<TextRedaction<TextSpanId>> {
+        let entity_map = Self::entity_map(&self.envelope.entities);
         let mut redactions = Vec::new();
 
+        // Index-based iteration: borrowing self.envelope.audit.decisions
+        // via for-in would conflict with the mutable access to
+        // self.envelope.audit.records in set_replaced_value.
         for i in 0..self.envelope.audit.decisions.len() {
             let decision = &self.envelope.audit.decisions[i];
-            let entity = match Self::find_entity(&self.envelope.entities, decision) {
-                Some(e) => e,
+            let entity = match entity_map.get(&decision.entity_id) {
+                Some(e) => *e,
                 None => continue,
             };
 
@@ -110,12 +120,13 @@ impl<'a> RedactionApplicator<'a> {
     }
 
     fn build_image_redactions(&mut self) -> Vec<ImageRedaction<ImageSpanId>> {
+        let entity_map = Self::entity_map(&self.envelope.entities);
         let mut redactions = Vec::new();
 
         for i in 0..self.envelope.audit.decisions.len() {
             let decision = &self.envelope.audit.decisions[i];
-            let entity = match Self::find_entity(&self.envelope.entities, decision) {
-                Some(e) => e,
+            let entity = match entity_map.get(&decision.entity_id) {
+                Some(e) => *e,
                 None => continue,
             };
 
@@ -141,7 +152,7 @@ impl<'a> RedactionApplicator<'a> {
             Self::set_replaced_value(
                 &mut self.envelope.audit.records,
                 entity_id,
-                Some("[IMAGE_REDACTED]".into()),
+                Some(IMAGE_REDACTED.into()),
             );
 
             tracing::trace!(
@@ -161,12 +172,13 @@ impl<'a> RedactionApplicator<'a> {
     }
 
     fn build_audio_redactions(&mut self) -> Vec<AudioRedaction<AudioSpanId>> {
+        let entity_map = Self::entity_map(&self.envelope.entities);
         let mut redactions = Vec::new();
 
         for i in 0..self.envelope.audit.decisions.len() {
             let decision = &self.envelope.audit.decisions[i];
-            let entity = match Self::find_entity(&self.envelope.entities, decision) {
-                Some(e) => e,
+            let entity = match entity_map.get(&decision.entity_id) {
+                Some(e) => *e,
                 None => continue,
             };
 
@@ -188,7 +200,7 @@ impl<'a> RedactionApplicator<'a> {
             Self::set_replaced_value(
                 &mut self.envelope.audit.records,
                 entity_id,
-                Some("[AUDIO_REDACTED]".into()),
+                Some(AUDIO_REDACTED.into()),
             );
 
             tracing::trace!(
@@ -209,20 +221,12 @@ impl<'a> RedactionApplicator<'a> {
         redactions
     }
 
-    fn find_entity<'b>(
-        entities: &'b nvisy_ontology::entity::Entities,
-        decision: &RedactionDecision,
-    ) -> Option<&'b Entity> {
-        entities
-            .iter()
-            .find(|e| e.source.as_uuid() == decision.entity_id)
+    /// Build a lookup map from entity UUID to entity reference.
+    fn entity_map(entities: &nvisy_ontology::entity::Entities) -> HashMap<Uuid, &Entity> {
+        entities.iter().map(|e| (e.source.as_uuid(), e)).collect()
     }
 
-    fn set_replaced_value(
-        records: &mut [RedactionRecord],
-        entity_id: uuid::Uuid,
-        value: Option<String>,
-    ) {
+    fn set_replaced_value(records: &mut [RedactionRecord], entity_id: Uuid, value: Option<String>) {
         if let Some(record) = records.iter_mut().find(|r| r.entity_id == entity_id) {
             record.replaced_value = value;
         }
@@ -392,5 +396,21 @@ mod tests {
             .apply()
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn hash_replacement_is_deterministic() {
+        let a = RedactionApplicator::hash_value("John Smith");
+        let b = RedactionApplicator::hash_value("John Smith");
+        assert_eq!(a, b);
+        assert!(!a.is_empty());
+    }
+
+    #[test]
+    fn pseudonymize_is_deterministic() {
+        let a = RedactionApplicator::pseudonymize(&EntityKind::PersonName, "John Smith");
+        let b = RedactionApplicator::pseudonymize(&EntityKind::PersonName, "John Smith");
+        assert_eq!(a, b);
+        assert!(a.contains('_'));
     }
 }

--- a/crates/nvisy-engine/src/operation/redaction/apply.rs
+++ b/crates/nvisy-engine/src/operation/redaction/apply.rs
@@ -1,5 +1,10 @@
-//! Compute replacement text from a strategy and apply redaction
-//! decisions to document content via codec transforms.
+//! Compute replacement values and build redaction instructions from
+//! evaluated decisions via codec transforms.
+//!
+//! [`RedactionApplicator`] takes evaluated decisions and the document's
+//! entities, and builds per-modality codec instruction vectors. The
+//! caller applies them to the document separately (avoiding borrow
+//! conflicts with the envelope).
 
 use nvisy_codec::handler::TextSpanId;
 use nvisy_codec::transform::{TextOutput, TextRedaction};
@@ -10,123 +15,218 @@ use sha2::{Digest, Sha256};
 
 const TARGET: &str = "nvisy_engine::op::redaction::apply";
 
-/// Build codec [`TextRedaction`] instructions from redaction decisions
-/// and the entities they reference.
+/// Builds per-modality codec instructions from redaction decisions
+/// and the document's entities.
 ///
-/// For each decision that targets a text entity with a text strategy,
-/// computes the replacement string and emits a `TextRedaction` with
-/// the span ID and byte offsets from the entity's [`TextLocation`].
-///
-/// Decisions targeting image or audio entities are skipped (those
-/// need separate codec transforms).
-pub(super) fn build_text_redactions(
-    decisions: &[RedactionDecision],
-    entities: &Entities,
-) -> Vec<TextRedaction<TextSpanId>> {
-    let mut redactions = Vec::new();
-
-    for decision in decisions {
-        let entity = match entities
-            .iter()
-            .find(|e| e.source.as_uuid() == decision.entity_id)
-        {
-            Some(e) => e,
-            None => continue,
-        };
-
-        let Some(Location::Text(ref loc)) = entity.location else {
-            continue;
-        };
-
-        let replacement = match &decision.spec {
-            Strategy::Text(text) => build_text_replacement(entity, text),
-            _ => continue,
-        };
-
-        let span_id = match &loc.element_id {
-            Some(id) => match id.parse::<usize>() {
-                Ok(n) => TextSpanId(n),
-                Err(_) => continue,
-            },
-            None => continue,
-        };
-
-        let output = if replacement.is_empty() {
-            TextOutput::Remove
-        } else {
-            TextOutput::Replace { replacement }
-        };
-
-        tracing::trace!(
-            target: TARGET,
-            entity_id = %decision.entity_id,
-            span = span_id.0,
-            start = loc.start_offset,
-            end = loc.end_offset,
-            "built text redaction instruction",
-        );
-
-        redactions.push(TextRedaction {
-            span_id,
-            start: loc.start_offset,
-            end: loc.end_offset,
-            output,
-        });
-    }
-
-    tracing::debug!(
-        target: TARGET,
-        decisions = decisions.len(),
-        text_redactions = redactions.len(),
-        "built codec instructions",
-    );
-
-    redactions
+/// The applicator borrows decisions and entities to produce typed
+/// redaction instruction vectors. The caller applies them to the
+/// document separately (avoiding borrow conflicts with the envelope).
+pub(super) struct RedactionApplicator<'a> {
+    decisions: &'a [RedactionDecision],
+    entities: &'a Entities,
 }
 
-/// Compute replacement text for a single entity and text strategy.
-fn build_text_replacement(entity: &Entity, strategy: &TextStrategy) -> String {
-    match strategy {
-        TextStrategy::Mask { mask_char } => mask_char.to_string().repeat(entity.value.len()),
+impl<'a> RedactionApplicator<'a> {
+    pub fn new(decisions: &'a [RedactionDecision], entities: &'a Entities) -> Self {
+        Self {
+            decisions,
+            entities,
+        }
+    }
 
-        TextStrategy::Replace { placeholder } => {
-            if placeholder.is_empty() {
-                format!("[{}]", entity.entity_kind.to_string().to_uppercase())
+    /// Build codec [`TextRedaction`] instructions from decisions targeting
+    /// text entities with text strategies.
+    pub fn build_text_redactions(&self) -> Vec<TextRedaction<TextSpanId>> {
+        let mut redactions = Vec::new();
+
+        for decision in self.decisions {
+            let entity = match self.find_entity(decision) {
+                Some(e) => e,
+                None => continue,
+            };
+
+            let Some(Location::Text(ref loc)) = entity.location else {
+                continue;
+            };
+
+            let replacement = match &decision.spec {
+                Strategy::Text(text) => self.text_replacement(entity, text),
+                _ => continue,
+            };
+
+            let span_id = match &loc.element_id {
+                Some(id) => match id.parse::<usize>() {
+                    Ok(n) => TextSpanId(n),
+                    Err(_) => continue,
+                },
+                None => continue,
+            };
+
+            let output = if replacement.is_empty() {
+                TextOutput::Remove
             } else {
-                placeholder
-                    .replace("{entityType}", &entity.entity_kind.to_string())
-                    .replace("{category}", &entity.category.to_string())
-            }
+                TextOutput::Replace { replacement }
+            };
+
+            tracing::trace!(
+                target: TARGET,
+                entity_id = %decision.entity_id,
+                span = span_id.0,
+                start = loc.start_offset,
+                end = loc.end_offset,
+                "built text redaction instruction",
+            );
+
+            redactions.push(TextRedaction {
+                span_id,
+                start: loc.start_offset,
+                end: loc.end_offset,
+                output,
+            });
         }
 
-        TextStrategy::Remove => String::new(),
-
-        TextStrategy::Hash => hash_value(&entity.value),
-
-        TextStrategy::Pseudonymize => pseudonymize(&entity.entity_kind, &entity.value),
-
-        TextStrategy::Encrypt { .. } => format!("[ENC:{}]", entity.entity_kind),
-        TextStrategy::Generate => format!("[GEN:{}]", entity.entity_kind),
-        TextStrategy::Tokenize { .. } => format!("[TOKEN:{}]", entity.entity_kind),
-        _ => format!("[REDACTED:{}]", entity.entity_kind),
+        redactions
     }
-}
 
-fn hash_value(value: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(value.as_bytes());
-    let hash = hasher.finalize();
-    hash.iter().take(8).map(|b| format!("{b:02x}")).collect()
-}
+    /// Build image redaction instructions from decisions targeting
+    /// image entities with image strategies.
+    pub fn build_image_redactions(&self) -> Vec<nvisy_codec::transform::ImageRedaction> {
+        use nvisy_codec::transform::{ImageOutput, ImageRedaction};
+        use nvisy_ontology::policy::ImageStrategy;
 
-fn pseudonymize(entity_kind: &EntityKind, value: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(entity_kind.to_string().as_bytes());
-    hasher.update(b":");
-    hasher.update(value.as_bytes());
-    let hash = hasher.finalize();
-    let id: u32 = u32::from_le_bytes([hash[0], hash[1], hash[2], hash[3]]);
-    format!("{entity_kind}_{id}")
+        let mut redactions = Vec::new();
+
+        for decision in self.decisions {
+            let entity = match self.find_entity(decision) {
+                Some(e) => e,
+                None => continue,
+            };
+
+            let Some(Location::Image(ref loc)) = entity.location else {
+                continue;
+            };
+
+            let output = match &decision.spec {
+                Strategy::Image(img) => match img {
+                    ImageStrategy::Blur { sigma } => ImageOutput::Blur { sigma: *sigma },
+                    ImageStrategy::Block { color } => ImageOutput::Block { color: *color },
+                    ImageStrategy::Pixelate { block_size } => ImageOutput::Pixelate {
+                        block_size: *block_size,
+                    },
+                    _ => continue,
+                },
+                _ => continue,
+            };
+
+            tracing::trace!(
+                target: TARGET,
+                entity_id = %decision.entity_id,
+                "built image redaction instruction",
+            );
+
+            redactions.push(ImageRedaction {
+                bounding_box: loc.bounding_box,
+                output,
+            });
+        }
+
+        redactions
+    }
+
+    /// Build audio redaction instructions from decisions targeting
+    /// audio entities with audio strategies.
+    pub fn build_audio_redactions(&self) -> Vec<nvisy_codec::transform::AudioRedaction> {
+        use nvisy_codec::transform::{AudioOutput, AudioRedaction};
+        use nvisy_ontology::policy::AudioStrategy;
+
+        let mut redactions = Vec::new();
+
+        for decision in self.decisions {
+            let entity = match self.find_entity(decision) {
+                Some(e) => e,
+                None => continue,
+            };
+
+            let Some(Location::Audio(ref loc)) = entity.location else {
+                continue;
+            };
+
+            let output = match &decision.spec {
+                Strategy::Audio(audio) => match audio {
+                    AudioStrategy::Silence => AudioOutput::Silence,
+                    AudioStrategy::Remove => AudioOutput::Remove,
+                    _ => continue,
+                },
+                _ => continue,
+            };
+
+            tracing::trace!(
+                target: TARGET,
+                entity_id = %decision.entity_id,
+                start = loc.time_span.start_secs,
+                end = loc.time_span.end_secs,
+                "built audio redaction instruction",
+            );
+
+            redactions.push(AudioRedaction {
+                start_secs: loc.time_span.start_secs,
+                end_secs: loc.time_span.end_secs,
+                output,
+            });
+        }
+
+        redactions
+    }
+
+    fn find_entity(&self, decision: &RedactionDecision) -> Option<&'a Entity> {
+        self.entities
+            .iter()
+            .find(|e| e.source.as_uuid() == decision.entity_id)
+    }
+
+    /// Compute replacement text for a single entity and text strategy.
+    fn text_replacement(&self, entity: &Entity, strategy: &TextStrategy) -> String {
+        match strategy {
+            TextStrategy::Mask { mask_char } => mask_char.to_string().repeat(entity.value.len()),
+
+            TextStrategy::Replace { placeholder } => {
+                if placeholder.is_empty() {
+                    format!("[{}]", entity.entity_kind.to_string().to_uppercase())
+                } else {
+                    placeholder
+                        .replace("{entityType}", &entity.entity_kind.to_string())
+                        .replace("{category}", &entity.category.to_string())
+                }
+            }
+
+            TextStrategy::Remove => String::new(),
+
+            TextStrategy::Hash => Self::hash_value(&entity.value),
+
+            TextStrategy::Pseudonymize => Self::pseudonymize(&entity.entity_kind, &entity.value),
+
+            TextStrategy::Encrypt { .. } => format!("[ENC:{}]", entity.entity_kind),
+            TextStrategy::Tokenize { .. } => format!("[TOKEN:{}]", entity.entity_kind),
+            _ => format!("[REDACTED:{}]", entity.entity_kind),
+        }
+    }
+
+    fn hash_value(value: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(value.as_bytes());
+        let hash = hasher.finalize();
+        hash.iter().take(8).map(|b| format!("{b:02x}")).collect()
+    }
+
+    fn pseudonymize(entity_kind: &EntityKind, value: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(entity_kind.to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(value.as_bytes());
+        let hash = hasher.finalize();
+        let id: u32 = u32::from_le_bytes([hash[0], hash[1], hash[2], hash[3]]);
+        format!("{entity_kind}_{id}")
+    }
 }
 
 #[cfg(test)]
@@ -154,6 +254,13 @@ mod tests {
             .unwrap()
     }
 
+    fn applicator<'a>(
+        decisions: &'a [RedactionDecision],
+        entities: &'a Entities,
+    ) -> RedactionApplicator<'a> {
+        RedactionApplicator::new(decisions, entities)
+    }
+
     #[test]
     fn mask_builds_text_redaction() {
         let entity = text_entity("John", 0, 5, 9);
@@ -163,7 +270,7 @@ mod tests {
             0.9,
         );
         let entities: Entities = vec![entity].into();
-        let redactions = build_text_redactions(&[decision], &entities);
+        let redactions = applicator(&[decision], &entities).build_text_redactions();
         assert_eq!(redactions.len(), 1);
         assert_eq!(redactions[0].span_id, TextSpanId(0));
         assert_eq!(redactions[0].start, 5);
@@ -180,7 +287,7 @@ mod tests {
             0.9,
         );
         let entities: Entities = vec![entity].into();
-        let redactions = build_text_redactions(&[decision], &entities);
+        let redactions = applicator(&[decision], &entities).build_text_redactions();
         assert_eq!(redactions.len(), 1);
         assert!(redactions[0].output.replacement_value().is_none());
     }
@@ -196,7 +303,7 @@ mod tests {
             0.9,
         );
         let entities: Entities = vec![entity].into();
-        let redactions = build_text_redactions(&[decision], &entities);
+        let redactions = applicator(&[decision], &entities).build_text_redactions();
         assert!(redactions.is_empty());
     }
 
@@ -216,7 +323,7 @@ mod tests {
             0.9,
         );
         let entities: Entities = vec![entity].into();
-        let redactions = build_text_redactions(&[decision], &entities);
+        let redactions = applicator(&[decision], &entities).build_text_redactions();
         assert!(redactions.is_empty());
     }
 
@@ -229,8 +336,8 @@ mod tests {
             0.9,
         );
         let entities: Entities = vec![entity].into();
-        let r1 = build_text_redactions(&[d1.clone()], &entities);
-        let r2 = build_text_redactions(&[d1], &entities);
+        let r1 = applicator(&[d1.clone()], &entities).build_text_redactions();
+        let r2 = applicator(&[d1], &entities).build_text_redactions();
         assert_eq!(
             r1[0].output.replacement_value(),
             r2[0].output.replacement_value()

--- a/crates/nvisy-engine/src/operation/redaction/apply.rs
+++ b/crates/nvisy-engine/src/operation/redaction/apply.rs
@@ -1,48 +1,69 @@
-//! Compute replacement values and build redaction instructions from
-//! evaluated decisions via codec transforms.
+//! Compute replacement values and apply redaction decisions to
+//! document content via codec transforms.
 //!
-//! [`RedactionApplicator`] takes evaluated decisions and the document's
-//! entities, and builds per-modality codec instruction vectors. The
-//! caller applies them to the document separately (avoiding borrow
-//! conflicts with the envelope).
+//! [`RedactionApplicator`] holds a mutable reference to the envelope
+//! and reads decisions/entities, builds per-modality codec instructions,
+//! writes `replaced_value` into audit records, and applies instructions
+//! to the document.
 
 use nvisy_codec::handler::{AudioSpanId, ImageSpanId, TextSpanId};
 use nvisy_codec::transform::{
     AudioOutput, AudioRedaction, ImageOutput, ImageRedaction, TextOutput, TextRedaction,
 };
-use nvisy_ontology::entity::{Entities, Entity, EntityKind, Location};
+use nvisy_ontology::entity::{Entity, EntityKind, Location};
 use nvisy_ontology::policy::{AudioStrategy, ImageStrategy, Strategy, TextStrategy};
-use nvisy_ontology::provenance::RedactionDecision;
+use nvisy_ontology::provenance::{RedactionDecision, RedactionRecord};
 use sha2::{Digest, Sha256};
+
+use crate::operation::DocumentEnvelope;
 
 const TARGET: &str = "nvisy_engine::op::redaction::apply";
 
-/// Builds per-modality codec instructions from redaction decisions
-/// and the document's entities.
+/// Builds and applies redaction instructions across all modalities.
 ///
-/// The applicator borrows decisions and entities to produce typed
-/// redaction instruction vectors. The caller applies them to the
-/// document separately (avoiding borrow conflicts with the envelope).
+/// Holds `&mut DocumentEnvelope` and accesses its fields directly:
+/// reads `audit.decisions` and `entities`, writes `audit.records`,
+/// and mutates `document`.
 pub(super) struct RedactionApplicator<'a> {
-    decisions: &'a [RedactionDecision],
-    entities: &'a Entities,
+    envelope: &'a mut DocumentEnvelope,
 }
 
 impl<'a> RedactionApplicator<'a> {
-    pub fn new(decisions: &'a [RedactionDecision], entities: &'a Entities) -> Self {
-        Self {
-            decisions,
-            entities,
-        }
+    pub fn new(envelope: &'a mut DocumentEnvelope) -> Self {
+        Self { envelope }
     }
 
-    /// Build codec [`TextRedaction`] instructions from decisions targeting
-    /// text entities with text strategies.
-    pub fn build_text_redactions(&self) -> Vec<TextRedaction<TextSpanId>> {
+    /// Build and apply all redaction instructions.
+    pub async fn apply(mut self) -> nvisy_core::Result<()> {
+        let text = self.build_text_redactions();
+        let image = self.build_image_redactions();
+        let audio = self.build_audio_redactions();
+
+        if !text.is_empty() {
+            self.envelope.document.apply_text_redactions(&text).await?;
+        }
+        if !image.is_empty() {
+            self.envelope
+                .document
+                .apply_image_redactions(&image)
+                .await?;
+        }
+        if !audio.is_empty() {
+            self.envelope
+                .document
+                .apply_audio_redactions(&audio)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    fn build_text_redactions(&mut self) -> Vec<TextRedaction<TextSpanId>> {
         let mut redactions = Vec::new();
 
-        for decision in self.decisions {
-            let entity = match self.find_entity(decision) {
+        for i in 0..self.envelope.audit.decisions.len() {
+            let decision = &self.envelope.audit.decisions[i];
+            let entity = match Self::find_entity(&self.envelope.entities, decision) {
                 Some(e) => e,
                 None => continue,
             };
@@ -60,10 +81,17 @@ impl<'a> RedactionApplicator<'a> {
                 continue;
             };
             let span_id = TextSpanId(index);
+            let entity_id = decision.entity_id;
+
+            Self::set_replaced_value(
+                &mut self.envelope.audit.records,
+                entity_id,
+                output.replacement_value().map(String::from),
+            );
 
             tracing::trace!(
                 target: TARGET,
-                entity_id = %decision.entity_id,
+                %entity_id,
                 span = span_id.0,
                 start = loc.start_offset,
                 end = loc.end_offset,
@@ -81,13 +109,12 @@ impl<'a> RedactionApplicator<'a> {
         redactions
     }
 
-    /// Build image redaction instructions from decisions targeting
-    /// image entities with image strategies.
-    pub fn build_image_redactions(&self) -> Vec<ImageRedaction<ImageSpanId>> {
+    fn build_image_redactions(&mut self) -> Vec<ImageRedaction<ImageSpanId>> {
         let mut redactions = Vec::new();
 
-        for decision in self.decisions {
-            let entity = match self.find_entity(decision) {
+        for i in 0..self.envelope.audit.decisions.len() {
+            let decision = &self.envelope.audit.decisions[i];
+            let entity = match Self::find_entity(&self.envelope.entities, decision) {
                 Some(e) => e,
                 None => continue,
             };
@@ -100,21 +127,26 @@ impl<'a> RedactionApplicator<'a> {
                 Strategy::Image(img) => match img {
                     ImageStrategy::Blur { sigma } => ImageOutput::Blur { sigma: *sigma },
                     ImageStrategy::Block { color } => ImageOutput::Block { color: *color },
-                    ImageStrategy::Pixelate { block_size } => {
-                        ImageOutput::Pixelate {
-                            block_size: *block_size,
-                        }
-                    }
+                    ImageStrategy::Pixelate { block_size } => ImageOutput::Pixelate {
+                        block_size: *block_size,
+                    },
                     _ => continue,
                 },
                 _ => continue,
             };
 
             let span_id = ImageSpanId(loc.page_number);
+            let entity_id = decision.entity_id;
+
+            Self::set_replaced_value(
+                &mut self.envelope.audit.records,
+                entity_id,
+                Some("[IMAGE_REDACTED]".into()),
+            );
 
             tracing::trace!(
                 target: TARGET,
-                entity_id = %decision.entity_id,
+                %entity_id,
                 "built image redaction instruction",
             );
 
@@ -128,13 +160,12 @@ impl<'a> RedactionApplicator<'a> {
         redactions
     }
 
-    /// Build audio redaction instructions from decisions targeting
-    /// audio entities with audio strategies.
-    pub fn build_audio_redactions(&self) -> Vec<AudioRedaction<AudioSpanId>> {
+    fn build_audio_redactions(&mut self) -> Vec<AudioRedaction<AudioSpanId>> {
         let mut redactions = Vec::new();
 
-        for decision in self.decisions {
-            let entity = match self.find_entity(decision) {
+        for i in 0..self.envelope.audit.decisions.len() {
+            let decision = &self.envelope.audit.decisions[i];
+            let entity = match Self::find_entity(&self.envelope.entities, decision) {
                 Some(e) => e,
                 None => continue,
             };
@@ -152,9 +183,17 @@ impl<'a> RedactionApplicator<'a> {
                 _ => continue,
             };
 
+            let entity_id = decision.entity_id;
+
+            Self::set_replaced_value(
+                &mut self.envelope.audit.records,
+                entity_id,
+                Some("[AUDIO_REDACTED]".into()),
+            );
+
             tracing::trace!(
                 target: TARGET,
-                entity_id = %decision.entity_id,
+                %entity_id,
                 start = loc.time_span.start_secs,
                 end = loc.time_span.end_secs,
                 "built audio redaction instruction",
@@ -170,13 +209,25 @@ impl<'a> RedactionApplicator<'a> {
         redactions
     }
 
-    fn find_entity(&self, decision: &RedactionDecision) -> Option<&'a Entity> {
-        self.entities
+    fn find_entity<'b>(
+        entities: &'b nvisy_ontology::entity::Entities,
+        decision: &RedactionDecision,
+    ) -> Option<&'b Entity> {
+        entities
             .iter()
             .find(|e| e.source.as_uuid() == decision.entity_id)
     }
 
-    /// Compute the [`TextOutput`] for a single entity and text strategy.
+    fn set_replaced_value(
+        records: &mut [RedactionRecord],
+        entity_id: uuid::Uuid,
+        value: Option<String>,
+    ) {
+        if let Some(record) = records.iter_mut().find(|r| r.entity_id == entity_id) {
+            record.replaced_value = value;
+        }
+    }
+
     fn text_output(entity: &Entity, strategy: &TextStrategy) -> TextOutput {
         match strategy {
             TextStrategy::Mask { mask_char } => {
@@ -236,11 +287,16 @@ impl<'a> RedactionApplicator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use nvisy_codec::Document;
+    use nvisy_core::content::{Content, ContentData, ContentMetadata, ContentSource};
     use nvisy_ontology::entity::{
-        Entity, EntityCategory, EntityKind, RecognitionMethod, TextLocation,
+        Entities, Entity, EntityCategory, EntityKind, Location, RecognitionMethod, TextLocation,
     };
+    use nvisy_ontology::policy::ImageStrategy;
+    use nvisy_ontology::provenance::RedactionDecision;
 
     use super::*;
+    use crate::operation::envelope::SharedData;
 
     fn text_entity(value: &str, span_index: usize, start: usize, end: usize) -> Entity {
         Entity::builder()
@@ -259,91 +315,82 @@ mod tests {
             .unwrap()
     }
 
-    fn applicator<'a>(
-        decisions: &'a [RedactionDecision],
-        entities: &'a Entities,
-    ) -> RedactionApplicator<'a> {
-        RedactionApplicator::new(decisions, entities)
+    async fn test_envelope(entities: Entities) -> DocumentEnvelope {
+        let data = ContentData::from_text(ContentSource::new(), "Hello John world");
+        let content =
+            Content::with_metadata(data, ContentMetadata::new().with_content_type("text/plain"));
+        let doc = Document::decode(&content).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let registry = crate::registry::Registry::open(dir.path()).unwrap();
+        let shared = SharedData::new(uuid::Uuid::new_v4(), uuid::Uuid::new_v4(), registry);
+        let mut envelope = DocumentEnvelope::new(doc, ContentMetadata::default(), shared);
+        envelope.entities = entities;
+        envelope
     }
 
-    #[test]
-    fn mask_builds_text_redaction() {
-        let entity = text_entity("John", 0, 5, 9);
+    #[tokio::test]
+    async fn mask_applies_and_records_replacement() {
+        let entity = text_entity("John", 0, 6, 10);
+        let entity_id = entity.source.as_uuid();
         let decision = RedactionDecision::new(
-            entity.source.as_uuid(),
+            entity_id,
             Strategy::Text(TextStrategy::Mask { mask_char: '*' }),
             0.9,
         );
-        let entities: Entities = vec![entity].into();
-        let redactions = applicator(&[decision], &entities).build_text_redactions();
-        assert_eq!(redactions.len(), 1);
-        assert_eq!(redactions[0].span_id, TextSpanId(0));
-        assert_eq!(redactions[0].start, 5);
-        assert_eq!(redactions[0].end, 9);
-        assert_eq!(redactions[0].output.replacement_value(), Some("****"));
-    }
+        let record = RedactionRecord::new(entity_id, "John", 0.9);
 
-    #[test]
-    fn remove_builds_remove_output() {
-        let entity = text_entity("secret", 0, 0, 6);
-        let decision = RedactionDecision::new(
-            entity.source.as_uuid(),
-            Strategy::Text(TextStrategy::Remove),
-            0.9,
+        let entities: Entities = vec![entity].into();
+        let mut envelope = test_envelope(entities).await;
+        envelope.audit.decisions.push(decision);
+        envelope.audit.records.push(record);
+
+        RedactionApplicator::new(&mut envelope)
+            .apply()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            envelope.audit.records[0].replaced_value.as_deref(),
+            Some("****"),
         );
-        let entities: Entities = vec![entity].into();
-        let redactions = applicator(&[decision], &entities).build_text_redactions();
-        assert_eq!(redactions.len(), 1);
-        assert_eq!(redactions[0].output, TextOutput::Remove);
     }
 
-    #[test]
-    fn skips_image_strategy_for_text_entity() {
+    #[tokio::test]
+    async fn remove_leaves_replaced_value_none() {
+        let entity = text_entity("John", 0, 6, 10);
+        let entity_id = entity.source.as_uuid();
+        let decision = RedactionDecision::new(entity_id, Strategy::Text(TextStrategy::Remove), 0.9);
+        let record = RedactionRecord::new(entity_id, "John", 0.9);
+
+        let entities: Entities = vec![entity].into();
+        let mut envelope = test_envelope(entities).await;
+        envelope.audit.decisions.push(decision);
+        envelope.audit.records.push(record);
+
+        RedactionApplicator::new(&mut envelope)
+            .apply()
+            .await
+            .unwrap();
+
+        assert!(envelope.audit.records[0].replaced_value.is_none());
+    }
+
+    #[tokio::test]
+    async fn skips_image_strategy_for_text_entity() {
         let entity = text_entity("face", 0, 0, 4);
         let decision = RedactionDecision::new(
             entity.source.as_uuid(),
             Strategy::Image(ImageStrategy::Blur { sigma: 15.0 }),
             0.9,
         );
-        let entities: Entities = vec![entity].into();
-        let redactions = applicator(&[decision], &entities).build_text_redactions();
-        assert!(redactions.is_empty());
-    }
 
-    #[test]
-    fn skips_entity_without_location() {
-        let entity = Entity::builder()
-            .with_category(EntityCategory::PersonalIdentity)
-            .with_entity_kind(EntityKind::PersonName)
-            .with_value("John")
-            .with_recognition_methods(vec![RecognitionMethod::regex("test")])
-            .with_confidence(0.9)
-            .build()
+        let entities: Entities = vec![entity].into();
+        let mut envelope = test_envelope(entities).await;
+        envelope.audit.decisions.push(decision);
+
+        RedactionApplicator::new(&mut envelope)
+            .apply()
+            .await
             .unwrap();
-        let decision = RedactionDecision::new(
-            entity.source.as_uuid(),
-            Strategy::Text(TextStrategy::Hash),
-            0.9,
-        );
-        let entities: Entities = vec![entity].into();
-        let redactions = applicator(&[decision], &entities).build_text_redactions();
-        assert!(redactions.is_empty());
-    }
-
-    #[test]
-    fn hash_replacement_is_deterministic() {
-        let entity = text_entity("John Smith", 0, 0, 10);
-        let d1 = RedactionDecision::new(
-            entity.source.as_uuid(),
-            Strategy::Text(TextStrategy::Hash),
-            0.9,
-        );
-        let entities: Entities = vec![entity].into();
-        let r1 = applicator(&[d1.clone()], &entities).build_text_redactions();
-        let r2 = applicator(&[d1], &entities).build_text_redactions();
-        assert_eq!(
-            r1[0].output.replacement_value(),
-            r2[0].output.replacement_value()
-        );
     }
 }

--- a/crates/nvisy-engine/src/operation/redaction/apply.rs
+++ b/crates/nvisy-engine/src/operation/redaction/apply.rs
@@ -6,10 +6,12 @@
 //! caller applies them to the document separately (avoiding borrow
 //! conflicts with the envelope).
 
-use nvisy_codec::handler::TextSpanId;
-use nvisy_codec::transform::{TextOutput, TextRedaction};
+use nvisy_codec::handler::{AudioSpanId, ImageSpanId, TextSpanId};
+use nvisy_codec::transform::{
+    AudioOutput, AudioRedaction, ImageOutput, ImageRedaction, TextOutput, TextRedaction,
+};
 use nvisy_ontology::entity::{Entities, Entity, EntityKind, Location};
-use nvisy_ontology::policy::{Strategy, TextStrategy};
+use nvisy_ontology::policy::{AudioStrategy, ImageStrategy, Strategy, TextStrategy};
 use nvisy_ontology::provenance::RedactionDecision;
 use sha2::{Digest, Sha256};
 
@@ -49,24 +51,15 @@ impl<'a> RedactionApplicator<'a> {
                 continue;
             };
 
-            let replacement = match &decision.spec {
-                Strategy::Text(text) => self.text_replacement(entity, text),
+            let output = match &decision.spec {
+                Strategy::Text(text) => Self::text_output(entity, text),
                 _ => continue,
             };
 
-            let span_id = match &loc.element_id {
-                Some(id) => match id.parse::<usize>() {
-                    Ok(n) => TextSpanId(n),
-                    Err(_) => continue,
-                },
-                None => continue,
+            let Some(index) = loc.span_index else {
+                continue;
             };
-
-            let output = if replacement.is_empty() {
-                TextOutput::Remove
-            } else {
-                TextOutput::Replace { replacement }
-            };
+            let span_id = TextSpanId(index);
 
             tracing::trace!(
                 target: TARGET,
@@ -90,10 +83,7 @@ impl<'a> RedactionApplicator<'a> {
 
     /// Build image redaction instructions from decisions targeting
     /// image entities with image strategies.
-    pub fn build_image_redactions(&self) -> Vec<nvisy_codec::transform::ImageRedaction> {
-        use nvisy_codec::transform::{ImageOutput, ImageRedaction};
-        use nvisy_ontology::policy::ImageStrategy;
-
+    pub fn build_image_redactions(&self) -> Vec<ImageRedaction<ImageSpanId>> {
         let mut redactions = Vec::new();
 
         for decision in self.decisions {
@@ -110,13 +100,17 @@ impl<'a> RedactionApplicator<'a> {
                 Strategy::Image(img) => match img {
                     ImageStrategy::Blur { sigma } => ImageOutput::Blur { sigma: *sigma },
                     ImageStrategy::Block { color } => ImageOutput::Block { color: *color },
-                    ImageStrategy::Pixelate { block_size } => ImageOutput::Pixelate {
-                        block_size: *block_size,
-                    },
+                    ImageStrategy::Pixelate { block_size } => {
+                        ImageOutput::Pixelate {
+                            block_size: *block_size,
+                        }
+                    }
                     _ => continue,
                 },
                 _ => continue,
             };
+
+            let span_id = ImageSpanId(loc.page_number);
 
             tracing::trace!(
                 target: TARGET,
@@ -125,6 +119,7 @@ impl<'a> RedactionApplicator<'a> {
             );
 
             redactions.push(ImageRedaction {
+                span_id,
                 bounding_box: loc.bounding_box,
                 output,
             });
@@ -135,10 +130,7 @@ impl<'a> RedactionApplicator<'a> {
 
     /// Build audio redaction instructions from decisions targeting
     /// audio entities with audio strategies.
-    pub fn build_audio_redactions(&self) -> Vec<nvisy_codec::transform::AudioRedaction> {
-        use nvisy_codec::transform::{AudioOutput, AudioRedaction};
-        use nvisy_ontology::policy::AudioStrategy;
-
+    pub fn build_audio_redactions(&self) -> Vec<AudioRedaction<AudioSpanId>> {
         let mut redactions = Vec::new();
 
         for decision in self.decisions {
@@ -169,8 +161,8 @@ impl<'a> RedactionApplicator<'a> {
             );
 
             redactions.push(AudioRedaction {
-                start_secs: loc.time_span.start_secs,
-                end_secs: loc.time_span.end_secs,
+                span_id: AudioSpanId::default(),
+                time_span: loc.time_span,
                 output,
             });
         }
@@ -184,30 +176,43 @@ impl<'a> RedactionApplicator<'a> {
             .find(|e| e.source.as_uuid() == decision.entity_id)
     }
 
-    /// Compute replacement text for a single entity and text strategy.
-    fn text_replacement(&self, entity: &Entity, strategy: &TextStrategy) -> String {
+    /// Compute the [`TextOutput`] for a single entity and text strategy.
+    fn text_output(entity: &Entity, strategy: &TextStrategy) -> TextOutput {
         match strategy {
-            TextStrategy::Mask { mask_char } => mask_char.to_string().repeat(entity.value.len()),
+            TextStrategy::Mask { mask_char } => {
+                TextOutput::replace(mask_char.to_string().repeat(entity.value.len()))
+            }
 
             TextStrategy::Replace { placeholder } => {
                 if placeholder.is_empty() {
-                    format!("[{}]", entity.entity_kind.to_string().to_uppercase())
+                    TextOutput::replace(format!(
+                        "[{}]",
+                        entity.entity_kind.to_string().to_uppercase()
+                    ))
                 } else {
-                    placeholder
-                        .replace("{entityType}", &entity.entity_kind.to_string())
-                        .replace("{category}", &entity.category.to_string())
+                    TextOutput::replace(
+                        placeholder
+                            .replace("{entityType}", &entity.entity_kind.to_string())
+                            .replace("{category}", &entity.category.to_string()),
+                    )
                 }
             }
 
-            TextStrategy::Remove => String::new(),
+            TextStrategy::Remove => TextOutput::Remove,
 
-            TextStrategy::Hash => Self::hash_value(&entity.value),
+            TextStrategy::Hash => TextOutput::replace(Self::hash_value(&entity.value)),
 
-            TextStrategy::Pseudonymize => Self::pseudonymize(&entity.entity_kind, &entity.value),
+            TextStrategy::Pseudonymize => {
+                TextOutput::replace(Self::pseudonymize(&entity.entity_kind, &entity.value))
+            }
 
-            TextStrategy::Encrypt { .. } => format!("[ENC:{}]", entity.entity_kind),
-            TextStrategy::Tokenize { .. } => format!("[TOKEN:{}]", entity.entity_kind),
-            _ => format!("[REDACTED:{}]", entity.entity_kind),
+            TextStrategy::Encrypt { .. } => {
+                TextOutput::replace(format!("[ENC:{}]", entity.entity_kind))
+            }
+            TextStrategy::Tokenize { .. } => {
+                TextOutput::replace(format!("[TOKEN:{}]", entity.entity_kind))
+            }
+            _ => TextOutput::replace(format!("[REDACTED:{}]", entity.entity_kind)),
         }
     }
 
@@ -237,7 +242,7 @@ mod tests {
 
     use super::*;
 
-    fn text_entity(value: &str, span_id: usize, start: usize, end: usize) -> Entity {
+    fn text_entity(value: &str, span_index: usize, start: usize, end: usize) -> Entity {
         Entity::builder()
             .with_category(EntityCategory::PersonalIdentity)
             .with_entity_kind(EntityKind::PersonName)
@@ -247,7 +252,7 @@ mod tests {
             .with_location(Location::from(TextLocation {
                 start_offset: start,
                 end_offset: end,
-                element_id: Some(span_id.to_string()),
+                span_index: Some(span_index),
                 ..Default::default()
             }))
             .build()
@@ -289,13 +294,11 @@ mod tests {
         let entities: Entities = vec![entity].into();
         let redactions = applicator(&[decision], &entities).build_text_redactions();
         assert_eq!(redactions.len(), 1);
-        assert!(redactions[0].output.replacement_value().is_none());
+        assert_eq!(redactions[0].output, TextOutput::Remove);
     }
 
     #[test]
-    fn skips_image_strategy() {
-        use nvisy_ontology::policy::ImageStrategy;
-
+    fn skips_image_strategy_for_text_entity() {
         let entity = text_entity("face", 0, 0, 4);
         let decision = RedactionDecision::new(
             entity.source.as_uuid(),

--- a/crates/nvisy-engine/src/operation/redaction/evaluate.rs
+++ b/crates/nvisy-engine/src/operation/redaction/evaluate.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use nvisy_core::Result;
-use nvisy_ontology::entity::{Entities, Entity};
+use nvisy_ontology::entity::{Entities, Entity, Location};
 use nvisy_ontology::policy::{PolicyRule, RuleAction, Strategy, TextStrategy};
 use nvisy_ontology::provenance::{RedactionDecision, RedactionRecord};
 use nvisy_ontology::workflow::Redaction;
@@ -35,6 +35,9 @@ impl RedactionOp {
             .iter()
             .flat_map(|p| p.rules.clone())
             .collect();
+        // Lower priority value = higher precedence. First match wins
+        // in find_matching_rule, so sorting ascending means the
+        // highest-precedence rule is checked first.
         rules.sort_by_key(|r| r.priority);
 
         let evaluator = PolicyEvaluator {
@@ -59,7 +62,7 @@ impl Operation for RedactionOp {
             "evaluating redaction policies",
         );
 
-        let (decisions, records) = self.evaluator.evaluate(&envelope.entities)?;
+        let (decisions, records) = self.evaluator.evaluate(&envelope.entities);
         envelope.audit.decisions.extend(decisions);
         envelope.audit.records.extend(records);
 
@@ -76,10 +79,7 @@ struct PolicyEvaluator {
 }
 
 impl PolicyEvaluator {
-    fn evaluate(
-        &self,
-        entities: &Entities,
-    ) -> Result<(Vec<RedactionDecision>, Vec<RedactionRecord>)> {
+    fn evaluate(&self, entities: &Entities) -> (Vec<RedactionDecision>, Vec<RedactionRecord>) {
         tracing::debug!(
             target: TARGET,
             entity_count = entities.len(),
@@ -95,16 +95,12 @@ impl PolicyEvaluator {
             let spec = match rule {
                 Some(r) => match &r.action {
                     RuleAction::Redact { strategy } => strategy.clone(),
-                    action @ (RuleAction::Review
-                    | RuleAction::Alert
-                    | RuleAction::Block
-                    | RuleAction::Suppress
-                    | _) => {
+                    _ => {
                         tracing::debug!(
                             target: TARGET,
                             entity_id = %entity.source.as_uuid(),
                             rule_id = %r.id,
-                            action = ?action,
+                            action = ?r.action,
                             "non-redact policy action",
                         );
                         continue;
@@ -114,27 +110,31 @@ impl PolicyEvaluator {
                     if entity.confidence < self.default_threshold {
                         continue;
                     }
+                    // Default strategy only applies to text entities.
+                    // Non-text entities without a matching rule are skipped.
+                    if !matches!(entity.location, Some(Location::Text(_))) {
+                        continue;
+                    }
                     self.default_spec.clone()
                 }
             };
 
             let entity_id = entity.source.as_uuid();
+            let policy_rule_id = rule.map(|r| r.id);
 
             let mut decision = RedactionDecision::new(entity_id, spec, entity.confidence);
-            if let Some(r) = rule {
-                decision = decision.with_policy_rule_id(r.id);
+            let mut record = RedactionRecord::new(entity_id, &entity.value, entity.confidence);
+
+            if let Some(rule_id) = policy_rule_id {
+                decision = decision.with_policy_rule_id(rule_id);
+                record = record.with_policy_rule_id(rule_id);
             }
             decision.source.set_parent_id(Some(entity_id));
-
-            let mut record = RedactionRecord::new(entity_id, &entity.value, entity.confidence);
-            if let Some(r) = rule {
-                record = record.with_policy_rule_id(r.id);
-            }
             record.source.set_parent_id(Some(entity_id));
 
             tracing::trace!(
                 target: TARGET,
-                entity_id = %entity_id,
+                %entity_id,
                 strategy = ?decision.spec,
                 "produced redaction decision",
             );
@@ -150,7 +150,7 @@ impl PolicyEvaluator {
             "policy evaluation complete",
         );
 
-        Ok((decisions, records))
+        (decisions, records)
     }
 
     fn find_matching_rule(&self, entity: &Entity) -> Option<&PolicyRule> {
@@ -163,17 +163,25 @@ impl PolicyEvaluator {
 
 #[cfg(test)]
 mod tests {
-    use nvisy_ontology::entity::{Entity, EntityCategory, EntityKind, RecognitionMethod};
+    use nvisy_ontology::entity::{Entity, EntityCategory, EntityKind, Location, RecognitionMethod};
 
     use super::*;
 
     fn test_entity(value: &str, confidence: f64) -> Entity {
+        use nvisy_ontology::entity::TextLocation;
+
         Entity::builder()
             .with_category(EntityCategory::PersonalIdentity)
             .with_entity_kind(EntityKind::PersonName)
             .with_value(value)
             .with_recognition_methods(vec![RecognitionMethod::regex("test")])
             .with_confidence(confidence)
+            .with_location(Location::from(TextLocation {
+                start_offset: 0,
+                end_offset: value.len(),
+                span_index: Some(0),
+                ..Default::default()
+            }))
             .build()
             .unwrap()
     }
@@ -186,7 +194,7 @@ mod tests {
             default_threshold: 0.8,
         };
         let entities: Entities = vec![test_entity("John", 0.5)].into();
-        let (decisions, _) = evaluator.evaluate(&entities).unwrap();
+        let (decisions, _) = evaluator.evaluate(&entities);
         assert!(decisions.is_empty());
     }
 
@@ -198,7 +206,7 @@ mod tests {
             default_threshold: 0.5,
         };
         let entities: Entities = vec![test_entity("John", 0.9)].into();
-        let (decisions, records) = evaluator.evaluate(&entities).unwrap();
+        let (decisions, records) = evaluator.evaluate(&entities);
         assert_eq!(decisions.len(), 1);
         assert_eq!(records.len(), 1);
         assert!(!decisions[0].applied);
@@ -212,7 +220,7 @@ mod tests {
             default_threshold: 0.0,
         };
         let entities: Entities = vec![test_entity("secret", 0.9)].into();
-        let (decisions, _) = evaluator.evaluate(&entities).unwrap();
+        let (decisions, _) = evaluator.evaluate(&entities);
         assert_eq!(decisions[0].spec, Strategy::Text(TextStrategy::Remove));
     }
 
@@ -224,7 +232,7 @@ mod tests {
             default_threshold: 0.0,
         };
         let entities: Entities = vec![test_entity("secret-value", 0.9)].into();
-        let (_, records) = evaluator.evaluate(&entities).unwrap();
+        let (_, records) = evaluator.evaluate(&entities);
         assert_eq!(records[0].original_value, "secret-value");
     }
 }

--- a/crates/nvisy-engine/src/operation/redaction/evaluate.rs
+++ b/crates/nvisy-engine/src/operation/redaction/evaluate.rs
@@ -60,39 +60,10 @@ impl Operation for RedactionOp {
         );
 
         let (decisions, records) = self.evaluator.evaluate(&envelope.entities)?;
-
-        // Build redaction instructions in a scoped borrow, then apply
-        // them to the document afterward (separate borrow scopes).
-        let (text_redactions, image_redactions, audio_redactions) = {
-            let applicator = RedactionApplicator::new(&decisions, &envelope.entities);
-            (
-                applicator.build_text_redactions(),
-                applicator.build_image_redactions(),
-                applicator.build_audio_redactions(),
-            )
-        };
-
-        if !text_redactions.is_empty() {
-            envelope
-                .document
-                .apply_text_redactions(&text_redactions)
-                .await?;
-        }
-        if !image_redactions.is_empty() {
-            envelope
-                .document
-                .apply_image_redactions(&image_redactions)
-                .await?;
-        }
-        if !audio_redactions.is_empty() {
-            envelope
-                .document
-                .apply_audio_redactions(&audio_redactions)
-                .await?;
-        }
-
         envelope.audit.decisions.extend(decisions);
         envelope.audit.records.extend(records);
+
+        RedactionApplicator::new(envelope).apply().await?;
 
         Ok(())
     }

--- a/crates/nvisy-engine/src/operation/redaction/evaluate.rs
+++ b/crates/nvisy-engine/src/operation/redaction/evaluate.rs
@@ -61,12 +61,16 @@ impl Operation for RedactionOp {
 
         let (decisions, records) = self.evaluator.evaluate(&envelope.entities)?;
 
-        // Build and apply redaction instructions across all modalities.
-        let applicator = RedactionApplicator::new(&decisions, &envelope.entities);
-        let text_redactions = applicator.build_text_redactions();
-        let image_redactions = applicator.build_image_redactions();
-        let audio_redactions = applicator.build_audio_redactions();
-        drop(applicator);
+        // Build redaction instructions in a scoped borrow, then apply
+        // them to the document afterward (separate borrow scopes).
+        let (text_redactions, image_redactions, audio_redactions) = {
+            let applicator = RedactionApplicator::new(&decisions, &envelope.entities);
+            (
+                applicator.build_text_redactions(),
+                applicator.build_image_redactions(),
+                applicator.build_audio_redactions(),
+            )
+        };
 
         if !text_redactions.is_empty() {
             envelope

--- a/crates/nvisy-engine/src/operation/redaction/evaluate.rs
+++ b/crates/nvisy-engine/src/operation/redaction/evaluate.rs
@@ -2,7 +2,8 @@
 //!
 //! Runs at **phase 4** alongside [`GenerateContextOp`]. Evaluates policy
 //! rules against detected entities to produce redaction decisions, then
-//! builds and applies text redaction instructions to the document.
+//! builds and applies redaction instructions across all modalities
+//! (text, image, audio) via [`RedactionApplicator`].
 //!
 //! [`GenerateContextOp`]: crate::operation::GenerateContextOp
 
@@ -14,7 +15,7 @@ use nvisy_ontology::policy::{PolicyRule, RuleAction, Strategy, TextStrategy};
 use nvisy_ontology::provenance::{RedactionDecision, RedactionRecord};
 use nvisy_ontology::workflow::Redaction;
 
-use super::apply::build_text_redactions;
+use super::apply::RedactionApplicator;
 use crate::operation::envelope::SharedData;
 use crate::operation::{DocumentEnvelope, Operation};
 
@@ -60,12 +61,29 @@ impl Operation for RedactionOp {
 
         let (decisions, records) = self.evaluator.evaluate(&envelope.entities)?;
 
-        // Build and apply text redaction instructions.
-        let text_redactions = build_text_redactions(&decisions, &envelope.entities);
+        // Build and apply redaction instructions across all modalities.
+        let applicator = RedactionApplicator::new(&decisions, &envelope.entities);
+        let text_redactions = applicator.build_text_redactions();
+        let image_redactions = applicator.build_image_redactions();
+        let audio_redactions = applicator.build_audio_redactions();
+        drop(applicator);
+
         if !text_redactions.is_empty() {
             envelope
                 .document
                 .apply_text_redactions(&text_redactions)
+                .await?;
+        }
+        if !image_redactions.is_empty() {
+            envelope
+                .document
+                .apply_image_redactions(&image_redactions)
+                .await?;
+        }
+        if !audio_redactions.is_empty() {
+            envelope
+                .document
+                .apply_audio_redactions(&audio_redactions)
                 .await?;
         }
 

--- a/crates/nvisy-engine/src/operation/redaction/mod.rs
+++ b/crates/nvisy-engine/src/operation/redaction/mod.rs
@@ -1,11 +1,12 @@
-//! Redaction operation: policy evaluation + application.
+//! Redaction operation: policy evaluation + multimodal application.
 //!
 //! Phase 4 of the pipeline. Two steps:
 //!
 //! 1. **Evaluate**: match entities against policy rules to produce
-//!    [`RedactionDecision`]s (in [`evaluate`]).
-//! 2. **Apply**: compute replacement text from each decision's strategy
-//!    and build codec [`TextRedaction`] instructions (in [`apply`]).
+//!    [`RedactionDecision`]s and [`RedactionRecord`]s (in [`evaluate`]).
+//! 2. **Apply**: build per-modality codec instructions (text, image,
+//!    audio) from decisions and apply them to the document, writing
+//!    replacement values into audit records (in [`apply`]).
 
 mod apply;
 mod evaluate;

--- a/crates/nvisy-ontology/src/entity/location/text.rs
+++ b/crates/nvisy-ontology/src/entity/location/text.rs
@@ -20,9 +20,9 @@ pub struct TextLocation {
     /// End offset of the surrounding context window for redaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_end_offset: Option<usize>,
-    /// Identifier of the document element containing this entity.
+    /// Positional index of the text span containing this entity.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub element_id: Option<String>,
+    pub span_index: Option<usize>,
     /// 1-based page number where the entity was found.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_number: Option<u32>,

--- a/crates/nvisy-ontology/src/policy/strategy/text.rs
+++ b/crates/nvisy-ontology/src/policy/strategy/text.rs
@@ -36,8 +36,6 @@ pub enum TextStrategy {
     },
     /// Remove the value entirely.
     Remove,
-    /// Replace with a realistically generated value.
-    Generate,
     /// Replace with a consistent pseudonym.
     Pseudonymize,
     /// Replace with a vault-backed reversible token.

--- a/crates/nvisy-ontology/src/provenance/record/redaction.rs
+++ b/crates/nvisy-ontology/src/provenance/record/redaction.rs
@@ -23,6 +23,14 @@ pub struct RedactionRecord {
     pub entity_id: Uuid,
     /// The original sensitive value, retained for audit purposes.
     pub original_value: String,
+    /// The replacement value after redaction was applied.
+    ///
+    /// `None` until the redaction is applied, or when the strategy
+    /// removes the value entirely (e.g. [`TextStrategy::Remove`]).
+    ///
+    /// [`TextStrategy::Remove`]: crate::policy::TextStrategy::Remove
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replaced_value: Option<String>,
     /// Detection confidence that led to this redaction.
     pub confidence: f64,
     /// Identifier of the policy rule that triggered this redaction.
@@ -42,6 +50,7 @@ impl RedactionRecord {
             source: ContentSource::new(),
             entity_id,
             original_value: original_value.into(),
+            replaced_value: None,
             confidence,
             policy_rule_id: None,
             version: 1,

--- a/crates/nvisy-pattern/src/engine/mod.rs
+++ b/crates/nvisy-pattern/src/engine/mod.rs
@@ -142,7 +142,7 @@ impl PatternEngine {
     ///
     /// Each entity carries a [`TextLocation`] with `start_offset` and
     /// `end_offset` set from the match. The caller is responsible for
-    /// attaching `element_id` and parent source from the span context.
+    /// attaching `span_index` and parent source from the span context.
     #[tracing::instrument(target = TARGET, skip(self, text, ctx), fields(text_len = text.len(), entities = tracing::field::Empty))]
     pub fn scan_entities(&self, text: &str, ctx: &ScanContext) -> Vec<Entity> {
         let mut raw = self.scan_raw(text, ctx);

--- a/crates/nvisy-provider/src/agent/ner/mod.rs
+++ b/crates/nvisy-provider/src/agent/ner/mod.rs
@@ -126,7 +126,7 @@ impl NerAgent {
     /// clear the state between documents.
     ///
     /// The caller is responsible for attaching span-level metadata
-    /// (`element_id`, parent source) after this call.
+    /// (`span_index`, parent source) after this call.
     #[tracing::instrument(
         target = "nvisy_provider::agent::ner",
         skip_all,


### PR DESCRIPTION
## Summary
- Rework `apply.rs` into `RedactionApplicator` struct that builds per-modality codec instructions (text, image, audio) from redaction decisions
- Move free functions (`hash_value`, `pseudonymize`, `text_replacement`) into `RedactionApplicator` methods
- Add `Document::apply_audio_redactions` delegation method (completes text/image/audio trio)
- Remove `TextStrategy::Generate` — tracked in nvisycom/elide#30 for proper LLM-based implementation across all modalities

## Test plan
- [x] All 115 tests pass
- [x] Clippy clean
- [x] Full workspace compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)