### PR TITLE
refactor(server, engine): handlers, async pipeline, RunOutcome

### DIFF
--- a/crates/nvisy-engine/src/pipeline/cache.rs
+++ b/crates/nvisy-engine/src/pipeline/cache.rs
@@ -228,12 +228,16 @@ mod tests {
     use super::*;
 
     fn test_context(name: &str) -> Context {
-        Context::new(name, vec![])
+        Context::builder()
+            .with_name(name)
+            .with_version(semver::Version::new(1, 0, 0))
+            .build()
+            .unwrap()
     }
 
     /// Insert a context directly into the cache for testing (bypasses registry).
     async fn insert(cache: &ContextCache, ctx: Context, ref_count: usize) -> Uuid {
-        let id = ctx.source.as_uuid();
+        let id = ctx.id;
         let mut inner = cache.inner.write().await;
         inner.insert(
             id,

--- a/crates/nvisy-engine/src/pipeline/default.rs
+++ b/crates/nvisy-engine/src/pipeline/default.rs
@@ -30,6 +30,8 @@ use nvisy_ontology::workflow::{ConcurrencyPolicy, Graph, GraphNodeKind};
 use nvisy_provider::http::HttpClient;
 use schemars::JsonSchema;
 use serde::Serialize;
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 use validator::Validate;
@@ -111,6 +113,8 @@ struct EngineInner {
     context_cache: ContextCache,
     /// In-memory run lifecycle tracker (volatile: lost on restart).
     runs: RunState,
+    /// Background pipeline tasks spawned by [`Engine::submit`].
+    background_tasks: Mutex<JoinSet<()>>,
 }
 
 /// The redaction pipeline engine.
@@ -160,6 +164,7 @@ impl Engine {
                 key_provider: None,
                 context_cache: ContextCache::new(),
                 runs: RunState::new(),
+                background_tasks: Mutex::new(JoinSet::new()),
             }),
         })
     }
