### PR TITLE
feat(engine, ontology): integrate upload-time annotations

### DIFF
--- a/crates/nvisy-core/src/content/content_metadata.rs
+++ b/crates/nvisy-core/src/content/content_metadata.rs
@@ -8,6 +8,7 @@
 
 use std::path::{Path, PathBuf};
 
+use nvisy_ontology::entity::Annotations;
 use serde::{Deserialize, Serialize};
 
 use crate::media::DocumentType;
@@ -43,6 +44,9 @@ pub struct ContentMetadata {
     /// Arbitrary key-value metadata associated with this content.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    /// Pre-identified regions and classification labels for this content.
+    #[serde(default, skip_serializing_if = "Annotations::is_empty")]
+    pub annotations: Annotations,
 }
 
 impl ContentMetadata {
@@ -57,6 +61,7 @@ impl ContentMetadata {
             size: None,
             sha256: None,
             metadata: None,
+            annotations: Annotations::new(),
         }
     }
 
@@ -70,7 +75,15 @@ impl ContentMetadata {
             size: None,
             sha256: None,
             metadata: None,
+            annotations: Annotations::new(),
         }
+    }
+
+    /// Set annotations (builder pattern).
+    #[must_use]
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = annotations;
+        self
     }
 
     /// Set the caller-supplied MIME type (builder pattern).

--- a/crates/nvisy-engine/src/operation/entity_recognition.rs
+++ b/crates/nvisy-engine/src/operation/entity_recognition.rs
@@ -81,7 +81,7 @@ impl Operation for EntityRecognitionOp {
                 detected = detected.len(),
                 "appending NER entities",
             );
-            envelope.audit.entities.extend(detected);
+            envelope.add_entities(detected);
         }
         self.agent.reset().await;
         Ok(())

--- a/crates/nvisy-engine/src/operation/envelope/mod.rs
+++ b/crates/nvisy-engine/src/operation/envelope/mod.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use nvisy_codec::Document;
 use nvisy_core::content::ContentMetadata;
 use nvisy_ontology::context::Contexts;
+use nvisy_ontology::entity::{Annotations, Entity};
 use nvisy_ontology::provenance::Audit;
 
 mod shared;
@@ -50,6 +51,10 @@ pub struct DocumentEnvelope {
     /// Content metadata (MIME type, filename, etc.) from the original upload.
     pub metadata: ContentMetadata,
 
+    /// User-supplied annotations (inclusions, exclusions, labels)
+    /// attached at upload time.
+    pub annotations: Annotations,
+
     /// Reference-data contexts loaded by [`LoadContext`] nodes.
     ///
     /// [`LoadContext`]: nvisy_ontology::workflow::LoadContext
@@ -73,6 +78,7 @@ impl DocumentEnvelope {
         Self {
             document,
             metadata,
+            annotations: Annotations::new(),
             contexts: Contexts::new(),
             audit,
             shared,
@@ -82,6 +88,20 @@ impl DocumentEnvelope {
     /// Number of detected entities.
     pub fn entity_count(&self) -> usize {
         self.audit.entities.len()
+    }
+
+    /// Add detected entities, filtering out any that fall within
+    /// exclusion annotations.
+    pub fn add_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
+        if self.annotations.is_empty() {
+            self.audit.entities.extend(entities);
+        } else {
+            for entity in entities {
+                if !self.annotations.is_excluded(&entity) {
+                    self.audit.entities.push(entity);
+                }
+            }
+        }
     }
 }
 

--- a/crates/nvisy-engine/src/operation/envelope/mod.rs
+++ b/crates/nvisy-engine/src/operation/envelope/mod.rs
@@ -52,8 +52,8 @@ pub struct DocumentEnvelope {
     pub metadata: ContentMetadata,
 
     /// User-supplied annotations (inclusions, exclusions, labels)
-    /// attached at upload time.
-    pub annotations: Annotations,
+    /// attached at upload time. Set during import from content metadata.
+    pub(crate) annotations: Annotations,
 
     /// Reference-data contexts loaded by [`LoadContext`] nodes.
     ///

--- a/crates/nvisy-engine/src/operation/import_file.rs
+++ b/crates/nvisy-engine/src/operation/import_file.rs
@@ -87,10 +87,14 @@ impl ImportFileOp {
         tracing::debug!(target: TARGET, doc_type = %doc.document_type(), "decoded document");
         let mut metadata = content.into_parts().1.unwrap_or_default();
 
-        // Move persisted annotations from metadata to the envelope.
+        // Move persisted annotations from metadata to the envelope
+        // and apply inclusions as entities.
         let annotations = std::mem::take(&mut metadata.annotations);
         let mut envelope = DocumentEnvelope::new(doc, metadata, Arc::clone(shared));
-        envelope.annotations = annotations;
+        if !annotations.is_empty() {
+            annotations.apply_inclusions(&mut envelope.audit.entities);
+            envelope.annotations = annotations;
+        }
         Ok(envelope)
     }
 }

--- a/crates/nvisy-engine/src/operation/import_file.rs
+++ b/crates/nvisy-engine/src/operation/import_file.rs
@@ -85,8 +85,13 @@ impl ImportFileOp {
 
         let doc = Document::decode(&content).await?;
         tracing::debug!(target: TARGET, doc_type = %doc.document_type(), "decoded document");
-        let metadata = content.into_parts().1.unwrap_or_default();
-        Ok(DocumentEnvelope::new(doc, metadata, Arc::clone(shared)))
+        let mut metadata = content.into_parts().1.unwrap_or_default();
+
+        // Move persisted annotations from metadata to the envelope.
+        let annotations = std::mem::take(&mut metadata.annotations);
+        let mut envelope = DocumentEnvelope::new(doc, metadata, Arc::clone(shared));
+        envelope.annotations = annotations;
+        Ok(envelope)
     }
 }
 

--- a/crates/nvisy-engine/src/operation/pattern_recognition.rs
+++ b/crates/nvisy-engine/src/operation/pattern_recognition.rs
@@ -108,7 +108,7 @@ impl Operation for PatternRecognitionOp {
                 detected = detected.len(),
                 "appending pattern entities",
             );
-            envelope.audit.entities.extend(detected);
+            envelope.add_entities(detected);
         }
         Ok(())
     }

