### PR TITLE
feat(engine): modality-aware import + annotation seeding + cleanups

### DIFF
--- a/crates/nvisy-codec/src/document/mod.rs
+++ b/crates/nvisy-codec/src/document/mod.rs
@@ -28,6 +28,24 @@ use crate::handler::{ImageData, ImageRedaction};
 #[cfg(feature = "text")]
 use crate::handler::{TextData, TextRedaction};
 
+/// Cheap, non-generic tag for which modality a [`DocumentHandle`]
+/// carries. Lets callers dispatch on the modality without holding
+/// the handle's lock or matching against the trait-object variants
+/// directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandleModality {
+    #[cfg(feature = "text")]
+    Text,
+    #[cfg(feature = "tabular")]
+    Tabular,
+    #[cfg(feature = "image")]
+    Image,
+    #[cfg(feature = "audio")]
+    Audio,
+    #[cfg(feature = "rich")]
+    Rich,
+}
+
 /// A fully type-erased document that can hold any supported modality.
 ///
 /// Variants are feature-gated by modality (`text`, `tabular`,
@@ -56,6 +74,24 @@ impl fmt::Debug for DocumentHandle {
 }
 
 impl DocumentHandle {
+    /// The modality tag for this handle. Cheaper than matching on
+    /// the variants directly and avoids holding the trait object
+    /// across borrows.
+    pub fn modality(&self) -> HandleModality {
+        match self {
+            #[cfg(feature = "text")]
+            Self::Text(_) => HandleModality::Text,
+            #[cfg(feature = "tabular")]
+            Self::Tabular(_) => HandleModality::Tabular,
+            #[cfg(feature = "image")]
+            Self::Image(_) => HandleModality::Image,
+            #[cfg(feature = "audio")]
+            Self::Audio(_) => HandleModality::Audio,
+            #[cfg(feature = "rich")]
+            Self::Rich(_) => HandleModality::Rich,
+        }
+    }
+
     /// The document type of the underlying content.
     pub fn document_type(&self) -> DocumentType {
         match self {

--- a/crates/nvisy-codec/src/lib.rs
+++ b/crates/nvisy-codec/src/lib.rs
@@ -18,4 +18,4 @@ pub mod core;
 pub mod document;
 pub mod handler;
 
-pub use self::document::DocumentHandle;
+pub use self::document::{DocumentHandle, HandleModality};

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -54,10 +54,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Internal crates
 nvisy-core = { workspace = true, features = ["http"] }
 nvisy-ontology = { workspace = true, features = [] }
-# Text is always on at the engine layer (and up). Optional
-# modalities opt-in via the matching engine feature above. The
-# workspace `default-features = false` on codec/formats means
-# engine's modality features are the single source of truth.
 nvisy-codec = { workspace = true, features = ["text"] }
 nvisy-formats = { workspace = true, features = ["text"] }
 
@@ -117,5 +113,6 @@ tracing = { workspace = true, features = [] }
 
 [dev-dependencies]
 nvisy-engine = { path = ".", features = ["test-utils"] }
+nvisy-formats = { workspace = true, features = ["txt", "csv", "test-utils"] }
 nvisy-ontology = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true, features = [] }

--- a/crates/nvisy-engine/src/deduplication/fuse/group.rs
+++ b/crates/nvisy-engine/src/deduplication/fuse/group.rs
@@ -164,8 +164,8 @@ where
                         let mut any_value_match = false;
                         for a in &groups[indices[i]] {
                             for b in &groups[indices[j]] {
-                                let va = envelope.value_at_loc(&a.location).await;
-                                let vb = envelope.value_at_loc(&b.location).await;
+                                let va = envelope.value_at(&a.location).await;
+                                let vb = envelope.value_at(&b.location).await;
                                 if let (Some(va), Some(vb)) = (va.as_deref(), vb.as_deref())
                                     && criteria.values_match(va, vb)
                                 {

--- a/crates/nvisy-engine/src/deduplication/fuse/key.rs
+++ b/crates/nvisy-engine/src/deduplication/fuse/key.rs
@@ -34,7 +34,7 @@ impl GroupKey {
         // Entities without a text value (e.g. image bounding boxes)
         // get a unique sentinel so they don't all bucket together.
         // They will still be grouped by location overlap in phase 2.
-        let value = match envelope.value_at_loc(&entity.location).await {
+        let value = match envelope.value_at(&entity.location).await {
             Some(v) => criteria.bucket_value(&v),
             None => entity.id.to_string(),
         };

--- a/crates/nvisy-engine/src/deduplication/fuse/mod.rs
+++ b/crates/nvisy-engine/src/deduplication/fuse/mod.rs
@@ -146,7 +146,7 @@ where
     result.refinement_methods.push(refinement);
 
     let value = envelope
-        .value_at_loc(&result.location)
+        .value_at(&result.location)
         .await
         .unwrap_or_default();
     tracing::trace!(
@@ -187,9 +187,12 @@ fn classify_refinement<M: Modality>(group: &[Entity<M>]) -> RefinementMethod {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
+    use nvisy_core::content::ContentMetadata;
     use nvisy_ontology::entity::{Entity, ModelKind, RecognitionMethod, RecognitionMethodKind};
     use nvisy_ontology::primitive::Confidence;
+    use tokio::sync::Mutex;
 
     use super::*;
     use crate::envelope::SharedData;
@@ -200,7 +203,15 @@ mod tests {
         )
         .expect("open registry");
         let shared = SharedData::new(uuid::Uuid::nil(), uuid::Uuid::nil(), registry);
-        DocumentEnvelope::from_text(text, shared).await
+        let handle = nvisy_formats::test_utils::decode_text(text)
+            .await
+            .expect("decode text");
+        DocumentEnvelope::<nvisy_ontology::modality::Text>::new(
+            Arc::new(Mutex::new(handle)),
+            ContentMetadata::new().with_content_type("text/plain"),
+            shared,
+        )
+        .await
     }
 
     fn conf(v: f64) -> Confidence {

--- a/crates/nvisy-engine/src/deduplication/mod.rs
+++ b/crates/nvisy-engine/src/deduplication/mod.rs
@@ -141,9 +141,13 @@ impl Deduplicator {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use nvisy_core::content::ContentMetadata;
     use nvisy_ontology::entity::{Entity, ModelKind, RecognitionMethod};
     use nvisy_ontology::modality::Text;
     use nvisy_ontology::primitive::Confidence;
+    use tokio::sync::Mutex;
 
     use super::*;
     use crate::envelope::SharedData;
@@ -160,7 +164,15 @@ mod tests {
         )
         .expect("open registry");
         let shared = SharedData::new(uuid::Uuid::nil(), uuid::Uuid::nil(), registry);
-        DocumentEnvelope::from_text(text, shared).await
+        let handle = nvisy_formats::test_utils::decode_text(text)
+            .await
+            .expect("decode text");
+        DocumentEnvelope::<Text>::new(
+            Arc::new(Mutex::new(handle)),
+            ContentMetadata::new().with_content_type("text/plain"),
+            shared,
+        )
+        .await
     }
 
     #[tokio::test]

--- a/crates/nvisy-engine/src/envelope/any.rs
+++ b/crates/nvisy-engine/src/envelope/any.rs
@@ -1,0 +1,45 @@
+//! [`AnyEnvelope`]: modality-erased enum over [`DocumentEnvelope<M>`].
+//!
+//! The importer produces one or more [`AnyEnvelope`]s per uploaded
+//! file. Single-modality content (txt, csv, png, wav, …) yields one
+//! entry; rich documents (PDF, DOCX) fan out into a `Text` and an
+//! `Image` entry that share one `Arc<Mutex<DocumentHandle>>` so
+//! reads and mutations stay coordinated.
+
+use derive_more::IsVariant;
+use nvisy_ontology::modality::{Audio, Image, Tabular, Text};
+
+use super::DocumentEnvelope;
+
+/// A modality-erased envelope returned by the importer.
+#[derive(Debug, IsVariant)]
+pub enum AnyEnvelope {
+    Text(DocumentEnvelope<Text>),
+    Tabular(DocumentEnvelope<Tabular>),
+    Image(DocumentEnvelope<Image>),
+    Audio(DocumentEnvelope<Audio>),
+}
+
+impl AnyEnvelope {
+    /// Human-readable name of the contained modality. Used for
+    /// telemetry and error messages.
+    pub fn modality_name(&self) -> &'static str {
+        match self {
+            Self::Text(_) => "text",
+            Self::Tabular(_) => "tabular",
+            Self::Image(_) => "image",
+            Self::Audio(_) => "audio",
+        }
+    }
+
+    /// Borrow the underlying shared codec handle without committing
+    /// to a modality.
+    pub fn handle(&self) -> &super::SharedHandle {
+        match self {
+            Self::Text(e) => &e.handle,
+            Self::Tabular(e) => &e.handle,
+            Self::Image(e) => &e.handle,
+            Self::Audio(e) => &e.handle,
+        }
+    }
+}

--- a/crates/nvisy-engine/src/envelope/mod.rs
+++ b/crates/nvisy-engine/src/envelope/mod.rs
@@ -12,6 +12,7 @@
 //! [`shared`]: DocumentEnvelope::shared
 
 mod accessors;
+mod any;
 mod policy_store;
 mod shared_data;
 pub mod value_at;
@@ -20,17 +21,17 @@ use std::fmt;
 use std::sync::Arc;
 
 use nvisy_codec::DocumentHandle;
-use nvisy_codec::handler::TextData;
 use nvisy_core::Error;
 use nvisy_core::content::{ContentData, ContentMetadata, ContentSource};
 use nvisy_core::media::DocumentType;
-use nvisy_ontology::context::Contexts;
 use nvisy_ontology::document::Document;
 use nvisy_ontology::entity::{Annotation, Entity};
-use nvisy_ontology::modality::{Audio, AudioBlock, Image, ImageBlock, Modality, Tabular, Text};
+use nvisy_ontology::modality::Modality;
 use nvisy_ontology::provenance::{Audit, RedactionMap};
 use tokio::sync::Mutex;
+use uuid::Uuid;
 
+pub use self::any::AnyEnvelope;
 pub use self::policy_store::PolicyStore;
 pub use self::shared_data::SharedData;
 
@@ -60,16 +61,18 @@ pub struct DocumentEnvelope<M: Modality> {
 
     /// User-supplied annotations (inclusions, exclusions, labels)
     /// attached at upload time. Set during import from content
-    /// metadata.
-    ///
-    /// Currently unused while annotation-driven inclusion seeding
-    /// and exclusion filtering are reinstated on the typed envelope.
+    /// metadata; `Inclusion` variants are also projected into
+    /// [`Self::audit::entities`] so detection/redaction see them as
+    /// pre-detected entities, while the original list stays here
+    /// for exclusion filtering and label-driven policy scoping.
     pub annotations: Vec<Annotation<M>>,
 
-    /// Reference-data contexts loaded by [`LoadContext`] nodes.
+    /// IDs of reference-data [`Context`]s loaded by [`LoadContext`]
+    /// nodes. Each UUID resolves through the engine's context cache.
     ///
+    /// [`Context`]: nvisy_ontology::context::Context
     /// [`LoadContext`]: crate::ingestion::LoadContext
-    pub contexts: Contexts,
+    pub contexts: Vec<Uuid>,
 
     /// Per-document audit trail: entities, processing log, and
     /// redaction records.
@@ -100,7 +103,7 @@ impl<M: Modality> DocumentEnvelope<M> {
             metadata,
             document: None,
             annotations: Vec::new(),
-            contexts: Contexts::new(),
+            contexts: Vec::new(),
             audit,
             redaction_map: RedactionMap::new(),
             shared,
@@ -138,85 +141,6 @@ impl<M: Modality> DocumentEnvelope<M> {
     }
 }
 
-/// Text-specific accessors that need the codec handle.
-impl DocumentEnvelope<Text> {
-    /// Resolve a [`Text`] location to its text representation by
-    /// reading from the codec handle.
-    pub async fn value_at(&self, location: &Text) -> Option<String> {
-        self.handle
-            .lock()
-            .await
-            .read_text(location)
-            .await
-            .map(TextData::into_inner)
-    }
-}
-
-/// Tabular-specific accessors that need the codec handle.
-impl DocumentEnvelope<Tabular> {
-    /// Resolve a [`Tabular`] location to its cell text by reading
-    /// from the codec handle.
-    pub async fn value_at(&self, location: &Tabular) -> Option<String> {
-        self.handle
-            .lock()
-            .await
-            .read_tabular(location)
-            .await
-            .map(TextData::into_inner)
-    }
-}
-
-/// Image-specific accessors that look up text via the OCR document.
-impl DocumentEnvelope<Image> {
-    /// Resolve an [`Image`] location to its OCR'd text — exact
-    /// bounding-box match against a block's `region` returns the
-    /// whole block text; sub-region matches consult the block's
-    /// `spans`.
-    pub async fn value_at(&self, location: &Image) -> Option<String> {
-        let doc = self.document.as_ref()?;
-        for block in &doc.blocks {
-            let (text, region) = match &block.kind {
-                ImageBlock::Text { text, region }
-                | ImageBlock::Heading { text, region }
-                | ImageBlock::Table { text, region } => (text, region),
-                _ => continue,
-            };
-            if region == location {
-                return Some(text.clone());
-            }
-            if let Some(s) = block.spans.iter().find(|s| s.source == *location) {
-                return Some(text[s.text_start..s.text_end].to_owned());
-            }
-        }
-        None
-    }
-}
-
-/// Audio-specific accessors that look up text via the STT document.
-impl DocumentEnvelope<Audio> {
-    /// Resolve an [`Audio`] location to its transcribed text — exact
-    /// time-span match against a `Speech` block returns the whole
-    /// transcript; sub-segment matches consult the block's `spans`.
-    pub async fn value_at(&self, location: &Audio) -> Option<String> {
-        let doc = self.document.as_ref()?;
-        for block in &doc.blocks {
-            let AudioBlock::Speech {
-                text, time_span, ..
-            } = &block.kind
-            else {
-                continue;
-            };
-            if time_span == &location.time_span {
-                return Some(text.clone());
-            }
-            if let Some(s) = block.spans.iter().find(|s| s.source == *location) {
-                return Some(text[s.text_start..s.text_end].to_owned());
-            }
-        }
-        None
-    }
-}
-
 impl<M: Modality> fmt::Debug for DocumentEnvelope<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DocumentEnvelope")
@@ -224,17 +148,5 @@ impl<M: Modality> fmt::Debug for DocumentEnvelope<M> {
             .field("contexts", &self.contexts.len())
             .field("entries", &self.audit.entries.len())
             .finish_non_exhaustive()
-    }
-}
-
-#[cfg(test)]
-impl DocumentEnvelope<Text> {
-    /// Create a test envelope from plain text content.
-    pub(crate) async fn from_text(text: &str, shared: Arc<SharedData>) -> Self {
-        let data = ContentData::from_text(ContentSource::new(), text);
-        let meta = ContentMetadata::new().with_content_type("text/plain");
-        let content = nvisy_core::content::Content::with_metadata(data, meta.clone());
-        let handle = nvisy_formats::decode(&content).await.expect("decode text");
-        Self::new(Arc::new(Mutex::new(handle)), meta, shared).await
     }
 }

--- a/crates/nvisy-engine/src/envelope/value_at.rs
+++ b/crates/nvisy-engine/src/envelope/value_at.rs
@@ -1,13 +1,16 @@
-//! [`ValueAt<M>`]: trait abstraction over [`DocumentEnvelope`]'s
-//! per-modality `value_at` accessors.
+//! [`ValueAt<M>`]: per-modality source-text lookup over a
+//! [`DocumentEnvelope`].
 //!
-//! Each `DocumentEnvelope<M>` has its own concrete `value_at(&M)`
-//! method (text reads from the codec handle, image consults the OCR
-//! document, etc.). Generic engine code (deduplication, fusion)
-//! parameterised over `M` calls into the right one via this trait.
+//! Each modality resolves a location differently: text/tabular read
+//! the bytes from the codec handle, while image/audio walk the
+//! extraction document's blocks for a matching region or span.
+//! Generic engine code (deduplication, fusion, redaction) bounds
+//! over `DocumentEnvelope<M>: ValueAt<M>` and calls into the right
+//! implementation at the call site.
 
 use async_trait::async_trait;
-use nvisy_ontology::modality::{Audio, Image, Modality, Tabular, Text};
+use nvisy_codec::handler::TextData;
+use nvisy_ontology::modality::{Audio, AudioBlock, Image, ImageBlock, Modality, Tabular, Text};
 
 use super::DocumentEnvelope;
 
@@ -18,33 +21,79 @@ pub trait ValueAt<M: Modality>: Sync {
     /// Resolve a location to its source text representation, or
     /// `None` if the underlying handle / extraction document has
     /// nothing at that location.
-    async fn value_at_loc(&self, location: &M) -> Option<String>;
+    async fn value_at(&self, location: &M) -> Option<String>;
 }
 
 #[async_trait]
 impl ValueAt<Text> for DocumentEnvelope<Text> {
-    async fn value_at_loc(&self, location: &Text) -> Option<String> {
-        self.value_at(location).await
+    async fn value_at(&self, location: &Text) -> Option<String> {
+        self.handle
+            .lock()
+            .await
+            .read_text(location)
+            .await
+            .map(TextData::into_inner)
     }
 }
 
 #[async_trait]
 impl ValueAt<Tabular> for DocumentEnvelope<Tabular> {
-    async fn value_at_loc(&self, location: &Tabular) -> Option<String> {
-        self.value_at(location).await
+    async fn value_at(&self, location: &Tabular) -> Option<String> {
+        self.handle
+            .lock()
+            .await
+            .read_tabular(location)
+            .await
+            .map(TextData::into_inner)
     }
 }
 
 #[async_trait]
 impl ValueAt<Image> for DocumentEnvelope<Image> {
-    async fn value_at_loc(&self, location: &Image) -> Option<String> {
-        self.value_at(location).await
+    /// Exact bounding-box match against a block's `region` returns
+    /// the whole block text; sub-region matches consult the block's
+    /// `spans`.
+    async fn value_at(&self, location: &Image) -> Option<String> {
+        let doc = self.document.as_ref()?;
+        for block in &doc.blocks {
+            let (text, region) = match &block.kind {
+                ImageBlock::Text { text, region }
+                | ImageBlock::Heading { text, region }
+                | ImageBlock::Table { text, region } => (text, region),
+                _ => continue,
+            };
+            if region == location {
+                return Some(text.clone());
+            }
+            if let Some(s) = block.spans.iter().find(|s| s.source == *location) {
+                return Some(text[s.text_start..s.text_end].to_owned());
+            }
+        }
+        None
     }
 }
 
 #[async_trait]
 impl ValueAt<Audio> for DocumentEnvelope<Audio> {
-    async fn value_at_loc(&self, location: &Audio) -> Option<String> {
-        self.value_at(location).await
+    /// Exact time-span match against a `Speech` block returns the
+    /// whole transcript; sub-segment matches consult the block's
+    /// `spans`.
+    async fn value_at(&self, location: &Audio) -> Option<String> {
+        let doc = self.document.as_ref()?;
+        for block in &doc.blocks {
+            let AudioBlock::Speech {
+                text, time_span, ..
+            } = &block.kind
+            else {
+                continue;
+            };
+            if time_span == &location.time_span {
+                return Some(text.clone());
+            }
+            if let Some(s) = block.spans.iter().find(|s| s.source == *location) {
+                return Some(text[s.text_start..s.text_end].to_owned());
+            }
+        }
+        None
     }
 }

--- a/crates/nvisy-engine/src/extraction/vlm/mod.rs
+++ b/crates/nvisy-engine/src/extraction/vlm/mod.rs
@@ -24,6 +24,7 @@ use nvisy_ontology::modality::Image;
 
 pub use self::params::VlmExtractorConfig;
 use crate::envelope::DocumentEnvelope;
+use crate::envelope::value_at::ValueAt;
 
 const TARGET: &str = "nvisy_engine::extraction::vlm";
 

--- a/crates/nvisy-engine/src/ingestion/importer.rs
+++ b/crates/nvisy-engine/src/ingestion/importer.rs
@@ -1,30 +1,43 @@
 //! File import operation.
 //!
-//! Decodes raw content into a [`DocumentEnvelope<Text>`], optionally
+//! Decodes raw content into one or more [`AnyEnvelope`]s, optionally
 //! applying pre-processing in order:
 //!
 //! 1. **Decompression** — decompress raw bytes (if format specified)
 //! 2. **Decryption** — decrypt content (if encryption config specified)
-//! 3. **Decode** — detect format and decode into a typed [`DocumentHandle`]
+//! 3. **Decode** — detect format and decode into a typed
+//!    [`DocumentHandle`]
+//! 4. **Dispatch** — wrap the handle in the matching
+//!    [`DocumentEnvelope<M>`]; rich documents (PDF, DOCX) fan out
+//!    into a `Text` and an `Image` envelope sharing one
+//!    `Arc<Mutex<DocumentHandle>>`.
+//! 5. **Seed** — convert any [`Inclusion`] annotations from the
+//!    content metadata into pre-detected entities on the envelope's
+//!    audit, and store the full annotation list on the envelope for
+//!    downstream exclusion filtering.
 //!
 //! [`DocumentHandle`]: nvisy_codec::DocumentHandle
+//! [`Inclusion`]: nvisy_ontology::entity::AnnotationKind::Inclusion
 
 use std::mem;
 use std::sync::Arc;
 
+use nvisy_codec::HandleModality;
 use nvisy_core::Result;
-use nvisy_core::content::{Content, ContentData};
-use nvisy_ontology::modality::Text;
+use nvisy_core::content::{Content, ContentData, ContentMetadata};
+use nvisy_ontology::entity::{Annotation, inclusion_entities};
+use nvisy_ontology::modality::{Audio, Image, Modality, Tabular, Text};
+use tokio::sync::Mutex;
 
-use crate::envelope::{DocumentEnvelope, SharedData};
+use crate::envelope::{AnyEnvelope, DocumentEnvelope, SharedData, SharedHandle};
 use crate::ingestion::compression::CompressionService;
 use crate::ingestion::encryption::{CryptoService, EncryptedContent};
 use crate::ingestion::{CompressionAlgorithm, EncryptionAlgorithm, EncryptionConfig};
 
 const TARGET: &str = "nvisy_engine::op::import_file";
 
-/// Decodes raw content into a [`DocumentEnvelope<Text>`], optionally applying
-/// decompression and decryption beforehand.
+/// Decodes raw content into one or more [`AnyEnvelope`]s, optionally
+/// applying decompression and decryption beforehand.
 #[derive(Default)]
 pub struct Importer {
     decompression: Option<CompressionAlgorithm>,
@@ -50,7 +63,7 @@ impl Importer {
         &self,
         content: Content,
         shared: &Arc<SharedData>,
-    ) -> Result<DocumentEnvelope<Text>> {
+    ) -> Result<Vec<AnyEnvelope>> {
         let mut content = content;
 
         if let Some(algorithm) = self.decompression {
@@ -76,19 +89,90 @@ impl Importer {
         let doc = nvisy_formats::decode(&content).await?;
         tracing::debug!(target: TARGET, doc_type = %doc.document_type(), "decoded document");
         let mut metadata = content.into_parts().1.unwrap_or_default();
+        let annotations = mem::take(&mut metadata.annotations);
 
-        // Move persisted annotations from metadata to the envelope.
-        // Inclusion entity seeding is reinstated once annotations are
-        // typed per modality.
-        let _annotations = mem::take(&mut metadata.annotations);
-        let envelope = <DocumentEnvelope<Text>>::new(
-            std::sync::Arc::new(tokio::sync::Mutex::new(doc)),
-            metadata,
-            Arc::clone(shared),
-        )
-        .await;
-        Ok(envelope)
+        let handle: SharedHandle = Arc::new(Mutex::new(doc));
+        let envelopes = dispatch(handle, metadata, annotations, shared).await;
+        tracing::debug!(
+            target: TARGET,
+            count = envelopes.len(),
+            modalities = ?envelopes.iter().map(AnyEnvelope::modality_name).collect::<Vec<_>>(),
+            "produced envelopes"
+        );
+        Ok(envelopes)
     }
+}
+
+/// Build the per-modality envelope(s) from a shared codec handle.
+///
+/// `annotations` is consumed: it's only applied to the `Text`
+/// envelope today (the metadata field is `Vec<Annotation<Text>>`).
+/// Non-text variants get an empty annotation list — when
+/// `ContentMetadata` grows per-modality annotation buckets, route
+/// each bucket to the matching branch here.
+async fn dispatch(
+    handle: SharedHandle,
+    metadata: ContentMetadata,
+    annotations: Vec<Annotation<Text>>,
+    shared: &Arc<SharedData>,
+) -> Vec<AnyEnvelope> {
+    let modality = handle.lock().await.modality();
+    match modality {
+        HandleModality::Text => {
+            let env = build_text_envelope(handle, metadata, annotations, shared).await;
+            vec![AnyEnvelope::Text(env)]
+        }
+        HandleModality::Tabular => {
+            let env = build_envelope::<Tabular>(handle, metadata, shared).await;
+            vec![AnyEnvelope::Tabular(env)]
+        }
+        HandleModality::Image => {
+            let env = build_envelope::<Image>(handle, metadata, shared).await;
+            vec![AnyEnvelope::Image(env)]
+        }
+        HandleModality::Audio => {
+            let env = build_envelope::<Audio>(handle, metadata, shared).await;
+            vec![AnyEnvelope::Audio(env)]
+        }
+        HandleModality::Rich => {
+            // PDF/DOCX: fan out into Text + Image envelopes sharing
+            // the same underlying handle so reads and mutations
+            // stay coordinated under the codec's mutex.
+            let text_env =
+                build_text_envelope(Arc::clone(&handle), metadata.clone(), annotations, shared)
+                    .await;
+            let image_env = build_envelope::<Image>(handle, metadata, shared).await;
+            vec![AnyEnvelope::Text(text_env), AnyEnvelope::Image(image_env)]
+        }
+    }
+}
+
+async fn build_text_envelope(
+    handle: SharedHandle,
+    metadata: ContentMetadata,
+    annotations: Vec<Annotation<Text>>,
+    shared: &Arc<SharedData>,
+) -> DocumentEnvelope<Text> {
+    let mut envelope = <DocumentEnvelope<Text>>::new(handle, metadata, Arc::clone(shared)).await;
+    let seeded = inclusion_entities::<Text>(&annotations);
+    if !seeded.is_empty() {
+        tracing::debug!(
+            target: TARGET,
+            count = seeded.len(),
+            "seeding inclusion annotations as entities"
+        );
+        envelope.add_entities(seeded);
+    }
+    envelope.annotations = annotations;
+    envelope
+}
+
+async fn build_envelope<M: Modality>(
+    handle: SharedHandle,
+    metadata: ContentMetadata,
+    shared: &Arc<SharedData>,
+) -> DocumentEnvelope<M> {
+    <DocumentEnvelope<M>>::new(handle, metadata, Arc::clone(shared)).await
 }
 
 /// Replace the data payload of a [`Content`] while preserving its metadata.
@@ -101,17 +185,83 @@ fn replace_data(content: Content, data: ContentData) -> Content {
 
 #[cfg(test)]
 mod tests {
-    use nvisy_core::content::{Content, ContentData};
+    use nvisy_core::content::{Content, ContentData, ContentMetadata};
+    use nvisy_ontology::entity::{
+        AnnotationKind, AnnotationTarget, EntityCategory, EntityKind, RecognitionMethod,
+    };
 
     use super::*;
     use crate::envelope::SharedData;
 
-    #[tokio::test]
-    async fn unknown_format_errors() {
+    fn shared() -> Arc<SharedData> {
         let dir = tempfile::tempdir().unwrap();
         let registry = crate::ingestion::registry::Registry::open(dir.path()).unwrap();
-        let shared = SharedData::new(uuid::Uuid::new_v4(), uuid::Uuid::new_v4(), registry);
+        SharedData::new(uuid::Uuid::new_v4(), uuid::Uuid::new_v4(), registry)
+    }
+
+    fn text_content(text: &str, annotations: Vec<Annotation<Text>>) -> Content {
+        let meta = ContentMetadata::new()
+            .with_content_type("text/plain")
+            .with_annotations(annotations);
+        Content::with_metadata(ContentData::from(text.to_owned()), meta)
+    }
+
+    #[tokio::test]
+    async fn unknown_format_errors() {
+        let shared = shared();
         let content = Content::new(ContentData::from("plain text has no magic bytes"));
         assert!(Importer::new().import(content, &shared).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn text_import_yields_single_text_envelope() {
+        let shared = shared();
+        let content = text_content("Hello, world!", Vec::new());
+        let envelopes = Importer::new().import(content, &shared).await.unwrap();
+        assert_eq!(envelopes.len(), 1);
+        assert!(envelopes[0].is_text());
+    }
+
+    #[tokio::test]
+    async fn text_import_seeds_inclusion_annotations_as_entities() {
+        let shared = shared();
+        let annotation = Annotation {
+            name: Some("uploader".into()),
+            kind: AnnotationKind::Inclusion {
+                category: EntityCategory::PersonalIdentity,
+                entity_kind: EntityKind::PersonName,
+                target: AnnotationTarget::Value("Jane Doe".into()),
+                confidence: None,
+            },
+        };
+        let content = text_content("Jane Doe lives somewhere.", vec![annotation.clone()]);
+
+        let envelopes = Importer::new().import(content, &shared).await.unwrap();
+        let AnyEnvelope::Text(env) = envelopes.into_iter().next().unwrap() else {
+            panic!("expected a Text envelope");
+        };
+
+        assert_eq!(env.audit.entities.len(), 1);
+        let entity = &env.audit.entities[0];
+        assert_eq!(entity.entity_kind, EntityKind::PersonName);
+        assert!(matches!(
+            entity.recognition_methods.first(),
+            Some(RecognitionMethod::Annotation(_))
+        ));
+        // Annotations are retained on the envelope for downstream
+        // exclusion filtering and label-driven policy scoping.
+        assert_eq!(env.annotations, vec![annotation]);
+    }
+
+    #[tokio::test]
+    async fn tabular_import_yields_single_tabular_envelope() {
+        let shared = shared();
+        let meta = ContentMetadata::new().with_content_type("text/csv");
+        let data = ContentData::from("name,age\nAlice,30\nBob,40\n".to_owned());
+        let content = Content::with_metadata(data, meta);
+
+        let envelopes = Importer::new().import(content, &shared).await.unwrap();
+        assert_eq!(envelopes.len(), 1);
+        assert!(envelopes[0].is_tabular());
     }
 }

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 use super::default::EngineInput;
 use crate::deduplication::{Deduplicator, FilterParams};
 use crate::detection::{Detection as DetectionConfig, DetectionEngine};
-use crate::envelope::{DocumentEnvelope, SharedData};
+use crate::envelope::{AnyEnvelope, DocumentEnvelope, SharedData};
 use crate::extraction::{Extraction as ExtractionConfig, Extractors};
 use crate::ingestion::{
     ExportFile as ExportFileConfig, Exporter, ImportFile as ImportFileConfig, Importer,
@@ -92,8 +92,30 @@ impl Orchestrator {
     pub async fn run(&self, plan: &EngineInput) -> Result<RunOutput, Error> {
         let envelopes = self.run_imports(&plan.imports).await?;
 
+        let mut results = Vec::new();
         let mut join_set = JoinSet::new();
         for envelope in envelopes {
+            let text_envelope = match envelope {
+                AnyEnvelope::Text(env) => env,
+                other => {
+                    let modality = other.modality_name();
+                    tracing::warn!(
+                        target: TARGET,
+                        modality,
+                        "non-text envelope skipped; downstream pipeline is text-only \
+                         (extraction fan-out for image/audio/tabular is pending)",
+                    );
+                    results.push(DocumentResult {
+                        envelope: None,
+                        error: Some(format!(
+                            "{modality} modality not yet supported by the pipeline; \
+                             only text envelopes are processed"
+                        )),
+                    });
+                    continue;
+                }
+            };
+
             let ctx = Arc::clone(&self.ctx);
             let sem = self.semaphore.clone();
             let plan = plan.clone();
@@ -105,7 +127,7 @@ impl Orchestrator {
                 };
 
                 let pipeline = DocumentPipeline { ctx: ctx.clone() };
-                match pipeline.run(envelope, &plan).await {
+                match pipeline.run(text_envelope, &plan).await {
                     Ok(envelope) => DocumentResult {
                         envelope: Some(envelope),
                         error: None,
@@ -118,7 +140,6 @@ impl Orchestrator {
             });
         }
 
-        let mut results = Vec::new();
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(doc_result) => results.push(doc_result),
@@ -148,10 +169,12 @@ impl Orchestrator {
     }
 
     /// Execute import steps to produce envelopes.
-    async fn run_imports(
-        &self,
-        imports: &[ImportFileConfig],
-    ) -> Result<Vec<DocumentEnvelope<Text>>, Error> {
+    ///
+    /// Each imported content can fan out into multiple envelopes
+    /// (e.g. rich documents → one text + one image envelope sharing
+    /// a single codec handle), so the result is a flat
+    /// `Vec<AnyEnvelope>`.
+    async fn run_imports(&self, imports: &[ImportFileConfig]) -> Result<Vec<AnyEnvelope>, Error> {
         let mut envelopes = Vec::new();
 
         for cfg in imports {
@@ -167,12 +190,11 @@ impl Orchestrator {
                     .read_content(shared.actor_id, content_id)
                     .await?;
                 let content = handle.content().await?;
-                let envelope = importer.import(content, &self.ctx.shared).await?;
-                envelopes.push(envelope);
+                envelopes.extend(importer.import(content, &self.ctx.shared).await?);
             }
         }
 
-        tracing::info!(target: TARGET, count = envelopes.len(), "documents imported");
+        tracing::info!(target: TARGET, count = envelopes.len(), "envelopes imported");
         Ok(envelopes)
     }
 }

--- a/crates/nvisy-engine/src/redaction/evaluate.rs
+++ b/crates/nvisy-engine/src/redaction/evaluate.rs
@@ -162,7 +162,7 @@ where
         if suppress_wins {
             let (policy_id, _) = matching[best_suppress_idx.expect("checked above")];
             let original = envelope
-                .value_at_loc(&entity.location)
+                .value_at(&entity.location)
                 .await
                 .unwrap_or_default();
             let entry = AuditEntry::<M>::builder()
@@ -201,7 +201,7 @@ where
         };
 
         let original = envelope
-            .value_at_loc(&entity.location)
+            .value_at(&entity.location)
             .await
             .unwrap_or_default();
         let mut builder = AuditEntry::<M>::builder().for_entity(entity.id, strategy, original);
@@ -268,10 +268,14 @@ fn condition_matches(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use nvisy_core::content::ContentMetadata;
     use nvisy_ontology::entity::Entity;
     use nvisy_ontology::policy::{Action, EntitySelector, StrategyPolicy, TextStrategy};
     use nvisy_ontology::primitive::Confidence;
     use semver::Version;
+    use tokio::sync::Mutex;
 
     use super::*;
     use crate::envelope::SharedData;
@@ -282,7 +286,15 @@ mod tests {
         )
         .expect("open registry");
         let shared = SharedData::new(uuid::Uuid::nil(), uuid::Uuid::nil(), registry);
-        DocumentEnvelope::from_text(text, shared).await
+        let handle = nvisy_formats::test_utils::decode_text(text)
+            .await
+            .expect("decode text");
+        DocumentEnvelope::<Text>::new(
+            Arc::new(Mutex::new(handle)),
+            ContentMetadata::new().with_content_type("text/plain"),
+            shared,
+        )
+        .await
     }
 
     fn ent(start: usize, end: usize, conf: f64) -> Entity<Text> {
@@ -440,6 +452,4 @@ mod tests {
         assert_ne!(env.audit.entries[0].status, AuditEntryStatus::Suppressed);
         assert_eq!(env.redaction_map.entries.len(), 1);
     }
-
-    use std::sync::Arc;
 }

--- a/crates/nvisy-engine/src/validation/mod.rs
+++ b/crates/nvisy-engine/src/validation/mod.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 pub use self::workflow::Validation;
 use self::workflow::Validation as ValidationConfig;
 use crate::envelope::DocumentEnvelope;
+use crate::envelope::value_at::ValueAt;
 
 const TARGET: &str = "nvisy_engine::validation";
 

--- a/crates/nvisy-formats/Cargo.toml
+++ b/crates/nvisy-formats/Cargo.toml
@@ -59,6 +59,10 @@ audio = ["wav", "mp3"]
 ## All rich-document formats: `pdf` + `docx`.
 rich = ["pdf", "docx"]
 
+## In-memory decode helpers for tests in this and downstream crates.
+## Re-export from `nvisy_formats::test_utils`.
+test-utils = []
+
 # Internal helpers — set automatically by any format feature above.
 # Library code uses `#[cfg(feature = "internal_text")]` to mean
 # "any text format is enabled", the right gate for shared

--- a/crates/nvisy-formats/src/lib.rs
+++ b/crates/nvisy-formats/src/lib.rs
@@ -11,6 +11,8 @@ pub mod image;
 pub mod rich;
 #[cfg(feature = "internal_tabular")]
 pub mod tabular;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 #[cfg(feature = "internal_text")]
 pub mod text;
 

--- a/crates/nvisy-formats/src/test_utils.rs
+++ b/crates/nvisy-formats/src/test_utils.rs
@@ -1,0 +1,23 @@
+//! In-memory decode helpers for use in unit and integration tests.
+//!
+//! Enabled by the `test-utils` feature, and always available within
+//! this crate's own test builds. Each helper constructs a synthetic
+//! [`Content`] with a hardcoded MIME type, runs it through
+//! [`crate::decode`], and returns a ready-to-wrap [`DocumentHandle`].
+//! Use them when you want a real codec handle without going through
+//! the full importer (decompression, decryption, registry I/O).
+
+use nvisy_codec::DocumentHandle;
+use nvisy_core::Error;
+use nvisy_core::content::{Content, ContentData, ContentMetadata};
+
+/// Decode `text` as a `text/plain` document and return the handle.
+///
+/// Panics if decoding fails — these helpers are for tests only.
+#[cfg(feature = "txt")]
+pub async fn decode_text(text: &str) -> Result<DocumentHandle, Error> {
+    let data = ContentData::from(text.to_owned());
+    let meta = ContentMetadata::new().with_content_type("text/plain");
+    let content = Content::with_metadata(data, meta);
+    crate::decode(&content).await
+}

--- a/crates/nvisy-ontology/src/context/mod.rs
+++ b/crates/nvisy-ontology/src/context/mod.rs
@@ -13,47 +13,12 @@ pub mod reference;
 pub mod temporal;
 
 use derive_builder::Builder;
-use derive_more::{Deref, DerefMut, From};
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub use self::entry::{ContextEntry, ContextEntryData};
-
-/// Lightweight set of context references carried by each document envelope.
-///
-/// Each UUID points to a [`Context`] in the engine's context cache.
-#[derive(Debug, Clone, Default, Deref, DerefMut, From)]
-#[derive(Serialize, Deserialize, JsonSchema)]
-pub struct Contexts(Vec<Uuid>);
-
-impl Contexts {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Add a context ID, deduplicating.
-    pub fn push(&mut self, id: Uuid) {
-        if !self.0.contains(&id) {
-            self.0.push(id);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn push_deduplicates() {
-        let id = Uuid::now_v7();
-        let mut ctx = Contexts::new();
-        ctx.push(id);
-        ctx.push(id);
-        assert_eq!(ctx.len(), 1);
-    }
-}
 
 /// A persistent, reusable collection of reference data for detection.
 #[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema)]

--- a/crates/nvisy-ontology/src/entity/annotation.rs
+++ b/crates/nvisy-ontology/src/entity/annotation.rs
@@ -6,6 +6,7 @@
 //! [`document_labels`]) are free functions on slices.
 
 use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use super::{Entity, EntityCategory, EntityKind, RecognitionMethod};
@@ -17,10 +18,7 @@ use crate::primitive::Confidence;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename_all = "snake_case",
-    bound(
-        serialize = "M: Serialize",
-        deserialize = "M: serde::de::DeserializeOwned",
-    )
+    bound(serialize = "M: Serialize", deserialize = "M: DeserializeOwned",)
 )]
 #[schemars(bound = "M: JsonSchema")]
 pub enum AnnotationTarget<M: Modality> {
@@ -36,10 +34,7 @@ pub enum AnnotationTarget<M: Modality> {
 #[serde(
     tag = "kind",
     rename_all = "snake_case",
-    bound(
-        serialize = "M: Serialize",
-        deserialize = "M: serde::de::DeserializeOwned",
-    )
+    bound(serialize = "M: Serialize", deserialize = "M: DeserializeOwned",)
 )]
 #[schemars(bound = "M: JsonSchema")]
 pub enum AnnotationKind<M: Modality> {
@@ -72,10 +67,7 @@ pub enum AnnotationKind<M: Modality> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename_all = "camelCase",
-    bound(
-        serialize = "M: Serialize",
-        deserialize = "M: serde::de::DeserializeOwned",
-    )
+    bound(serialize = "M: Serialize", deserialize = "M: DeserializeOwned",)
 )]
 #[schemars(bound = "M: JsonSchema")]
 pub struct Annotation<M: Modality> {

--- a/crates/nvisy-ontology/src/entity/mod.rs
+++ b/crates/nvisy-ontology/src/entity/mod.rs
@@ -15,6 +15,7 @@ mod source;
 
 use derive_builder::Builder;
 use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -44,10 +45,7 @@ use crate::primitive::{Confidence, LanguageTag};
 )]
 #[serde(
     rename_all = "camelCase",
-    bound(
-        serialize = "M: Serialize",
-        deserialize = "M: serde::de::DeserializeOwned",
-    )
+    bound(serialize = "M: Serialize", deserialize = "M: DeserializeOwned",)
 )]
 #[schemars(bound = "M: JsonSchema")]
 pub struct Entity<M: Modality> {

--- a/crates/nvisy-ontology/src/policy/mod.rs
+++ b/crates/nvisy-ontology/src/policy/mod.rs
@@ -16,6 +16,7 @@ mod strategy;
 use derive_builder::Builder;
 use schemars::JsonSchema;
 use semver::Version;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -38,7 +39,7 @@ use crate::modality::Modality;
     rename_all = "camelCase",
     bound(
         serialize = "M::Strategy: Serialize",
-        deserialize = "M::Strategy: serde::de::DeserializeOwned",
+        deserialize = "M::Strategy: DeserializeOwned",
     )
 )]
 #[schemars(bound = "M::Strategy: JsonSchema")]

--- a/crates/nvisy-ontology/src/policy/strategy/mod.rs
+++ b/crates/nvisy-ontology/src/policy/strategy/mod.rs
@@ -17,6 +17,7 @@ mod tabular;
 mod text;
 
 use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub use self::audio::AudioStrategy;
@@ -34,7 +35,7 @@ use crate::modality::Modality;
     rename_all = "snake_case",
     bound(
         serialize = "M::Strategy: Serialize",
-        deserialize = "M::Strategy: serde::de::DeserializeOwned",
+        deserialize = "M::Strategy: DeserializeOwned",
     )
 )]
 #[schemars(bound = "M::Strategy: JsonSchema")]
@@ -60,7 +61,7 @@ pub enum Action<M: Modality> {
     rename_all = "camelCase",
     bound(
         serialize = "M::Strategy: Serialize",
-        deserialize = "M::Strategy: serde::de::DeserializeOwned",
+        deserialize = "M::Strategy: DeserializeOwned",
     )
 )]
 #[schemars(bound = "M::Strategy: JsonSchema")]

--- a/crates/nvisy-ontology/src/provenance/entry.rs
+++ b/crates/nvisy-ontology/src/provenance/entry.rs
@@ -3,6 +3,7 @@
 use derive_builder::Builder;
 use jiff::Timestamp;
 use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 use uuid::Uuid;
@@ -56,7 +57,7 @@ pub enum AuditEntryStatus {
     rename_all = "camelCase",
     bound(
         serialize = "M::Strategy: Serialize",
-        deserialize = "M::Strategy: serde::de::DeserializeOwned",
+        deserialize = "M::Strategy: DeserializeOwned",
     )
 )]
 #[schemars(bound = "M::Strategy: JsonSchema")]
@@ -94,7 +95,7 @@ pub struct AuditEntry<M: Modality> {
     rename_all = "camelCase",
     bound(
         serialize = "M::Strategy: Serialize",
-        deserialize = "M::Strategy: serde::de::DeserializeOwned",
+        deserialize = "M::Strategy: DeserializeOwned",
     )
 )]
 #[schemars(bound = "M::Strategy: JsonSchema")]

--- a/crates/nvisy-ontology/src/provenance/mod.rs
+++ b/crates/nvisy-ontology/src/provenance/mod.rs
@@ -19,6 +19,7 @@ mod review;
 
 use derive_builder::Builder;
 use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -50,7 +51,7 @@ use crate::modality::Modality;
     rename_all = "camelCase",
     bound(
         serialize = "M: Serialize, M::Strategy: Serialize",
-        deserialize = "M: serde::de::DeserializeOwned, M::Strategy: serde::de::DeserializeOwned",
+        deserialize = "M: DeserializeOwned, M::Strategy: DeserializeOwned",
     )
 )]
 #[schemars(bound = "M: JsonSchema, M::Strategy: JsonSchema")]

--- a/crates/nvisy-ontology/src/provenance/redaction_map.rs
+++ b/crates/nvisy-ontology/src/provenance/redaction_map.rs
@@ -10,6 +10,7 @@
 
 use derive_more::{Deref, DerefMut};
 use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -25,10 +26,7 @@ use crate::modality::Modality;
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename_all = "camelCase",
-    bound(
-        serialize = "M: Serialize",
-        deserialize = "M: serde::de::DeserializeOwned",
-    )
+    bound(serialize = "M: Serialize", deserialize = "M: DeserializeOwned",)
 )]
 #[schemars(bound = "M: JsonSchema")]
 pub struct RedactionMapping<M: Modality> {
@@ -50,10 +48,7 @@ pub struct RedactionMapping<M: Modality> {
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename_all = "camelCase",
-    bound(
-        serialize = "M: Serialize",
-        deserialize = "M: serde::de::DeserializeOwned",
-    )
+    bound(serialize = "M: Serialize", deserialize = "M: DeserializeOwned",)
 )]
 #[schemars(bound = "M: JsonSchema")]
 pub struct RedactionMap<M: Modality> {


### PR DESCRIPTION
## Summary

- **Importer fan-out:** introduces `AnyEnvelope` (Text/Tabular/Image/Audio); `Importer::import` returns `Vec<AnyEnvelope>` and rich documents (PDF/DOCX) fan out into a Text + Image envelope pair sharing one `Arc<Mutex<DocumentHandle>>`. Orchestrator routes Text envelopes through the existing pipeline and emits an explicit warning + stub `DocumentResult` for non-Text envelopes (full per-modality pipeline genericity is a follow-up).
- **Annotation seeding:** for Text envelopes, `Inclusion` annotations are projected into `audit.entities` via `inclusion_entities::<Text>` + `envelope.add_entities`, and the full annotation list is retained on `envelope.annotations` for downstream exclusion filtering and label-driven policy scoping. Restores the feature dropped during the typed-envelope refactor (closes #198).
- **Codec:** new `HandleModality` tag enum + `DocumentHandle::modality()` method that the importer now uses (replaces an engine-local discriminant).
- **`ValueAt` collapse:** moved the four inherent `DocumentEnvelope<M>::value_at` bodies into the matching `ValueAt<M>` trait impls and renamed the trait method back to `value_at`; non-generic callers just `use crate::envelope::value_at::ValueAt;`.
- **Test-utils:** new `nvisy-formats` `test-utils` feature exposing `test_utils::decode_text(&str) -> Result<DocumentHandle>`. Dropped the inherent `DocumentEnvelope<Text>::from_text` test helper from `envelope/mod.rs`; engine tests now compose the formats helper with `DocumentEnvelope::new` directly.
- **Misc cleanups:** dropped the `Contexts` newtype (was `Vec<Uuid>` behind `Deref`/`DerefMut`); shortened `serde::de::DeserializeOwned` → `DeserializeOwned` across ontology `#[serde(bound(...))]` strings with a proper `use serde::de::DeserializeOwned;`.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test -p nvisy-engine -p nvisy-ontology --all-features` — 148 tests pass
- [x] New importer tests: text inclusion seeding round-trip, text/tabular variant dispatch, unknown format error
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)