@@ -238,7 +243,7 @@ impl Engine {
         let (run_id, compiled, prepared) = self.prepare(&input).await?;
         let actor_id = input.actor_id;
         let engine = self.clone();
-        tokio::spawn(async move {
+        self.inner.background_tasks.lock().await.spawn(async move {
             match engine.execute(run_id, input, compiled, prepared).await {
                 Ok(output) => {
                     if let Err(e) = engine
@@ -248,6 +253,7 @@ impl Engine {
                         .await
                     {
                         tracing::error!(%run_id, error = %e, "failed to persist run audits");
+                        engine.inner.runs.fail(run_id).await;
                     }
                 }
                 Err(e) => {
@@ -638,7 +644,9 @@ impl Engine {
     /// Returns `NotFound` if the run does not exist or belongs to a
     /// different actor, or `Validation` if the run is still active.
     pub async fn delete_run(&self, actor_id: Uuid, id: Uuid) -> Result<(), Error> {
-        self.inner.runs.delete_run(actor_id, id).await
+        self.inner.runs.delete_run(actor_id, id).await?;
+        let _ = self.inner.registry.remove_audits(actor_id, id).await;
+        Ok(())
     }
 
     /// Delete all finished runs for the actor. Active runs are preserved.
@@ -651,5 +659,14 @@ impl Engine {
     /// Returns the base data directory path backing the registry.
     pub fn data_dir(&self) -> &Path {
         self.inner.registry.base_dir()
+    }
+
+    /// Wait for all background pipeline tasks to complete.
+    ///
+    /// Call during graceful shutdown to ensure in-flight runs finish
+    /// and persist their results before the process exits.
+    pub async fn shutdown(&self) {
+        let tasks = std::mem::take(&mut *self.inner.background_tasks.lock().await);
+        tasks.join_all().await;
     }
 }

--- a/crates/nvisy-engine/src/pipeline/default.rs
+++ b/crates/nvisy-engine/src/pipeline/default.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use nvisy_core::Error;
 use nvisy_ontology::policy::{Policies, Retention, RetentionPolicy, RetentionScope};
 use nvisy_ontology::provenance::Audit;
-use nvisy_ontology::workflow::{Graph, GraphNodeKind};
+use nvisy_ontology::workflow::{ConcurrencyPolicy, Graph, GraphNodeKind};
 use nvisy_provider::http::HttpClient;
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -35,12 +35,13 @@ use uuid::Uuid;
 use validator::Validate;
 
 use super::cache::ContextCache;
-use super::config::RuntimeConfig;
+use super::config::{ResourceLimits, RuntimeConfig};
 use super::orchestrator::{Orchestrator, RunContext};
 use super::plan;
 use super::runs::state::{RunRecord, RunState};
 use super::runs::{
-    AnalyticsSnapshot, NodeSnapshot, NodeStatus, RunEntry, RunFilter, RunSnapshot, RunStatus,
+    AnalyticsSnapshot, NodeSnapshot, NodeStatus, RunEntry, RunFilter, RunOutcome, RunSnapshot,
+    RunStatus,
 };
 use crate::operation::encryption::SharedKeyProvider;
 use crate::operation::envelope::SharedData;
@@ -81,6 +82,16 @@ pub struct EngineOutput {
     /// Per-document audit trails: entities, redaction entries, and
     /// content source metadata. One audit per processed document.
     pub audits: Vec<Audit>,
+}
+
+/// Intermediate state produced by [`Engine::prepare`] and consumed by
+/// [`Engine::execute`].
+struct PreparedRun {
+    cancel: CancellationToken,
+    effective_config: RuntimeConfig,
+    context_ids: Vec<Uuid>,
+    limits: ResourceLimits,
+    concurrency: Option<ConcurrencyPolicy>,
 }
 
 /// Shared inner state for the engine, held behind an `Arc`.
@@ -197,18 +208,65 @@ impl Engine {
         &self.inner.registry
     }
 
-    /// Execute a full redaction pipeline.
+    /// Execute a full redaction pipeline synchronously (blocks until done).
     ///
     /// Compiles the graph, pre-loads contexts, runs the DAG orchestrator,
-    /// and collects results. See the module-level docs for the full
-    /// phase breakdown.
+    /// and collects results. Used directly in tests and the CLI.
     ///
     /// # Errors
     ///
     /// Returns an error if graph compilation fails, the run times out, or
     /// all nodes fail during execution.
     pub async fn run(&self, input: EngineInput) -> Result<EngineOutput, Error> {
-        let run_id = uuid::Uuid::new_v4();
+        let (run_id, compiled, prepared) = self.prepare(&input).await?;
+        self.execute(run_id, input, compiled, prepared).await
+    }
+
+    /// Submit a pipeline run for background execution.
+    ///
+    /// Compiles and validates the graph synchronously (fail-fast on bad
+    /// input), then spawns the actual execution on a background tokio
+    /// task. Returns the run ID immediately.
+    ///
+    /// Results are persisted to the registry and can be retrieved via
+    /// [`Engine::get_run`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if graph compilation or validation fails.
+    pub async fn submit(&self, input: EngineInput) -> Result<Uuid, Error> {
+        let (run_id, compiled, prepared) = self.prepare(&input).await?;
+        let actor_id = input.actor_id;
+        let engine = self.clone();
+        tokio::spawn(async move {
+            match engine.execute(run_id, input, compiled, prepared).await {
+                Ok(output) => {
+                    if let Err(e) = engine
+                        .inner
+                        .registry
+                        .store_audits(actor_id, run_id, output.audits)
+                        .await
+                    {
+                        tracing::error!(%run_id, error = %e, "failed to persist run audits");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(%run_id, error = %e, "background run failed");
+                }
+            }
+        });
+        Ok(run_id)
+    }
+
+    /// Validate input, compile the graph, and insert the initial run record.
+    ///
+    /// Returns the run ID, compiled execution plan, and prepared state
+    /// needed by [`execute`].
+    async fn prepare(
+        &self,
+        input: &EngineInput,
+    ) -> Result<(Uuid, plan::ExecutionPlan, PreparedRun), Error> {
+        let run_id = Uuid::now_v7();
         let cancel = CancellationToken::new();
 
         let effective_config = match &input.config {
@@ -244,7 +302,7 @@ impl Engine {
                 .map_err(|e| Error::validation(e.to_string(), "concurrency"))?;
         }
 
-        let record = RunRecord {
+        let failed_record = RunRecord {
             actor_id: input.actor_id,
             status: RunStatus::Failed,
             created_at: jiff::Timestamp::now(),
@@ -259,7 +317,7 @@ impl Engine {
         let compiled = match plan::compile(&input.graph, limits.channel_buffer) {
             Ok(plan) => plan,
             Err(e) => {
-                self.inner.runs.insert(run_id, record).await;
+                self.inner.runs.insert(run_id, failed_record).await;
                 return Err(e);
             }
         };
@@ -286,7 +344,7 @@ impl Engine {
                 run_id,
                 RunRecord {
                     actor_id: input.actor_id,
-                    status: RunStatus::Running,
+                    status: RunStatus::Pending,
                     created_at: jiff::Timestamp::now(),
                     started_at: None,
                     completed_at: None,
@@ -298,9 +356,35 @@ impl Engine {
             )
             .await;
 
+        let prepared = PreparedRun {
+            cancel,
+            effective_config,
+            context_ids,
+            limits,
+            concurrency,
+        };
+
+        Ok((run_id, compiled, prepared))
+    }
+
+    /// Run the compiled plan to completion.
+    async fn execute(
+        &self,
+        run_id: Uuid,
+        input: EngineInput,
+        compiled: plan::ExecutionPlan,
+        prepared: PreparedRun,
+    ) -> Result<EngineOutput, Error> {
+        let PreparedRun {
+            cancel,
+            effective_config,
+            context_ids,
+            limits,
+            concurrency,
+        } = prepared;
+
         // Acquire contexts into the shared cache. The returned guard
-        // releases them (decrementing ref counts) when dropped: even
-        // if this function panics.
+        // releases them (decrementing ref counts) when dropped.
         let _context_guard = self
             .inner
             .context_cache
@@ -419,6 +503,25 @@ impl Engine {
         Ok(output)
     }
 
+    /// Get a full [`RunSnapshot`] including per-node status for a single run.
+    ///
+    /// For completed runs (`Succeeded`/`PartialFailure`), audit trails are
+    /// loaded from the registry and included in the [`RunOutcome`].
+    ///
+    /// Returns `None` if the run does not exist or belongs to a different actor.
+    pub async fn get_run(&self, actor_id: Uuid, id: Uuid) -> Option<RunSnapshot> {
+        let mut snapshot = self.inner.runs.get_run(actor_id, id).await?;
+        match &mut snapshot.outcome {
+            RunOutcome::Succeeded { audits, .. } | RunOutcome::PartialFailure { audits, .. } => {
+                if let Ok(loaded) = self.inner.registry.load_audits(actor_id, id).await {
+                    *audits = loaded;
+                }
+            }
+            _ => {}
+        }
+        Some(snapshot)
+    }
+
     /// Enforce retention policies after a pipeline run.
     ///
     /// Iterates all retention policies across all submitted policies.
@@ -487,6 +590,18 @@ impl Engine {
                 }
                 RetentionScope::AuditLogs => {
                     output.audits.clear();
+                    if let Err(e) = self
+                        .inner
+                        .registry
+                        .remove_audits(actor_id, output.run_id)
+                        .await
+                    {
+                        tracing::warn!(
+                            run_id = %output.run_id,
+                            error = %e,
+                            "failed to delete persisted audits for zero-retention",
+                        );
+                    }
                 }
                 _ => {}
             }
@@ -496,13 +611,6 @@ impl Engine {
     /// Compute a point-in-time [`AnalyticsSnapshot`] from all tracked runs.
     pub async fn snapshot(&self) -> AnalyticsSnapshot {
         self.inner.runs.snapshot().await
-    }
-
-    /// Get a full [`RunSnapshot`] including per-node status for a single run.
-    ///
-    /// Returns `None` if the run does not exist or belongs to a different actor.
-    pub async fn get_run(&self, actor_id: Uuid, id: Uuid) -> Option<RunSnapshot> {
-        self.inner.runs.get_run(actor_id, id).await
     }
 
     /// List runs matching the given filter, scoped to the actor.

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -33,5 +33,6 @@ pub use self::config::{
 };
 pub use self::default::{Engine, EngineInput, EngineOutput};
 pub use self::runs::{
-    AnalyticsSnapshot, NodeSnapshot, NodeStatus, RunEntry, RunFilter, RunSnapshot, RunStatus,
+    AnalyticsSnapshot, NodeSnapshot, NodeStatus, RunEntry, RunFilter, RunOutcome, RunSnapshot,
+    RunStatus,
 };

--- a/crates/nvisy-engine/src/pipeline/runs/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/runs/mod.rs
@@ -6,8 +6,8 @@
 //!
 //! Two projection types serve different API needs:
 //!
-//! - [`RunSnapshot`] — full detail including per-node snapshots
-//!   (`GET /runs/{id}`).
+//! - [`RunSnapshot`] — full detail including per-node snapshots and
+//!   a type-safe [`RunOutcome`] (`GET /runs/{id}`).
 //! - [`RunEntry`] — lightweight with node count only, no per-node
 //!   detail (`GET /runs`).
 //!
@@ -18,13 +18,14 @@ mod analytics;
 pub(crate) mod state;
 
 use jiff::Timestamp;
+use nvisy_ontology::provenance::Audit;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub use self::analytics::AnalyticsSnapshot;
 
-/// Lifecycle status of a pipeline run.
+/// Lifecycle status of a pipeline run (internal tracking tag).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -72,15 +73,59 @@ pub struct NodeSnapshot {
     pub error: Option<String>,
 }
 
+/// Rich outcome of a pipeline run, carrying state-specific data.
+///
+/// `Succeeded` and `PartialFailure` include audit trails (populated
+/// from the registry by [`Engine::get_run`]). `Failed` carries an
+/// optional error message. `Pending` and `Running` have no extra data.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RunOutcome {
+    /// The run has been created but not yet started.
+    Pending,
+    /// The run is actively executing nodes.
+    Running,
+    /// All nodes completed without error.
+    Succeeded {
+        /// When the run reached a terminal state.
+        #[schemars(with = "String")]
+        completed_at: Timestamp,
+        /// Per-document audit trails.
+        audits: Vec<Audit>,
+    },
+    /// Some nodes succeeded while others failed.
+    PartialFailure {
+        /// When the run reached a terminal state.
+        #[schemars(with = "String")]
+        completed_at: Timestamp,
+        /// Per-document audit trails from successful nodes.
+        audits: Vec<Audit>,
+    },
+    /// All nodes failed.
+    Failed {
+        /// When the run reached a terminal state.
+        #[schemars(with = "String")]
+        completed_at: Timestamp,
+        /// Error description, if available.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    /// The run was cancelled by the caller.
+    Cancelled {
+        /// When the run was cancelled.
+        #[schemars(with = "String")]
+        completed_at: Timestamp,
+    },
+}
+
 /// Full point-in-time snapshot of a pipeline run.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RunSnapshot {
     /// Unique run identifier.
     pub id: Uuid,
     /// Identity of the actor who initiated the run.
     pub actor_id: Uuid,
-    /// Current overall status.
-    pub status: RunStatus,
     /// Timestamp when the run was created.
     #[schemars(with = "String")]
     pub created_at: Timestamp,
@@ -88,16 +133,15 @@ pub struct RunSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Option<String>")]
     pub started_at: Option<Timestamp>,
-    /// Timestamp when the run finished, if applicable.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<String>")]
-    pub completed_at: Option<Timestamp>,
     /// Per-node snapshots.
     pub nodes: Vec<NodeSnapshot>,
+    /// Run outcome with state-specific data.
+    pub outcome: RunOutcome,
 }
 
 /// Lightweight summary of a run for listing endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RunEntry {
     /// Unique run identifier.
     pub id: Uuid,

--- a/crates/nvisy-engine/src/pipeline/runs/state.rs
+++ b/crates/nvisy-engine/src/pipeline/runs/state.rs
@@ -22,7 +22,8 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use super::{
-    AnalyticsSnapshot, NodeSnapshot, NodeStatus, RunEntry, RunFilter, RunSnapshot, RunStatus,
+    AnalyticsSnapshot, NodeSnapshot, NodeStatus, RunEntry, RunFilter, RunOutcome, RunSnapshot,
+    RunStatus,
 };
 
 const TARGET: &str = "nvisy_engine::pipeline::runs";
@@ -64,15 +65,38 @@ pub(crate) struct RunRecord {
 
 impl RunRecord {
     /// Project this entry into a full [`RunSnapshot`] for API responses.
+    ///
+    /// Terminal outcomes (`Succeeded`, `PartialFailure`) are built with
+    /// empty audit vecs — [`Engine::get_run`] populates them from the
+    /// registry.
     fn to_snapshot(&self, id: Uuid) -> RunSnapshot {
+        let outcome = match self.status {
+            RunStatus::Pending => RunOutcome::Pending,
+            RunStatus::Running => RunOutcome::Running,
+            RunStatus::Succeeded => RunOutcome::Succeeded {
+                completed_at: self.completed_at.unwrap_or_else(Timestamp::now),
+                audits: vec![],
+            },
+            RunStatus::PartialFailure => RunOutcome::PartialFailure {
+                completed_at: self.completed_at.unwrap_or_else(Timestamp::now),
+                audits: vec![],
+            },
+            RunStatus::Failed => RunOutcome::Failed {
+                completed_at: self.completed_at.unwrap_or_else(Timestamp::now),
+                error: None,
+            },
+            RunStatus::Cancelled => RunOutcome::Cancelled {
+                completed_at: self.completed_at.unwrap_or_else(Timestamp::now),
+            },
+        };
+
         RunSnapshot {
             id,
             actor_id: self.actor_id,
-            status: self.status,
             created_at: self.created_at,
             started_at: self.started_at,
-            completed_at: self.completed_at,
             nodes: self.nodes.values().cloned().collect(),
+            outcome,
         }
     }
 

--- a/crates/nvisy-engine/src/registry/store.rs
+++ b/crates/nvisy-engine/src/registry/store.rs
@@ -346,6 +346,12 @@ impl Registry {
             .await
     }
 
+    #[tracing::instrument(target = TARGET, name = "registry.unregister_all_policies", skip(self), fields(%actor_id))]
+    pub async fn unregister_all_policies(&self, actor_id: Uuid) -> Result<usize> {
+        self.remove_all_entries(&self.inner.policies_ks, actor_id)
+            .await
+    }
+
     #[tracing::instrument(target = TARGET, name = "registry.list_policies", skip(self), fields(%actor_id))]
     pub async fn list_policies(&self, actor_id: Uuid) -> Result<Vec<Uuid>> {
         self.list_resource_ids(&self.inner.policies_ks, actor_id)

--- a/crates/nvisy-engine/src/registry/store.rs
+++ b/crates/nvisy-engine/src/registry/store.rs
@@ -8,6 +8,7 @@ use nvisy_core::Result;
 use nvisy_core::content::{Content, ContentMetadata, ContentSource};
 use nvisy_ontology::context::Context;
 use nvisy_ontology::policy::Policy;
+use nvisy_ontology::provenance::Audit;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -32,6 +33,7 @@ struct RegistryInner {
     content_meta_ks: Keyspace,
     contexts_ks: Keyspace,
     policies_ks: Keyspace,
+    audits_ks: Keyspace,
 }
 
 impl std::fmt::Debug for Registry {
@@ -52,6 +54,7 @@ impl Registry {
         let content_meta_ks = db.open_keyspace("content_meta")?;
         let contexts_ks = db.open_keyspace("contexts")?;
         let policies_ks = db.open_keyspace("policies")?;
+        let audits_ks = db.open_keyspace("run_outputs")?;
 
         tracing::debug!(target: TARGET, "registry opened");
         Ok(Self {
@@ -62,6 +65,7 @@ impl Registry {
                 content_meta_ks,
                 contexts_ks,
                 policies_ks,
+                audits_ks,
             }),
         })
     }
@@ -355,6 +359,36 @@ impl Registry {
     #[tracing::instrument(target = TARGET, name = "registry.list_policies", skip(self), fields(%actor_id))]
     pub async fn list_policies(&self, actor_id: Uuid) -> Result<Vec<Uuid>> {
         self.list_resource_ids(&self.inner.policies_ks, actor_id)
+            .await
+    }
+
+    /// Persist audit trails for a completed pipeline run.
+    #[tracing::instrument(target = TARGET, name = "registry.store_audits", skip(self, audits), fields(%actor_id, %run_id))]
+    pub async fn store_audits(
+        &self,
+        actor_id: Uuid,
+        run_id: Uuid,
+        audits: Vec<Audit>,
+    ) -> Result<()> {
+        let key = CompositeKey::new(actor_id, run_id);
+        let count = audits.len();
+        self.store_json(&self.inner.audits_ks, key, &audits).await?;
+        tracing::trace!(target: TARGET, count, "audits stored");
+        Ok(())
+    }
+
+    /// Load persisted audit trails for a pipeline run.
+    #[tracing::instrument(target = TARGET, name = "registry.load_audits", skip(self), fields(%actor_id, %run_id))]
+    pub async fn load_audits(&self, actor_id: Uuid, run_id: Uuid) -> Result<Vec<Audit>> {
+        let key = CompositeKey::new(actor_id, run_id);
+        self.load_json(&self.inner.audits_ks, key, "audits").await
+    }
+
+    /// Remove persisted audit trails for a pipeline run.
+    #[tracing::instrument(target = TARGET, name = "registry.remove_audits", skip(self), fields(%actor_id, %run_id))]
+    pub async fn remove_audits(&self, actor_id: Uuid, run_id: Uuid) -> Result<()> {
+        let key = CompositeKey::new(actor_id, run_id);
+        self.remove_entry(&self.inner.audits_ks, key, "audits")
             .await
     }
 }

--- a/crates/nvisy-engine/src/registry/store.rs
+++ b/crates/nvisy-engine/src/registry/store.rs
@@ -293,7 +293,7 @@ impl Registry {
 
     #[tracing::instrument(target = TARGET, name = "registry.register_context", skip(self, context), fields(%actor_id))]
     pub async fn register_context(&self, actor_id: Uuid, context: Context) -> Result<Uuid> {
-        let id = context.source.as_uuid();
+        let id = context.id;
         let key = CompositeKey::new(actor_id, id);
         self.store_json(&self.inner.contexts_ks, key, &context)
             .await?;
@@ -401,6 +401,14 @@ mod tests {
 
     use super::*;
 
+    fn test_context(name: &str) -> Context {
+        Context::builder()
+            .with_name(name)
+            .with_version(semver::Version::new(1, 0, 0))
+            .build()
+            .unwrap()
+    }
+
     fn temp_registry() -> anyhow::Result<(tempfile::TempDir, Registry)> {
         let temp = tempfile::tempdir()?;
         let registry = Registry::open(temp.path().join("data"))?;
@@ -490,7 +498,7 @@ mod tests {
         let (_temp, registry) = temp_registry()?;
         let actor = Uuid::now_v7();
         let id = registry
-            .register_context(actor, Context::new("test-ctx", vec![]))
+            .register_context(actor, test_context("test-ctx"))
             .await?;
         let ctx = registry.read_context(actor, id).await?;
         assert_eq!(ctx.name, "test-ctx");
@@ -503,7 +511,7 @@ mod tests {
         let actor_a = Uuid::now_v7();
         let actor_b = Uuid::now_v7();
         let id = registry
-            .register_context(actor_a, Context::new("private", vec![]))
+            .register_context(actor_a, test_context("private"))
             .await?;
         assert!(registry.read_context(actor_b, id).await.is_err());
         registry.read_context(actor_a, id).await?;
@@ -514,12 +522,8 @@ mod tests {
     async fn unregister_all_contexts() -> anyhow::Result<()> {
         let (_temp, registry) = temp_registry()?;
         let actor = Uuid::now_v7();
-        registry
-            .register_context(actor, Context::new("c1", vec![]))
-            .await?;
-        registry
-            .register_context(actor, Context::new("c2", vec![]))
-            .await?;
+        registry.register_context(actor, test_context("c1")).await?;
+        registry.register_context(actor, test_context("c2")).await?;
         assert_eq!(registry.unregister_all_contexts(actor).await?, 2);
         assert!(registry.list_contexts(actor).await?.is_empty());
         Ok(())

--- a/crates/nvisy-engine/tests/runs.rs
+++ b/crates/nvisy-engine/tests/runs.rs
@@ -2,7 +2,7 @@
 
 mod fixtures;
 
-use nvisy_engine::pipeline::{RunFilter, RunStatus};
+use nvisy_engine::pipeline::{RunFilter, RunOutcome, RunStatus};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -16,7 +16,7 @@ async fn dry_run_returns_without_exporting() -> anyhow::Result<()> {
 
     // Dry run should succeed and return a valid run_id.
     let snapshot = engine.get_run(actor, output.run_id).await.unwrap();
-    assert_eq!(snapshot.status, RunStatus::Succeeded);
+    assert!(matches!(snapshot.outcome, RunOutcome::Succeeded { .. }));
 
     // Dry run produces audits but no applied redactions.
     assert!(output.audits.iter().all(|a| a.entries.is_empty()));
@@ -33,7 +33,7 @@ async fn successful_run_has_succeeded_status() -> anyhow::Result<()> {
     let output = engine.run(fixtures::engine_input(actor, graph)).await?;
 
     let snapshot = engine.get_run(actor, output.run_id).await.unwrap();
-    assert_eq!(snapshot.status, RunStatus::Succeeded);
+    assert!(matches!(snapshot.outcome, RunOutcome::Succeeded { .. }));
     Ok(())
 }
 

--- a/crates/nvisy-ontology/src/context/mod.rs
+++ b/crates/nvisy-ontology/src/context/mod.rs
@@ -14,11 +14,11 @@ pub mod temporal;
 
 use derive_builder::Builder;
 use schemars::JsonSchema;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub use self::entry::{ContextEntry, ContextEntryData};
-use crate::entity::ContentSource;
 
 /// Lightweight set of context references carried by each document envelope.
 ///
@@ -67,11 +67,14 @@ impl Contexts {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct Context {
-    /// Content source identity and lineage.
-    #[builder(default)]
-    pub source: ContentSource,
+    /// Unique identifier for this context.
+    #[builder(default = "Uuid::now_v7()")]
+    pub id: Uuid,
     /// Human-readable label for this context.
     pub name: String,
+    /// Context version.
+    #[schemars(with = "String")]
+    pub version: Version,
     /// Optional longer description.
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -85,15 +88,5 @@ impl Context {
     /// Start building a new context.
     pub fn builder() -> ContextBuilder {
         ContextBuilder::default()
-    }
-
-    /// Create a new context with the given name and entries.
-    pub fn new(name: impl Into<String>, entries: Vec<ContextEntry>) -> Self {
-        Self {
-            source: ContentSource::new(),
-            name: name.into(),
-            description: None,
-            entries,
-        }
     }
 }

--- a/crates/nvisy-server/Cargo.toml
+++ b/crates/nvisy-server/Cargo.toml
@@ -66,6 +66,7 @@ derive_more = { workspace = true, features = ["deref", "display"] }
 # Primitive datatypes
 uuid = { workspace = true, features = [] }
 jiff = { workspace = true, features = [] }
+semver = { workspace = true, features = [] }
 
 # Observability
 tracing = { workspace = true, features = [] }

--- a/crates/nvisy-server/src/handler/contexts.rs
+++ b/crates/nvisy-server/src/handler/contexts.rs
@@ -73,12 +73,7 @@ async fn list_contexts(
     let mut entries = Vec::with_capacity(ids.len());
     for id in ids {
         if let Ok(ctx) = registry.read_context(actor_id, id).await {
-            entries.push(ContextEntry {
-                id,
-                name: ctx.name,
-                version: ctx.version.to_string(),
-                entries: ctx.entries.len(),
-            });
+            entries.push(ContextEntry::from(ctx));
         }
     }
     let page = pagination.paginate(entries);

--- a/crates/nvisy-server/src/handler/contexts.rs
+++ b/crates/nvisy-server/src/handler/contexts.rs
@@ -13,25 +13,19 @@
 //! Paths are relative — the version prefix (e.g. `/api/v1`) is applied
 //! by the version module.
 
-use std::time::Duration;
-
 use aide::axum::ApiRouter;
 use aide::axum::routing::{get_with, post_with};
 use aide::transform::TransformOperation;
-use axum::error_handling::HandleErrorLayer;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use nvisy_engine::registry::Registry;
 use nvisy_ontology::context::Context;
-use tower::ServiceBuilder;
-use tower::timeout::TimeoutLayer;
 
 use super::error::Result;
 use super::request::{ContextPath, NewContext, Pagination};
 use super::response::{ContextEntry, ContextId, ContextList};
 use crate::extract::{ActorId, Json, Path};
-use crate::middleware::constants::{DEFAULT_READ_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS};
-use crate::middleware::recovery::handle_error;
+use crate::middleware::{DEFAULT_READ_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS, RouterTimeoutExt};
 use crate::service::ServiceState;
 
 const TARGET: &str = "nvisy_server::contexts";
@@ -174,13 +168,7 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
             "/contexts/{id}",
             get_with(download_context, download_context_docs),
         )
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_READ_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_READ_TIMEOUT_SECS);
 
     let write_routes = ApiRouter::new()
         .api_route(
@@ -192,13 +180,7 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
             "/contexts/{id}",
             aide::axum::routing::delete_with(delete_context, delete_context_docs),
         )
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_WRITE_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_WRITE_TIMEOUT_SECS);
 
     read_routes.merge(write_routes)
 }

--- a/crates/nvisy-server/src/handler/contexts.rs
+++ b/crates/nvisy-server/src/handler/contexts.rs
@@ -76,6 +76,7 @@ async fn list_contexts(
             entries.push(ContextEntry {
                 id,
                 name: ctx.name,
+                version: ctx.version.to_string(),
                 entries: ctx.entries.len(),
             });
         }

--- a/crates/nvisy-server/src/handler/files.rs
+++ b/crates/nvisy-server/src/handler/files.rs
@@ -13,26 +13,20 @@
 //! Paths are relative — the version prefix (e.g. `/api/v1`) is applied
 //! by the version module.
 
-use std::time::Duration;
-
 use aide::axum::ApiRouter;
 use aide::axum::routing::{get_with, post_with};
 use aide::transform::TransformOperation;
-use axum::error_handling::HandleErrorLayer;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use nvisy_core::content::{Content, ContentData, ContentMetadata};
 use nvisy_engine::registry::Registry;
-use tower::ServiceBuilder;
-use tower::timeout::TimeoutLayer;
 
 use super::error::Result;
 use super::request::{ContentPath, NewFile, Pagination};
 use super::response::{File, FileEntry, FileId, FileList};
 use super::utility::Base64;
 use crate::extract::{ActorId, Json, Path};
-use crate::middleware::constants::{DEFAULT_READ_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS};
-use crate::middleware::recovery::handle_error;
+use crate::middleware::{DEFAULT_READ_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS, RouterTimeoutExt};
 use crate::service::ServiceState;
 
 const TARGET: &str = "nvisy_server::files";
@@ -212,13 +206,7 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
     let read_routes = ApiRouter::new()
         .api_route("/files", get_with(list_files, list_files_docs))
         .api_route("/files/{id}", get_with(download_file, download_file_docs))
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_READ_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_READ_TIMEOUT_SECS);
 
     let write_routes = ApiRouter::new()
         .api_route(
@@ -230,13 +218,7 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
             "/files/{id}",
             aide::axum::routing::delete_with(delete_file, delete_file_docs),
         )
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_WRITE_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_WRITE_TIMEOUT_SECS);
 
     read_routes.merge(write_routes)
 }

--- a/crates/nvisy-server/src/handler/infra.rs
+++ b/crates/nvisy-server/src/handler/infra.rs
@@ -18,9 +18,7 @@ use nvisy_engine::pipeline::{AnalyticsSnapshot, Engine};
 
 use super::response::{ComponentCheck, Health, ServiceStatus};
 use crate::extract::Json;
-use crate::middleware::{
-    DEFAULT_HEALTH_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS, RouterTimeoutExt,
-};
+use crate::middleware::{DEFAULT_HEALTH_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS, RouterTimeoutExt};
 use crate::service::ServiceState;
 
 const TARGET: &str = "nvisy_server::infra";

--- a/crates/nvisy-server/src/handler/infra.rs
+++ b/crates/nvisy-server/src/handler/infra.rs
@@ -10,21 +10,17 @@
 //! `/health` is served at the root (unversioned). `/analytics` is
 //! relative and nested under the version prefix by the version module.
 
-use std::time::Duration;
-
 use aide::axum::ApiRouter;
 use aide::axum::routing::get_with;
 use aide::transform::TransformOperation;
-use axum::error_handling::HandleErrorLayer;
 use axum::extract::State;
 use nvisy_engine::pipeline::{AnalyticsSnapshot, Engine};
-use tower::ServiceBuilder;
-use tower::timeout::TimeoutLayer;
 
 use super::response::{ComponentCheck, Health, ServiceStatus};
 use crate::extract::Json;
-use crate::middleware::constants::{DEFAULT_HEALTH_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS};
-use crate::middleware::recovery::handle_error;
+use crate::middleware::{
+    DEFAULT_HEALTH_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS, RouterTimeoutExt,
+};
 use crate::service::ServiceState;
 
 const TARGET: &str = "nvisy_server::infra";
@@ -102,24 +98,12 @@ fn analytics_docs(op: TransformOperation) -> TransformOperation {
 pub fn health_routes() -> ApiRouter<ServiceState> {
     ApiRouter::new()
         .api_route("/health", get_with(health_check, health_docs))
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_HEALTH_TIMEOUT_SECS,
-                ))),
-        )
+        .with_timeout(DEFAULT_HEALTH_TIMEOUT_SECS)
 }
 
 /// Analytics route for API v1 (relative path).
 pub fn routes_v1() -> ApiRouter<ServiceState> {
     ApiRouter::new()
         .api_route("/analytics", get_with(get_analytics, analytics_docs))
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_READ_TIMEOUT_SECS,
-                ))),
-        )
+        .with_timeout(DEFAULT_READ_TIMEOUT_SECS)
 }

--- a/crates/nvisy-server/src/handler/policies.rs
+++ b/crates/nvisy-server/src/handler/policies.rs
@@ -13,25 +13,19 @@
 //! Paths are relative — the version prefix (e.g. `/api/v1`) is applied
 //! by the version module.
 
-use std::time::Duration;
-
 use aide::axum::ApiRouter;
 use aide::axum::routing::{get_with, post_with};
 use aide::transform::TransformOperation;
-use axum::error_handling::HandleErrorLayer;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use nvisy_engine::registry::Registry;
 use nvisy_ontology::policy::Policy;
-use tower::ServiceBuilder;
-use tower::timeout::TimeoutLayer;
 
 use super::error::Result;
 use super::request::{NewPolicy, Pagination, PolicyPath};
 use super::response::{PolicyEntry, PolicyId, PolicyList};
 use crate::extract::{ActorId, Json, Path};
-use crate::middleware::constants::{DEFAULT_READ_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS};
-use crate::middleware::recovery::handle_error;
+use crate::middleware::{DEFAULT_READ_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS, RouterTimeoutExt};
 use crate::service::ServiceState;
 
 const TARGET: &str = "nvisy_server::policies";
@@ -169,13 +163,7 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
             "/policies/{id}",
             get_with(download_policy, download_policy_docs),
         )
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_READ_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_READ_TIMEOUT_SECS);
 
     let write_routes = ApiRouter::new()
         .api_route(
@@ -187,13 +175,7 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
             "/policies/{id}",
             aide::axum::routing::delete_with(delete_policy, delete_policy_docs),
         )
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_WRITE_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_WRITE_TIMEOUT_SECS);
 
     read_routes.merge(write_routes)
 }

--- a/crates/nvisy-server/src/handler/policies.rs
+++ b/crates/nvisy-server/src/handler/policies.rs
@@ -5,9 +5,10 @@
 //! | Method   | Path              | Description                    |
 //! |----------|-------------------|--------------------------------|
 //! | `POST`   | `/policies`       | Upload a policy                |
-//! | `GET`    | `/policies`       | List all policy identifiers    |
+//! | `GET`    | `/policies`       | List all policies              |
 //! | `GET`    | `/policies/{id}`  | Download a previously uploaded policy |
 //! | `DELETE` | `/policies/{id}`  | Delete a single policy         |
+//! | `DELETE` | `/policies`       | Delete all policies            |
 //!
 //! Paths are relative — the version prefix (e.g. `/api/v1`) is applied
 //! by the version module.
@@ -18,7 +19,7 @@ use aide::axum::ApiRouter;
 use aide::axum::routing::{get_with, post_with};
 use aide::transform::TransformOperation;
 use axum::error_handling::HandleErrorLayer;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use nvisy_engine::registry::Registry;
 use nvisy_ontology::policy::Policy;
@@ -26,7 +27,8 @@ use tower::ServiceBuilder;
 use tower::timeout::TimeoutLayer;
 
 use super::error::Result;
-use super::request::PolicyPath;
+use super::request::{NewPolicy, Pagination, PolicyPath};
+use super::response::{PolicyEntry, PolicyId, PolicyList};
 use crate::extract::{ActorId, Json, Path};
 use crate::middleware::constants::{DEFAULT_READ_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS};
 use crate::middleware::recovery::handle_error;
@@ -43,11 +45,11 @@ const TARGET: &str = "nvisy_server::policies";
 async fn upload_policy(
     State(registry): State<Registry>,
     ActorId(actor_id): ActorId,
-    Json(policy): Json<Policy>,
-) -> Result<(StatusCode, Json<serde_json::Value>)> {
-    let id = registry.register_policy(actor_id, policy).await?;
+    Json(req): Json<NewPolicy>,
+) -> Result<(StatusCode, Json<PolicyId>)> {
+    let id = registry.register_policy(actor_id, req.policy).await?;
     tracing::info!(target: TARGET, %id, "policy uploaded");
-    Ok((StatusCode::CREATED, Json(serde_json::json!({ "id": id }))))
+    Ok((StatusCode::CREATED, Json(PolicyId { id })))
 }
 
 fn upload_policy_docs(op: TransformOperation) -> TransformOperation {
@@ -66,17 +68,29 @@ fn upload_policy_docs(op: TransformOperation) -> TransformOperation {
 async fn list_policies(
     State(registry): State<Registry>,
     ActorId(actor_id): ActorId,
-) -> Result<Json<Vec<uuid::Uuid>>> {
+    Query(pagination): Query<Pagination>,
+) -> Result<Json<PolicyList>> {
     let ids = registry.list_policies(actor_id).await?;
-    tracing::debug!(target: TARGET, count = ids.len(), "policies listed");
-    Ok(Json(ids))
+    let mut entries = Vec::with_capacity(ids.len());
+    for id in ids {
+        if let Ok(policy) = registry.read_policy(actor_id, id).await {
+            entries.push(PolicyEntry {
+                id,
+                name: policy.name,
+                version: policy.version.to_string(),
+            });
+        }
+    }
+    let page = pagination.paginate(entries);
+    tracing::debug!(target: TARGET, total = page.total, count = page.items.len(), "policies listed");
+    Ok(Json(page))
 }
 
 fn list_policies_docs(op: TransformOperation) -> TransformOperation {
     op.id("listPolicies")
         .tag("policies")
         .summary("List all uploaded policies")
-        .description("Returns the identifiers of every policy currently stored.")
+        .description("Returns a paginated list of policies currently stored.")
 }
 
 /// `GET /policies/{id}`
@@ -125,6 +139,28 @@ fn delete_policy_docs(op: TransformOperation) -> TransformOperation {
         .description("Removes a single policy identified by its UUID.")
 }
 
+/// `DELETE /policies`
+#[tracing::instrument(
+    target = "nvisy_server::policies",
+    skip_all,
+    fields(%actor_id),
+)]
+async fn delete_all_policies(
+    State(registry): State<Registry>,
+    ActorId(actor_id): ActorId,
+) -> Result<StatusCode> {
+    let deleted = registry.unregister_all_policies(actor_id).await?;
+    tracing::info!(target: TARGET, deleted, "all policies deleted");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn delete_all_policies_docs(op: TransformOperation) -> TransformOperation {
+    op.id("deleteAllPolicies")
+        .tag("policies")
+        .summary("Delete all uploaded policies")
+        .description("Removes every policy currently stored.")
+}
+
 /// Policy routes for API v1 (relative paths).
 pub fn routes_v1() -> ApiRouter<ServiceState> {
     let read_routes = ApiRouter::new()
@@ -142,7 +178,11 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
         );
 
     let write_routes = ApiRouter::new()
-        .api_route("/policies", post_with(upload_policy, upload_policy_docs))
+        .api_route(
+            "/policies",
+            post_with(upload_policy, upload_policy_docs)
+                .delete_with(delete_all_policies, delete_all_policies_docs),
+        )
         .api_route(
             "/policies/{id}",
             aide::axum::routing::delete_with(delete_policy, delete_policy_docs),

--- a/crates/nvisy-server/src/handler/policies.rs
+++ b/crates/nvisy-server/src/handler/policies.rs
@@ -68,11 +68,7 @@ async fn list_policies(
     let mut entries = Vec::with_capacity(ids.len());
     for id in ids {
         if let Ok(policy) = registry.read_policy(actor_id, id).await {
-            entries.push(PolicyEntry {
-                id,
-                name: policy.name,
-                version: policy.version.to_string(),
-            });
+            entries.push(PolicyEntry::from(policy));
         }
     }
     let page = pagination.paginate(entries);

--- a/crates/nvisy-server/src/handler/request/mod.rs
+++ b/crates/nvisy-server/src/handler/request/mod.rs
@@ -13,7 +13,7 @@ mod runs;
 
 pub use self::contexts::NewContext;
 pub use self::files::NewFile;
-pub use self::policies::NewPolicy;
 pub use self::pagination::{Page, Pagination};
 pub use self::path::{ContentPath, ContextPath, PolicyPath, RunPath};
+pub use self::policies::NewPolicy;
 pub use self::runs::{NewRun, RunQuery};

--- a/crates/nvisy-server/src/handler/request/mod.rs
+++ b/crates/nvisy-server/src/handler/request/mod.rs
@@ -8,10 +8,12 @@ mod contexts;
 mod files;
 mod pagination;
 mod path;
+mod policies;
 mod runs;
 
 pub use self::contexts::NewContext;
 pub use self::files::NewFile;
+pub use self::policies::NewPolicy;
 pub use self::pagination::{Page, Pagination};
 pub use self::path::{ContentPath, ContextPath, PolicyPath, RunPath};
 pub use self::runs::{NewRun, RunQuery};

--- a/crates/nvisy-server/src/handler/request/pagination.rs
+++ b/crates/nvisy-server/src/handler/request/pagination.rs
@@ -9,29 +9,28 @@ use serde::{Deserialize, Serialize};
 pub struct Pagination {
     /// Maximum number of items to return (default: 50).
     #[serde(default = "default_limit")]
-    pub limit: u32,
+    pub limit: usize,
     /// Number of items to skip (default: 0).
     #[serde(default)]
-    pub offset: u32,
+    pub offset: usize,
 }
 
-fn default_limit() -> u32 {
+fn default_limit() -> usize {
     50
 }
 
 impl Pagination {
     /// Apply pagination to a vector, returning a [`Page`].
     pub fn paginate<T: Serialize + JsonSchema>(&self, items: Vec<T>) -> Page<T> {
-        let total = items.len() as u32;
+        let total = items.len();
         let items: Vec<T> = items
             .into_iter()
-            .skip(self.offset as usize)
-            .take(self.limit as usize)
+            .skip(self.offset)
+            .take(self.limit)
             .collect();
-        let has_more = self.offset + items.len() as u32 > total;
         Page {
             total,
-            has_more,
+            has_more: self.offset + items.len() < total,
             items,
         }
     }
@@ -42,7 +41,7 @@ impl Pagination {
 #[serde(rename_all = "camelCase")]
 pub struct Page<T: Serialize + JsonSchema> {
     /// Total number of items before pagination.
-    pub total: u32,
+    pub total: usize,
     /// Whether more items exist beyond this page.
     pub has_more: bool,
     /// The items in this page.

--- a/crates/nvisy-server/src/handler/request/policies.rs
+++ b/crates/nvisy-server/src/handler/request/policies.rs
@@ -1,0 +1,13 @@
+//! Policy request types.
+
+use nvisy_ontology::policy::Policy;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+/// Request body for `POST /policies`: policy upload.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NewPolicy {
+    /// The policy to store.
+    pub policy: Policy,
+}

--- a/crates/nvisy-server/src/handler/response/contexts.rs
+++ b/crates/nvisy-server/src/handler/response/contexts.rs
@@ -17,6 +17,8 @@ pub struct ContextEntry {
     pub id: Uuid,
     /// Human-readable label.
     pub name: String,
+    /// Context version string.
+    pub version: String,
     /// Number of reference-data entries in this context.
     pub entries: usize,
 }

--- a/crates/nvisy-server/src/handler/response/contexts.rs
+++ b/crates/nvisy-server/src/handler/response/contexts.rs
@@ -1,6 +1,8 @@
 //! Context response types.
 
+use nvisy_ontology::context::Context;
 use schemars::JsonSchema;
+use semver::Version;
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -17,10 +19,23 @@ pub struct ContextEntry {
     pub id: Uuid,
     /// Human-readable label.
     pub name: String,
-    /// Context version string.
-    pub version: String,
+    /// Context version.
+    #[schemars(with = "String")]
+    pub version: Version,
     /// Number of reference-data entries in this context.
     pub entries: usize,
+}
+
+impl From<Context> for ContextEntry {
+    fn from(ctx: Context) -> Self {
+        let entries = ctx.entries.len();
+        Self {
+            id: ctx.id,
+            name: ctx.name,
+            version: ctx.version,
+            entries,
+        }
+    }
 }
 
 /// Response body for `POST /contexts`.

--- a/crates/nvisy-server/src/handler/response/mod.rs
+++ b/crates/nvisy-server/src/handler/response/mod.rs
@@ -16,4 +16,4 @@ pub use self::contexts::{ContextEntry, ContextId, ContextList};
 pub use self::error::ErrorResponse;
 pub use self::files::{File, FileEntry, FileId, FileList};
 pub use self::policies::{PolicyEntry, PolicyId, PolicyList};
-pub use self::runs::RunList;
+pub use self::runs::{RunList, RunResult};

--- a/crates/nvisy-server/src/handler/response/mod.rs
+++ b/crates/nvisy-server/src/handler/response/mod.rs
@@ -8,10 +8,12 @@ mod check;
 mod contexts;
 mod error;
 mod files;
+mod policies;
 mod runs;
 
 pub use self::check::{ComponentCheck, Health, ServiceStatus};
 pub use self::contexts::{ContextEntry, ContextId, ContextList};
 pub use self::error::ErrorResponse;
 pub use self::files::{File, FileEntry, FileId, FileList};
+pub use self::policies::{PolicyEntry, PolicyId, PolicyList};
 pub use self::runs::RunList;

--- a/crates/nvisy-server/src/handler/response/mod.rs
+++ b/crates/nvisy-server/src/handler/response/mod.rs
@@ -16,4 +16,4 @@ pub use self::contexts::{ContextEntry, ContextId, ContextList};
 pub use self::error::ErrorResponse;
 pub use self::files::{File, FileEntry, FileId, FileList};
 pub use self::policies::{PolicyEntry, PolicyId, PolicyList};
-pub use self::runs::{RunList, RunResult};
+pub use self::runs::{RunId, RunList};

--- a/crates/nvisy-server/src/handler/response/policies.rs
+++ b/crates/nvisy-server/src/handler/response/policies.rs
@@ -1,0 +1,30 @@
+//! Policy response types.
+
+use schemars::JsonSchema;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::handler::request::Page;
+
+/// Response body for `GET /policies`.
+pub type PolicyList = Page<PolicyEntry>;
+
+/// Summary of a stored policy for listing endpoints.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyEntry {
+    /// Identifier of the policy.
+    pub id: Uuid,
+    /// Human-readable policy name.
+    pub name: String,
+    /// Policy version string.
+    pub version: String,
+}
+
+/// Response body for `POST /policies`.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyId {
+    /// Identifier assigned to the uploaded policy.
+    pub id: Uuid,
+}

--- a/crates/nvisy-server/src/handler/response/policies.rs
+++ b/crates/nvisy-server/src/handler/response/policies.rs
@@ -1,6 +1,8 @@
 //! Policy response types.
 
+use nvisy_ontology::policy::Policy;
 use schemars::JsonSchema;
+use semver::Version;
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -17,8 +19,19 @@ pub struct PolicyEntry {
     pub id: Uuid,
     /// Human-readable policy name.
     pub name: String,
-    /// Policy version string.
-    pub version: String,
+    /// Policy version.
+    #[schemars(with = "String")]
+    pub version: Version,
+}
+
+impl From<Policy> for PolicyEntry {
+    fn from(policy: Policy) -> Self {
+        Self {
+            id: policy.id,
+            name: policy.name,
+            version: policy.version,
+        }
+    }
 }
 
 /// Response body for `POST /policies`.

--- a/crates/nvisy-server/src/handler/response/runs.rs
+++ b/crates/nvisy-server/src/handler/response/runs.rs
@@ -1,8 +1,39 @@
 //! Run response types.
 
-use nvisy_engine::pipeline::RunEntry;
+use nvisy_engine::pipeline::{EngineOutput, RunEntry};
+use nvisy_ontology::provenance::Audit;
+use schemars::JsonSchema;
+use serde::Serialize;
+use uuid::Uuid;
 
 use crate::handler::request::Page;
 
 /// Response body for `GET /runs`.
 pub type RunList = Page<RunEntry>;
+
+/// Response body for `POST /runs`.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RunResult {
+    /// Identifier assigned to this pipeline run.
+    pub run_id: Uuid,
+    /// Per-document audit trails.
+    pub audits: Vec<Audit>,
+    /// Total number of entities detected across all documents.
+    pub total_entities: usize,
+    /// Total number of redaction entries produced.
+    pub total_entries: usize,
+}
+
+impl From<EngineOutput> for RunResult {
+    fn from(output: EngineOutput) -> Self {
+        let total_entities = output.audits.iter().map(|a| a.entities.len()).sum();
+        let total_entries = output.audits.iter().map(|a| a.entries.len()).sum();
+        Self {
+            run_id: output.run_id,
+            audits: output.audits,
+            total_entities,
+            total_entries,
+        }
+    }
+}

--- a/crates/nvisy-server/src/handler/response/runs.rs
+++ b/crates/nvisy-server/src/handler/response/runs.rs
@@ -1,7 +1,6 @@
 //! Run response types.
 
-use nvisy_engine::pipeline::{EngineOutput, RunEntry};
-use nvisy_ontology::provenance::Audit;
+use nvisy_engine::pipeline::RunEntry;
 use schemars::JsonSchema;
 use serde::Serialize;
 use uuid::Uuid;
@@ -14,26 +13,7 @@ pub type RunList = Page<RunEntry>;
 /// Response body for `POST /runs`.
 #[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct RunResult {
-    /// Identifier assigned to this pipeline run.
-    pub run_id: Uuid,
-    /// Per-document audit trails.
-    pub audits: Vec<Audit>,
-    /// Total number of entities detected across all documents.
-    pub total_entities: usize,
-    /// Total number of redaction entries produced.
-    pub total_entries: usize,
-}
-
-impl From<EngineOutput> for RunResult {
-    fn from(output: EngineOutput) -> Self {
-        let total_entities = output.audits.iter().map(|a| a.entities.len()).sum();
-        let total_entries = output.audits.iter().map(|a| a.entries.len()).sum();
-        Self {
-            run_id: output.run_id,
-            audits: output.audits,
-            total_entities,
-            total_entries,
-        }
-    }
+pub struct RunId {
+    /// Identifier assigned to the submitted pipeline run.
+    pub id: Uuid,
 }

--- a/crates/nvisy-server/src/handler/runs.rs
+++ b/crates/nvisy-server/src/handler/runs.rs
@@ -23,9 +23,11 @@ use nvisy_engine::pipeline::{Engine, EngineInput, RunFilter, RunSnapshot};
 
 use super::error::{ErrorKind, Result};
 use super::request::{NewRun, RunPath, RunQuery};
-use super::response::{RunList, RunResult};
+use super::response::{RunId, RunList};
 use crate::extract::{ActorId, Json, Path};
-use crate::middleware::{DEFAULT_PIPELINE_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS, RouterTimeoutExt};
+use crate::middleware::{
+    DEFAULT_PIPELINE_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS, RouterTimeoutExt,
+};
 use crate::service::ServiceState;
 
 const TARGET: &str = "nvisy_server::runs";
@@ -40,7 +42,7 @@ async fn create_run(
     State(engine): State<Engine>,
     ActorId(actor_id): ActorId,
     Json(req): Json<NewRun>,
-) -> Result<(StatusCode, Json<RunResult>)> {
+) -> Result<(StatusCode, Json<RunId>)> {
     let input = EngineInput {
         actor_id,
         policy_ids: req.policy_ids,
@@ -49,17 +51,10 @@ async fn create_run(
         dry_run: req.dry_run,
     };
 
-    let result = RunResult::from(engine.run(input).await?);
+    let id = engine.submit(input).await?;
+    tracing::info!(target: TARGET, %id, "pipeline run submitted");
 
-    tracing::info!(
-        target: TARGET,
-        run_id = %result.run_id,
-        entities = result.total_entities,
-        entries = result.total_entries,
-        "pipeline run complete",
-    );
-
-    Ok((StatusCode::CREATED, Json(result)))
+    Ok((StatusCode::ACCEPTED, Json(RunId { id })))
 }
 
 fn create_run_docs(op: TransformOperation) -> TransformOperation {

--- a/crates/nvisy-server/src/handler/runs.rs
+++ b/crates/nvisy-server/src/handler/runs.rs
@@ -14,24 +14,18 @@
 //! Paths are relative — the version prefix (e.g. `/api/v1`) is applied
 //! by the version module.
 
-use std::time::Duration;
-
 use aide::axum::ApiRouter;
 use aide::axum::routing::{get_with, post_with};
 use aide::transform::TransformOperation;
-use axum::error_handling::HandleErrorLayer;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
-use nvisy_engine::pipeline::{Engine, EngineInput, EngineOutput, RunFilter, RunSnapshot};
-use tower::ServiceBuilder;
-use tower::timeout::TimeoutLayer;
+use nvisy_engine::pipeline::{Engine, EngineInput, RunFilter, RunSnapshot};
 
 use super::error::{ErrorKind, Result};
 use super::request::{NewRun, RunPath, RunQuery};
-use super::response::RunList;
+use super::response::{RunList, RunResult};
 use crate::extract::{ActorId, Json, Path};
-use crate::middleware::constants::{DEFAULT_PIPELINE_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS};
-use crate::middleware::recovery::handle_error;
+use crate::middleware::{DEFAULT_PIPELINE_TIMEOUT_SECS, DEFAULT_READ_TIMEOUT_SECS, RouterTimeoutExt};
 use crate::service::ServiceState;
 
 const TARGET: &str = "nvisy_server::runs";
@@ -46,7 +40,7 @@ async fn create_run(
     State(engine): State<Engine>,
     ActorId(actor_id): ActorId,
     Json(req): Json<NewRun>,
-) -> Result<(StatusCode, Json<EngineOutput>)> {
+) -> Result<(StatusCode, Json<RunResult>)> {
     let input = EngineInput {
         actor_id,
         policy_ids: req.policy_ids,
@@ -55,19 +49,17 @@ async fn create_run(
         dry_run: req.dry_run,
     };
 
-    let output = engine.run(input).await?;
+    let result = RunResult::from(engine.run(input).await?);
 
-    let total_entities: usize = output.audits.iter().map(|a| a.entities.len()).sum();
-    let total_entries: usize = output.audits.iter().map(|a| a.entries.len()).sum();
     tracing::info!(
         target: TARGET,
-        run_id = %output.run_id,
-        entities = total_entities,
-        entries = total_entries,
+        run_id = %result.run_id,
+        entities = result.total_entities,
+        entries = result.total_entries,
         "pipeline run complete",
     );
 
-    Ok((StatusCode::CREATED, Json(output)))
+    Ok((StatusCode::CREATED, Json(result)))
 }
 
 fn create_run_docs(op: TransformOperation) -> TransformOperation {
@@ -215,13 +207,7 @@ fn delete_all_runs_docs(op: TransformOperation) -> TransformOperation {
 pub fn routes_v1() -> ApiRouter<ServiceState> {
     let pipeline_routes = ApiRouter::new()
         .api_route("/runs", post_with(create_run, create_run_docs))
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_PIPELINE_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_PIPELINE_TIMEOUT_SECS);
 
     let read_routes = ApiRouter::new()
         .api_route(
@@ -233,13 +219,7 @@ pub fn routes_v1() -> ApiRouter<ServiceState> {
             get_with(get_run, get_run_docs).delete_with(delete_run, delete_run_docs),
         )
         .api_route("/runs/{id}/cancel", post_with(cancel_run, cancel_run_docs))
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(TimeoutLayer::new(Duration::from_secs(
-                    DEFAULT_READ_TIMEOUT_SECS,
-                ))),
-        );
+        .with_timeout(DEFAULT_READ_TIMEOUT_SECS);
 
     pipeline_routes.merge(read_routes)
 }

--- a/crates/nvisy-server/src/middleware/mod.rs
+++ b/crates/nvisy-server/src/middleware/mod.rs
@@ -48,11 +48,11 @@ mod security;
 mod specification;
 mod sunset;
 
+pub(crate) use self::constants::{DEFAULT_HEALTH_TIMEOUT_SECS, DEFAULT_PIPELINE_TIMEOUT_SECS};
 pub use self::constants::{
     DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_FILE_BODY_SIZE, DEFAULT_READ_TIMEOUT_SECS,
     DEFAULT_REQUEST_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS,
 };
-pub(crate) use self::constants::{DEFAULT_HEALTH_TIMEOUT_SECS, DEFAULT_PIPELINE_TIMEOUT_SECS};
 pub use self::observability::RouterObservabilityExt;
 pub use self::recovery::{RecoveryConfig, RouterRecoveryExt, RouterTimeoutExt};
 pub use self::security::{RouterSecurityExt, SecurityConfig};

--- a/crates/nvisy-server/src/middleware/mod.rs
+++ b/crates/nvisy-server/src/middleware/mod.rs
@@ -41,18 +41,20 @@
 //! }
 //! ```
 
-pub(crate) mod constants;
+mod constants;
 mod observability;
-pub(crate) mod recovery;
+mod recovery;
 mod security;
 mod specification;
 mod sunset;
 
 pub use self::constants::{
-    DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_FILE_BODY_SIZE, DEFAULT_REQUEST_TIMEOUT_SECS,
+    DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_FILE_BODY_SIZE, DEFAULT_READ_TIMEOUT_SECS,
+    DEFAULT_REQUEST_TIMEOUT_SECS, DEFAULT_WRITE_TIMEOUT_SECS,
 };
+pub(crate) use self::constants::{DEFAULT_HEALTH_TIMEOUT_SECS, DEFAULT_PIPELINE_TIMEOUT_SECS};
 pub use self::observability::RouterObservabilityExt;
-pub use self::recovery::{RecoveryConfig, RouterRecoveryExt};
+pub use self::recovery::{RecoveryConfig, RouterRecoveryExt, RouterTimeoutExt};
 pub use self::security::{RouterSecurityExt, SecurityConfig};
 pub use self::specification::{OpenApiConfig, RouterOpenApiExt};
 pub use self::sunset::{SunsetConfig, sunset_headers};

--- a/crates/nvisy-server/src/middleware/recovery.rs
+++ b/crates/nvisy-server/src/middleware/recovery.rs
@@ -17,6 +17,7 @@ use std::any::Any;
 use std::future::ready;
 use std::time::Duration;
 
+use aide::axum::ApiRouter;
 use axum::Router;
 use axum::error_handling::HandleErrorLayer;
 use axum::response::{IntoResponse, Response};
@@ -86,6 +87,25 @@ where
             .layer(TimeoutLayer::new(config.request_timeout));
 
         self.layer(middlewares)
+    }
+}
+
+/// Extension trait for [`ApiRouter`] to apply a per-group timeout.
+pub trait RouterTimeoutExt<S> {
+    /// Layer a timeout with error recovery onto this router.
+    fn with_timeout(self, secs: u64) -> Self;
+}
+
+impl<S> RouterTimeoutExt<S> for ApiRouter<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    fn with_timeout(self, secs: u64) -> Self {
+        self.layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(handle_error))
+                .layer(TimeoutLayer::new(Duration::from_secs(secs))),
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

### Handler alignment
- Add `NewPolicy` request wrapper, typed `PolicyId`/`PolicyEntry`/`PolicyList` response types
- Pagination on `GET /policies`, `DELETE /policies` (delete all)
- `Registry::unregister_all_policies`

### Timeout and pagination fixes
- `RouterTimeoutExt` trait on `ApiRouter` replacing 10 identical `ServiceBuilder`/`HandleErrorLayer`/`TimeoutLayer` blocks
- Fix `has_more` pagination bug, use `usize` consistently
- Make `middleware::constants` and `middleware::recovery` private, re-export from `middleware` root

### Async pipeline submission
- Split `Engine::run()` into `prepare()` + `execute()`, add `Engine::submit()`
- `submit()` compiles graph synchronously (fail-fast), spawns execution on a background tokio task
- `POST /runs` returns `202 Accepted` with `RunId` instead of blocking
- `run()` stays as `prepare()` + `execute()` for tests/CLI

### Type-safe RunOutcome
- Replace `RunStatus` on `RunSnapshot` with `RunOutcome` enum: `Pending`, `Running`, `Succeeded { completed_at, audits }`, `PartialFailure { completed_at, audits }`, `Failed { completed_at, error }`, `Cancelled { completed_at }`
- Audits persisted to new `audits_ks` registry keyspace, loaded by `Engine::get_run()`
- Retention enforcement removes persisted audits for `ZeroRetention` + `AuditLogs`

## Test plan
- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy clean across workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)