--- a/crates/nvisy-engine/src/operation/redaction/evaluate.rs
+++ b/crates/nvisy-engine/src/operation/redaction/evaluate.rs
@@ -62,7 +62,8 @@ impl Operation for RedactionOp {
             "evaluating redaction policies",
         );
 
-        let records = self.evaluator.evaluate(&envelope.audit.entities);
+        let document_labels = envelope.annotations.document_labels();
+        let records = self.evaluator.evaluate(&envelope.audit.entities, &document_labels);
         envelope.audit.entries.extend(records);
 
         RedactionApplicator::new(envelope).apply().await?;
@@ -78,17 +79,18 @@ struct PolicyEvaluator {
 }
 
 impl PolicyEvaluator {
-    fn evaluate(&self, entities: &Entities) -> Vec<AuditEntry> {
+    fn evaluate(&self, entities: &Entities, document_labels: &[&str]) -> Vec<AuditEntry> {
         tracing::debug!(
             target: TARGET,
             entity_count = entities.len(),
             rules = self.rules.len(),
+            labels = document_labels.len(),
             "evaluating policies",
         );
         let mut records = Vec::new();
 
         for entity in entities {
-            let rule = self.find_matching_rule(entity);
+            let rule = self.find_matching_rule(entity, document_labels);
 
             let spec = match rule {
                 Some(r) => match &r.action {
@@ -145,10 +147,29 @@ impl PolicyEvaluator {
         records
     }
 
-    fn find_matching_rule(&self, entity: &Entity) -> Option<&PolicyRule> {
+    fn find_matching_rule(
+        &self,
+        entity: &Entity,
+        document_labels: &[&str],
+    ) -> Option<&PolicyRule> {
         self.rules.iter().find(|rule| {
-            rule.selector
+            // Check entity selector match.
+            if !rule
+                .selector
                 .matches(&entity.category, entity.entity_kind, entity.confidence)
+            {
+                return false;
+            }
+            // Check rule conditions (required document labels).
+            if let Some(ref conditions) = rule.conditions
+                && !conditions
+                    .required_labels
+                    .iter()
+                    .all(|required| document_labels.contains(&required.as_str()))
+            {
+                return false;
+            }
+            true
         })
     }
 }

--- a/crates/nvisy-engine/src/operation/redaction/evaluate.rs
+++ b/crates/nvisy-engine/src/operation/redaction/evaluate.rs
@@ -63,7 +63,9 @@ impl Operation for RedactionOp {
         );
 
         let document_labels = envelope.annotations.document_labels();
-        let records = self.evaluator.evaluate(&envelope.audit.entities, &document_labels);
+        let records = self
+            .evaluator
+            .evaluate(&envelope.audit.entities, &document_labels);
         envelope.audit.entries.extend(records);
 
         RedactionApplicator::new(envelope).apply().await?;
@@ -147,11 +149,7 @@ impl PolicyEvaluator {
         records
     }
 
-    fn find_matching_rule(
-        &self,
-        entity: &Entity,
-        document_labels: &[&str],
-    ) -> Option<&PolicyRule> {
+    fn find_matching_rule(&self, entity: &Entity, document_labels: &[&str]) -> Option<&PolicyRule> {
         self.rules.iter().find(|rule| {
             // Check entity selector match.
             if !rule
@@ -207,7 +205,7 @@ mod tests {
             default_threshold: 0.8,
         };
         let entities: Entities = vec![test_entity("John", 0.5)].into();
-        let records = evaluator.evaluate(&entities);
+        let records = evaluator.evaluate(&entities, &[]);
         assert!(records.is_empty());
     }
 
@@ -219,7 +217,7 @@ mod tests {
             default_threshold: 0.5,
         };
         let entities: Entities = vec![test_entity("John", 0.9)].into();
-        let records = evaluator.evaluate(&entities);
+        let records = evaluator.evaluate(&entities, &[]);
         assert_eq!(records.len(), 1);
         assert!(!records[0].redaction.is_applied);
     }
@@ -232,7 +230,7 @@ mod tests {
             default_threshold: 0.0,
         };
         let entities: Entities = vec![test_entity("secret", 0.9)].into();
-        let records = evaluator.evaluate(&entities);
+        let records = evaluator.evaluate(&entities, &[]);
         assert_eq!(
             records[0].redaction.strategy,
             Strategy::Text(TextStrategy::Remove)
@@ -247,7 +245,7 @@ mod tests {
             default_threshold: 0.0,
         };
         let entities: Entities = vec![test_entity("secret-value", 0.9)].into();
-        let records = evaluator.evaluate(&entities);
+        let records = evaluator.evaluate(&entities, &[]);
         assert_eq!(records[0].value.original, "secret-value");
     }
 }

--- a/crates/nvisy-engine/src/pipeline/executor.rs
+++ b/crates/nvisy-engine/src/pipeline/executor.rs
@@ -306,10 +306,18 @@ impl NodeExecutor {
                 import_ref.import(content, shared).await
             };
 
-            let envelope = match retry {
+            let mut envelope = match retry {
                 Some(policy) => policy.with_retry(do_import).await?,
                 None => do_import().await?,
             };
+
+            // Apply upload-time annotations: convert inclusions to
+            // entities, store annotations for exclusion filtering.
+            if !cfg.annotations.is_empty() {
+                cfg.annotations
+                    .apply_inclusions(&mut envelope.audit.entities);
+                envelope.annotations = cfg.annotations.clone();
+            }
 
             fan_out(senders, envelope).await?;
             count += 1;
@@ -479,6 +487,7 @@ async fn clone_envelope(envelope: &DocumentEnvelope) -> Result<DocumentEnvelope,
     Ok(DocumentEnvelope {
         document,
         metadata: envelope.metadata.clone(),
+        annotations: envelope.annotations.clone(),
         contexts: envelope.contexts.clone(),
         audit: envelope.audit.clone(),
         shared: Arc::clone(&envelope.shared),

--- a/crates/nvisy-engine/src/pipeline/executor.rs
+++ b/crates/nvisy-engine/src/pipeline/executor.rs
@@ -306,19 +306,10 @@ impl NodeExecutor {
                 import_ref.import(content, shared).await
             };
 
-            let mut envelope = match retry {
+            let envelope = match retry {
                 Some(policy) => policy.with_retry(do_import).await?,
                 None => do_import().await?,
             };
-
-            // Apply annotations stored on the content metadata:
-            // convert inclusions to entities, keep exclusions for
-            // filtering during detection.
-            if !envelope.annotations.is_empty() {
-                envelope
-                    .annotations
-                    .apply_inclusions(&mut envelope.audit.entities);
-            }
 
             fan_out(senders, envelope).await?;
             count += 1;

--- a/crates/nvisy-engine/src/pipeline/executor.rs
+++ b/crates/nvisy-engine/src/pipeline/executor.rs
@@ -311,12 +311,13 @@ impl NodeExecutor {
                 None => do_import().await?,
             };
 
-            // Apply upload-time annotations: convert inclusions to
-            // entities, store annotations for exclusion filtering.
-            if !cfg.annotations.is_empty() {
-                cfg.annotations
+            // Apply annotations stored on the content metadata:
+            // convert inclusions to entities, keep exclusions for
+            // filtering during detection.
+            if !envelope.annotations.is_empty() {
+                envelope
+                    .annotations
                     .apply_inclusions(&mut envelope.audit.entities);
-                envelope.annotations = cfg.annotations.clone();
             }
 
             fan_out(senders, envelope).await?;

--- a/crates/nvisy-engine/tests/compilation.rs
+++ b/crates/nvisy-engine/tests/compilation.rs
@@ -11,8 +11,7 @@ fn import_node(content_id: Uuid) -> GraphNode {
         Uuid::new_v4(),
         GraphNodeKind::ImportFile(ImportFile {
             content_ids: vec![content_id],
-            decompression: None,
-            decryption: None,
+            ..Default::default()
         }),
     )
 }
@@ -67,8 +66,7 @@ async fn duplicate_node_ids_rejected() -> anyhow::Result<()> {
         shared_id,
         GraphNodeKind::ImportFile(ImportFile {
             content_ids: vec![content_id],
-            decompression: None,
-            decryption: None,
+            ..Default::default()
         }),
     );
     let node_b = GraphNode::new(

--- a/crates/nvisy-engine/tests/fixtures/mod.rs
+++ b/crates/nvisy-engine/tests/fixtures/mod.rs
@@ -44,8 +44,7 @@ pub fn import_export_graph(content_id: Uuid) -> Graph {
                 import_id,
                 GraphNodeKind::ImportFile(ImportFile {
                     content_ids: vec![content_id],
-                    decompression: None,
-                    decryption: None,
+                    ..Default::default()
                 }),
             ),
             GraphNode::new(

--- a/crates/nvisy-ontology/src/entity/annotation.rs
+++ b/crates/nvisy-ontology/src/entity/annotation.rs
@@ -28,6 +28,9 @@ pub enum AnnotationKind {
         entity_kind: EntityKind,
         /// What this inclusion targets.
         target: AnnotationTarget,
+        /// Confidence in the range `[0.0, 1.0]` (default 1.0).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        confidence: Option<f64>,
     },
     /// Known-safe region that detection should skip.
     Exclusion {
@@ -45,13 +48,12 @@ pub enum AnnotationKind {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Annotation {
+    /// Optional human-readable name for this annotation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     /// What kind of annotation and its variant-specific data.
     #[serde(flatten)]
     pub kind: AnnotationKind,
-    /// Confidence of the annotation in the range `[0.0, 1.0]`.
-    /// Defaults to 1.0 for inclusions when not specified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub confidence: Option<f64>,
 }
 
 /// A collection of [`Annotation`]s.
@@ -100,25 +102,18 @@ impl Annotations {
     /// An entity is excluded if an exclusion targets a matching value
     /// (exact) or an overlapping location (any modality).
     pub fn is_excluded(&self, entity: &Entity) -> bool {
-        for ann in &self.0 {
+        self.0.iter().any(|ann| {
             let AnnotationKind::Exclusion { target } = &ann.kind else {
-                continue;
+                return false;
             };
             match target {
-                AnnotationTarget::Value(value) if *value == entity.value => return true,
-                AnnotationTarget::Location(location) => {
-                    if entity
-                        .location
-                        .as_ref()
-                        .is_some_and(|loc| loc.overlaps(location))
-                    {
-                        return true;
-                    }
-                }
-                _ => {}
+                AnnotationTarget::Value(value) => *value == entity.value,
+                AnnotationTarget::Location(location) => entity
+                    .location
+                    .as_ref()
+                    .is_some_and(|loc| loc.overlaps(location)),
             }
-        }
-        false
+        })
     }
 
     /// Convert inclusion annotations into entities and add them to the collection.
@@ -128,30 +123,28 @@ impl Annotations {
                 category,
                 entity_kind,
                 target,
+                confidence,
             } = &ann.kind
             else {
                 continue;
             };
 
             let (value, location) = match target {
-                AnnotationTarget::Value(value) => {
-                    if value.is_empty() {
+                AnnotationTarget::Value(v) => {
+                    if v.is_empty() {
                         continue;
                     }
-                    (value.clone(), None)
+                    (v.clone(), None)
                 }
-                AnnotationTarget::Location(location) => {
-                    (String::new(), Some(location.clone()))
-                }
+                AnnotationTarget::Location(loc) => (String::new(), Some(loc.clone())),
             };
 
-            let confidence = ann.confidence.unwrap_or(1.0);
             let mut builder = Entity::builder()
                 .with_category(*category)
                 .with_entity_kind(*entity_kind)
                 .with_value(value)
-                .with_recognition_methods(vec![RecognitionMethod::annotation(None)])
-                .with_confidence(confidence);
+                .with_recognition_methods(vec![RecognitionMethod::annotation(ann.name.clone())])
+                .with_confidence(confidence.unwrap_or(1.0));
             if let Some(loc) = location {
                 builder = builder.with_location(loc);
             }
@@ -163,5 +156,171 @@ impl Annotations {
 impl From<Vec<Annotation>> for Annotations {
     fn from(v: Vec<Annotation>) -> Self {
         Self(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::entity::TextLocation;
+
+    use super::*;
+
+    fn inclusion(value: &str) -> Annotation {
+        Annotation {
+            name: None,
+            kind: AnnotationKind::Inclusion {
+                category: EntityCategory::PersonalIdentity,
+                entity_kind: EntityKind::PersonName,
+                target: AnnotationTarget::Value(value.into()),
+                confidence: None,
+            },
+        }
+    }
+
+    fn exclusion_value(value: &str) -> Annotation {
+        Annotation {
+            name: None,
+            kind: AnnotationKind::Exclusion {
+                target: AnnotationTarget::Value(value.into()),
+            },
+        }
+    }
+
+    fn exclusion_location(start: usize, end: usize) -> Annotation {
+        Annotation {
+            name: None,
+            kind: AnnotationKind::Exclusion {
+                target: AnnotationTarget::Location(Location::from(TextLocation {
+                    start_offset: start,
+                    end_offset: end,
+                    ..Default::default()
+                })),
+            },
+        }
+    }
+
+    fn label(name: &str) -> Annotation {
+        Annotation {
+            name: None,
+            kind: AnnotationKind::Label { label: name.into() },
+        }
+    }
+
+    fn test_entity(value: &str, start: usize, end: usize) -> Entity {
+        Entity::builder()
+            .with_category(EntityCategory::PersonalIdentity)
+            .with_entity_kind(EntityKind::PersonName)
+            .with_value(value)
+            .with_recognition_methods(vec![RecognitionMethod::regex("test")])
+            .with_confidence(0.9)
+            .with_location(Location::from(TextLocation {
+                start_offset: start,
+                end_offset: end,
+                ..Default::default()
+            }))
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn apply_inclusions_creates_entities() {
+        let annotations =
+            Annotations::from(vec![inclusion("John Smith"), inclusion("jane@example.com")]);
+        let mut entities = Entities::new();
+        annotations.apply_inclusions(&mut entities);
+        assert_eq!(entities.len(), 2);
+        assert_eq!(entities[0].value, "John Smith");
+        assert_eq!(entities[1].value, "jane@example.com");
+        assert!((entities[0].confidence - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn apply_inclusions_skips_empty_value() {
+        let annotations = Annotations::from(vec![inclusion("")]);
+        let mut entities = Entities::new();
+        annotations.apply_inclusions(&mut entities);
+        assert!(entities.is_empty());
+    }
+
+    #[test]
+    fn apply_inclusions_uses_annotation_confidence() {
+        let ann = Annotation {
+            name: None,
+            kind: AnnotationKind::Inclusion {
+                category: EntityCategory::PersonalIdentity,
+                entity_kind: EntityKind::PersonName,
+                target: AnnotationTarget::Value("test".into()),
+                confidence: Some(0.7),
+            },
+        };
+        let mut entities = Entities::new();
+        Annotations::from(vec![ann]).apply_inclusions(&mut entities);
+        assert!((entities[0].confidence - 0.7).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn apply_inclusions_records_annotation_name() {
+        let ann = Annotation {
+            name: Some("hr-list".into()),
+            kind: AnnotationKind::Inclusion {
+                category: EntityCategory::PersonalIdentity,
+                entity_kind: EntityKind::PersonName,
+                target: AnnotationTarget::Value("test".into()),
+                confidence: None,
+            },
+        };
+        let mut entities = Entities::new();
+        Annotations::from(vec![ann]).apply_inclusions(&mut entities);
+        assert_eq!(
+            entities[0].recognition_methods[0],
+            RecognitionMethod::annotation(Some("hr-list".into()))
+        );
+    }
+
+    #[test]
+    fn exclusion_by_value() {
+        let annotations = Annotations::from(vec![exclusion_value("safe-value")]);
+        let entity = test_entity("safe-value", 0, 10);
+        assert!(annotations.is_excluded(&entity));
+    }
+
+    #[test]
+    fn exclusion_by_value_no_match() {
+        let annotations = Annotations::from(vec![exclusion_value("other")]);
+        let entity = test_entity("sensitive", 0, 9);
+        assert!(!annotations.is_excluded(&entity));
+    }
+
+    #[test]
+    fn exclusion_by_location_overlap() {
+        let annotations = Annotations::from(vec![exclusion_location(5, 15)]);
+        let entity = test_entity("test", 10, 20);
+        assert!(annotations.is_excluded(&entity));
+    }
+
+    #[test]
+    fn exclusion_by_location_no_overlap() {
+        let annotations = Annotations::from(vec![exclusion_location(0, 5)]);
+        let entity = test_entity("test", 10, 20);
+        assert!(!annotations.is_excluded(&entity));
+    }
+
+    #[test]
+    fn document_labels_extracts_label_annotations() {
+        let annotations = Annotations::from(vec![
+            label("medical"),
+            inclusion("test"),
+            label("gdpr"),
+            exclusion_value("safe"),
+        ]);
+        let labels = annotations.document_labels();
+        assert_eq!(labels, vec!["medical", "gdpr"]);
+    }
+
+    #[test]
+    fn empty_annotations_exclude_nothing() {
+        let annotations = Annotations::new();
+        let entity = test_entity("anything", 0, 8);
+        assert!(!annotations.is_excluded(&entity));
     }
 }

--- a/crates/nvisy-ontology/src/entity/annotation.rs
+++ b/crates/nvisy-ontology/src/entity/annotation.rs
@@ -38,7 +38,7 @@ pub enum AnnotationScope {
 }
 
 /// A classification label attached to a document or region.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AnnotationLabel {
     /// Label name (e.g. `"contains-phi"`, `"gdpr-request"`).
@@ -75,7 +75,7 @@ impl AnnotationLabel {
 }
 
 /// A user-provided or upstream annotation on a content region.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Annotation {
     /// What kind of annotation this is.
@@ -84,7 +84,7 @@ pub struct Annotation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category: Option<EntityCategory>,
     /// Entity kind, if applicable.
-    #[serde(rename = "entity_type", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entity_kind: Option<EntityKind>,
     /// The annotated text or value.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -98,7 +98,7 @@ pub struct Annotation {
 }
 
 /// A collection of [`Annotation`]s.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Annotations(Vec<Annotation>);
 
 impl Annotations {
@@ -171,7 +171,7 @@ impl Annotations {
                 .with_category(category)
                 .with_entity_kind(entity_kind)
                 .with_value(value)
-                .with_recognition_methods(vec![RecognitionMethod::manual("annotation")])
+                .with_recognition_methods(vec![RecognitionMethod::annotation(None)])
                 .with_confidence(1.0);
             if let Some(ref loc) = ann.location {
                 builder = builder.with_location(loc.clone());

--- a/crates/nvisy-ontology/src/entity/annotation.rs
+++ b/crates/nvisy-ontology/src/entity/annotation.rs
@@ -2,99 +2,56 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use strum::{Display, EnumString};
 
 use super::{Entities, Entity, EntityCategory, EntityKind, Location, RecognitionMethod};
 use crate::entity::Overlap;
 
-/// The kind of annotation applied to a content region.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
-#[derive(EnumString, Serialize, Deserialize, JsonSchema)]
+/// What a region annotation points at: a text value or a spatial/temporal location.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-#[non_exhaustive]
+pub enum AnnotationTarget {
+    /// A specific text or data value.
+    Value(String),
+    /// A modality-specific location (text span, image region, audio segment).
+    Location(Location),
+}
+
+/// The kind of annotation with variant-specific data.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AnnotationKind {
     /// Pre-identified sensitive region that should be treated as a detection.
-    Inclusion,
+    Inclusion {
+        /// Broad classification of the sensitive data.
+        category: EntityCategory,
+        /// Specific entity kind.
+        entity_kind: EntityKind,
+        /// What this inclusion targets.
+        target: AnnotationTarget,
+    },
     /// Known-safe region that detection should skip.
-    Exclusion,
-    /// Classification label attached to a document or region.
-    Label,
+    Exclusion {
+        /// What this exclusion targets.
+        target: AnnotationTarget,
+    },
+    /// Classification label for document-level policy scoping.
+    Label {
+        /// Label name (e.g. `"medical"`, `"gdpr-request"`).
+        label: String,
+    },
 }
 
-/// The scope to which an annotation label applies.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
-#[derive(EnumString, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-#[non_exhaustive]
-pub enum AnnotationScope {
-    /// Label applies to the entire document.
-    Document,
-    /// Label applies to a specific page.
-    Page,
-    /// Label applies to a specific region or element.
-    Region,
-}
-
-/// A classification label attached to a document or region.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct AnnotationLabel {
-    /// Label name (e.g. `"contains-phi"`, `"gdpr-request"`).
-    pub name: String,
-    /// Scope of the label.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scope: Option<AnnotationScope>,
-    /// Confidence of the label assignment.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub confidence: Option<f64>,
-}
-
-impl AnnotationLabel {
-    /// Create a new label with the given name.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            scope: None,
-            confidence: None,
-        }
-    }
-
-    /// Set the scope.
-    pub fn with_scope(mut self, scope: AnnotationScope) -> Self {
-        self.scope = Some(scope);
-        self
-    }
-
-    /// Set the confidence.
-    pub fn with_confidence(mut self, confidence: f64) -> Self {
-        self.confidence = Some(confidence);
-        self
-    }
-}
-
-/// A user-provided or upstream annotation on a content region.
+/// A user-provided annotation on a content region.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Annotation {
-    /// What kind of annotation this is.
+    /// What kind of annotation and its variant-specific data.
+    #[serde(flatten)]
     pub kind: AnnotationKind,
-    /// Entity category, if applicable.
+    /// Confidence of the annotation in the range `[0.0, 1.0]`.
+    /// Defaults to 1.0 for inclusions when not specified.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub category: Option<EntityCategory>,
-    /// Entity kind, if applicable.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entity_kind: Option<EntityKind>,
-    /// The annotated text or value.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-    /// Modality-specific location of the annotated region.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub location: Option<Location>,
-    /// Classification labels attached to this annotation.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub labels: Vec<AnnotationLabel>,
+    pub confidence: Option<f64>,
 }
 
 /// A collection of [`Annotation`]s.
@@ -127,26 +84,38 @@ impl Annotations {
         self.0.push(annotation);
     }
 
+    /// All document-level label names.
+    pub fn document_labels(&self) -> Vec<&str> {
+        self.0
+            .iter()
+            .filter_map(|a| match &a.kind {
+                AnnotationKind::Label { label } => Some(label.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Check whether the given entity falls within any exclusion annotation.
     ///
-    /// An entity is excluded if:
-    /// - An exclusion annotation has the same value (exact match), or
-    /// - An exclusion annotation has a text location that overlaps the entity's.
+    /// An entity is excluded if an exclusion targets a matching value
+    /// (exact) or an overlapping location (any modality).
     pub fn is_excluded(&self, entity: &Entity) -> bool {
         for ann in &self.0 {
-            if ann.kind != AnnotationKind::Exclusion {
+            let AnnotationKind::Exclusion { target } = &ann.kind else {
                 continue;
-            }
-            if let Some(ref excl_val) = ann.value
-                && *excl_val == entity.value
-            {
-                return true;
-            }
-            if let (Some(Location::Text(entity_loc)), Some(Location::Text(excl_loc))) =
-                (&entity.location, &ann.location)
-                && entity_loc.overlaps(excl_loc)
-            {
-                return true;
+            };
+            match target {
+                AnnotationTarget::Value(value) if *value == entity.value => return true,
+                AnnotationTarget::Location(location) => {
+                    if entity
+                        .location
+                        .as_ref()
+                        .is_some_and(|loc| loc.overlaps(location))
+                    {
+                        return true;
+                    }
+                }
+                _ => {}
             }
         }
         false
@@ -155,26 +124,36 @@ impl Annotations {
     /// Convert inclusion annotations into entities and add them to the collection.
     pub fn apply_inclusions(&self, entities: &mut Entities) {
         for ann in &self.0 {
-            if ann.kind != AnnotationKind::Inclusion {
+            let AnnotationKind::Inclusion {
+                category,
+                entity_kind,
+                target,
+            } = &ann.kind
+            else {
                 continue;
-            }
-            let category = match ann.category {
-                Some(c) => c,
-                None => continue,
             };
-            let entity_kind = match ann.entity_kind {
-                Some(ek) => ek,
-                None => continue,
+
+            let (value, location) = match target {
+                AnnotationTarget::Value(value) => {
+                    if value.is_empty() {
+                        continue;
+                    }
+                    (value.clone(), None)
+                }
+                AnnotationTarget::Location(location) => {
+                    (String::new(), Some(location.clone()))
+                }
             };
-            let value = ann.value.clone().unwrap_or_default();
+
+            let confidence = ann.confidence.unwrap_or(1.0);
             let mut builder = Entity::builder()
-                .with_category(category)
-                .with_entity_kind(entity_kind)
+                .with_category(*category)
+                .with_entity_kind(*entity_kind)
                 .with_value(value)
                 .with_recognition_methods(vec![RecognitionMethod::annotation(None)])
-                .with_confidence(1.0);
-            if let Some(ref loc) = ann.location {
-                builder = builder.with_location(loc.clone());
+                .with_confidence(confidence);
+            if let Some(loc) = location {
+                builder = builder.with_location(loc);
             }
             entities.push(builder.build().expect("required fields provided"));
         }

--- a/crates/nvisy-ontology/src/entity/method/mod.rs
+++ b/crates/nvisy-ontology/src/entity/method/mod.rs
@@ -11,6 +11,6 @@ mod recognition;
 mod refinement;
 
 pub use self::extraction::ExtractionMethod;
-pub use self::provenance::{ManualProvenance, ModelProvenance, PatternProvenance};
+pub use self::provenance::{AnnotationProvenance, ModelProvenance, PatternProvenance};
 pub use self::recognition::{RecognitionMethod, RecognitionMethodKind};
 pub use self::refinement::RefinementMethod;

--- a/crates/nvisy-ontology/src/entity/method/provenance.rs
+++ b/crates/nvisy-ontology/src/entity/method/provenance.rs
@@ -30,11 +30,11 @@ pub struct ModelProvenance {
     pub model: Option<ModelInfo>,
 }
 
-/// Provenance for a manual annotation.
+/// Provenance for an annotation (pre-identified region from upload).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[derive(Serialize, Deserialize, JsonSchema)]
-pub struct ManualProvenance {
-    /// Identifier of the annotator.
+pub struct AnnotationProvenance {
+    /// Identifier of the annotator (human or service account).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotator: Option<String>,
 }

--- a/crates/nvisy-ontology/src/entity/method/recognition.rs
+++ b/crates/nvisy-ontology/src/entity/method/recognition.rs
@@ -3,7 +3,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::provenance::{ManualProvenance, ModelProvenance, PatternProvenance};
+use super::provenance::{AnnotationProvenance, ModelProvenance, PatternProvenance};
 use crate::entity::model::ModelInfo;
 
 /// Technique used to identify a sensitive entity within extracted content.
@@ -37,10 +37,8 @@ pub enum RecognitionMethod {
     Biometric(ModelProvenance),
 
     // Human
-    /// User-provided annotation.
-    Manual(ManualProvenance),
     /// Pre-identified region supplied alongside the uploaded file.
-    Annotation(ManualProvenance),
+    Annotation(AnnotationProvenance),
 }
 
 impl RecognitionMethod {
@@ -95,16 +93,9 @@ impl RecognitionMethod {
         Self::Biometric(ModelProvenance { model: Some(model) })
     }
 
-    /// Create a `Manual` method with the given annotator ID.
-    pub fn manual(annotator: impl Into<String>) -> Self {
-        Self::Manual(ManualProvenance {
-            annotator: Some(annotator.into()),
-        })
-    }
-
     /// Create an `Annotation` method with an optional annotator ID.
     pub fn annotation(annotator: Option<String>) -> Self {
-        Self::Annotation(ManualProvenance { annotator })
+        Self::Annotation(AnnotationProvenance { annotator })
     }
 
     /// Returns the discriminant kind, stripping provenance data.
@@ -119,7 +110,6 @@ impl RecognitionMethod {
             Self::Classification(_) => RecognitionMethodKind::Classification,
             Self::Embedding(_) => RecognitionMethodKind::Embedding,
             Self::Biometric(_) => RecognitionMethodKind::Biometric,
-            Self::Manual(_) => RecognitionMethodKind::Manual,
             Self::Annotation(_) => RecognitionMethodKind::Annotation,
         }
     }
@@ -142,6 +132,5 @@ pub enum RecognitionMethodKind {
     Embedding,
     CrossReference,
     Biometric,
-    Manual,
     Annotation,
 }

--- a/crates/nvisy-ontology/src/entity/method/recognition.rs
+++ b/crates/nvisy-ontology/src/entity/method/recognition.rs
@@ -39,6 +39,8 @@ pub enum RecognitionMethod {
     // Human
     /// User-provided annotation.
     Manual(ManualProvenance),
+    /// Pre-identified region supplied alongside the uploaded file.
+    Annotation(ManualProvenance),
 }
 
 impl RecognitionMethod {
@@ -100,6 +102,11 @@ impl RecognitionMethod {
         })
     }
 
+    /// Create an `Annotation` method with an optional annotator ID.
+    pub fn annotation(annotator: Option<String>) -> Self {
+        Self::Annotation(ManualProvenance { annotator })
+    }
+
     /// Returns the discriminant kind, stripping provenance data.
     /// Useful as a HashMap key when provenance details don't matter
     /// (e.g. calibration maps, weight tables).
@@ -113,6 +120,7 @@ impl RecognitionMethod {
             Self::Embedding(_) => RecognitionMethodKind::Embedding,
             Self::Biometric(_) => RecognitionMethodKind::Biometric,
             Self::Manual(_) => RecognitionMethodKind::Manual,
+            Self::Annotation(_) => RecognitionMethodKind::Annotation,
         }
     }
 }
@@ -135,4 +143,5 @@ pub enum RecognitionMethodKind {
     CrossReference,
     Biometric,
     Manual,
+    Annotation,
 }

--- a/crates/nvisy-ontology/src/entity/mod.rs
+++ b/crates/nvisy-ontology/src/entity/mod.rs
@@ -19,9 +19,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub use self::annotation::{
-    Annotation, AnnotationKind, AnnotationLabel, AnnotationScope, Annotations,
-};
+pub use self::annotation::{Annotation, AnnotationKind, AnnotationTarget, Annotations};
 pub use self::category::EntityCategory;
 pub use self::kind::EntityKind;
 pub use self::location::{

--- a/crates/nvisy-ontology/src/entity/mod.rs
+++ b/crates/nvisy-ontology/src/entity/mod.rs
@@ -28,7 +28,7 @@ pub use self::location::{
     AudioLocation, ImageLocation, Location, Overlap, TabularLocation, TextLocation,
 };
 pub use self::method::{
-    ExtractionMethod, ManualProvenance, ModelProvenance, PatternProvenance, RecognitionMethod,
+    AnnotationProvenance, ExtractionMethod, ModelProvenance, PatternProvenance, RecognitionMethod,
     RecognitionMethodKind, RefinementMethod,
 };
 pub use self::model::{ModelInfo, ModelKind};

--- a/crates/nvisy-ontology/src/workflow/ingest/import.rs
+++ b/crates/nvisy-ontology/src/workflow/ingest/import.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use super::{CompressionAlgorithm, EncryptionConfig};
+use crate::entity::Annotations;
 
 /// Configuration for the [`ImportFile`] graph node.
 ///
@@ -20,7 +21,7 @@ use super::{CompressionAlgorithm, EncryptionConfig};
 /// that must be applied before the bytes are passed to extraction nodes.
 ///
 /// [`ImportFile`]: crate::graph::GraphNodeKind::ImportFile
-#[derive(Debug, Clone, Default, PartialEq, Eq, Validate)]
+#[derive(Debug, Clone, Default, PartialEq, Validate)]
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct ImportFile {
     /// Identifiers of previously uploaded content to import. Must contain at least one.
@@ -33,4 +34,11 @@ pub struct ImportFile {
     /// Decrypt the content before decoding.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub decryption: Option<EncryptionConfig>,
+    /// Pre-identified regions and classification labels for this content.
+    ///
+    /// Inclusion annotations are converted to entities during import.
+    /// Exclusion annotations filter out detected entities in downstream
+    /// operations.
+    #[serde(default, skip_serializing_if = "Annotations::is_empty")]
+    pub annotations: Annotations,
 }

--- a/crates/nvisy-ontology/src/workflow/ingest/import.rs
+++ b/crates/nvisy-ontology/src/workflow/ingest/import.rs
@@ -13,7 +13,6 @@ use uuid::Uuid;
 use validator::Validate;
 
 use super::{CompressionAlgorithm, EncryptionConfig};
-use crate::entity::Annotations;
 
 /// Configuration for the [`ImportFile`] graph node.
 ///
@@ -21,7 +20,7 @@ use crate::entity::Annotations;
 /// that must be applied before the bytes are passed to extraction nodes.
 ///
 /// [`ImportFile`]: crate::graph::GraphNodeKind::ImportFile
-#[derive(Debug, Clone, Default, PartialEq, Validate)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Validate)]
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct ImportFile {
     /// Identifiers of previously uploaded content to import. Must contain at least one.
@@ -34,11 +33,4 @@ pub struct ImportFile {
     /// Decrypt the content before decoding.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub decryption: Option<EncryptionConfig>,
-    /// Pre-identified regions and classification labels for this content.
-    ///
-    /// Inclusion annotations are converted to entities during import.
-    /// Exclusion annotations filter out detected entities in downstream
-    /// operations.
-    #[serde(default, skip_serializing_if = "Annotations::is_empty")]
-    pub annotations: Annotations,
 }

--- a/crates/nvisy-pattern/src/engine/mod.rs
+++ b/crates/nvisy-pattern/src/engine/mod.rs
@@ -420,7 +420,7 @@ mod tests {
             DenyRule {
                 category: EntityCategory::PersonalIdentity,
                 entity_kind: EntityKind::PersonName,
-                method: RecognitionMethod::manual("test"),
+                method: RecognitionMethod::annotation(Some("test".into())),
             },
         );
         let engine = PatternEngine::builder()
@@ -460,14 +460,14 @@ mod tests {
             DenyRule {
                 category: EntityCategory::Financial,
                 entity_kind: EntityKind::PaymentCard,
-                method: RecognitionMethod::manual("test"),
+                method: RecognitionMethod::annotation(Some("test".into())),
             },
         );
         assert_eq!(deny.len(), 2);
         assert!(deny.contains("secret"));
         let rule = deny.get("other").unwrap();
         assert_eq!(rule.category, EntityCategory::Financial);
-        assert_eq!(rule.method, RecognitionMethod::manual("test"));
+        assert_eq!(rule.method, RecognitionMethod::annotation(Some("test".into())));
     }
 
     #[test]

--- a/crates/nvisy-pattern/src/engine/mod.rs
+++ b/crates/nvisy-pattern/src/engine/mod.rs
@@ -467,7 +467,10 @@ mod tests {
         assert!(deny.contains("secret"));
         let rule = deny.get("other").unwrap();
         assert_eq!(rule.category, EntityCategory::Financial);
-        assert_eq!(rule.method, RecognitionMethod::annotation(Some("test".into())));
+        assert_eq!(
+            rule.method,
+            RecognitionMethod::annotation(Some("test".into()))
+        );
     }
 
     #[test]

--- a/crates/nvisy-pattern/src/engine/scan_context.rs
+++ b/crates/nvisy-pattern/src/engine/scan_context.rs
@@ -20,7 +20,7 @@ use super::deny_list::DenyList;
 ///     .with_deny(DenyList::new().with("secret", DenyRule {
 ///         category: EntityCategory::PersonalIdentity,
 ///         entity_kind: EntityKind::PersonName,
-///         method: RecognitionMethod::manual("test"),
+///         method: RecognitionMethod::annotation(Some("test".into())),
 ///     }));
 /// let matches = PatternEngine::instance().scan_text("text", &ctx);
 /// ```


### PR DESCRIPTION
## Summary

Integrate annotation types into the detection pipeline for upload-time pre-identified entities, exclusion zones, and document-level labels.

### Annotation types rework
- **`Annotation`** struct with `name: Option<String>` and flattened `AnnotationKind` enum
- **`AnnotationKind::Inclusion`**: pre-identified sensitive region with category, entity_kind, target, confidence
- **`AnnotationKind::Exclusion`**: known-safe region with target (value or location)
- **`AnnotationKind::Label`**: document-level classification for policy scoping
- **`AnnotationTarget`**: `Value(String)` | `Location(Location)` — what an annotation points at

### Pipeline integration
- `RecognitionMethod::Annotation` variant with `AnnotationProvenance` (replaces removed `Manual` variant)
- Annotations stored on `ContentMetadata` in the registry, loaded during import
- `ImportFileOp` applies inclusions as entities during import
- `DocumentEnvelope::add_entities()` filters exclusions during detection
- Multimodal exclusion support via `Overlap` trait

### Policy scoping (closes #128)
- `Annotations::document_labels()` extracts label annotations
- `PolicyEvaluator::find_matching_rule()` checks `RuleCondition.required_labels` against document labels
- Rules with unmet label conditions are skipped

### Removed
- `RecognitionMethod::Manual` + `ManualProvenance`
- `AnnotationLabel`, `AnnotationScope`, `AnnotationBuilder`

Closes #126
Closes #128

## Test plan
- [x] All 165 tests pass (50 ontology + 115 engine)
- [x] 10 new annotation unit tests (inclusions, exclusions, labels, edge cases)
- [x] Clippy clean across workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)