### PR TITLE
refactor(ontology): Tabular.{row,column}_index: usize → u32

### DIFF
--- a/crates/nvisy-engine/src/extraction/tabular.rs
+++ b/crates/nvisy-engine/src/extraction/tabular.rs
@@ -33,7 +33,7 @@ pub(super) async fn populate_document(envelope: &mut DocumentEnvelope<Tabular>) 
     }
 
     // Group cells by row, preserving column order within each row.
-    let mut rows: BTreeMap<usize, Vec<Tabular>> = BTreeMap::new();
+    let mut rows: BTreeMap<u32, Vec<Tabular>> = BTreeMap::new();
     for located in locations {
         rows.entry(located.location.row_index)
             .or_default()

--- a/crates/nvisy-formats/src/tabular/csv_handler.rs
+++ b/crates/nvisy-formats/src/tabular/csv_handler.rs
@@ -75,7 +75,7 @@ impl Handle<Tabular> for CsvHandler {
                     source,
                     Tabular {
                         row_index: 0,
-                        column_index: col,
+                        column_index: col as u32,
                         start_offset: None,
                         end_offset: None,
                         column_name: Some(headers[col].clone()),
@@ -91,8 +91,8 @@ impl Handle<Tabular> for CsvHandler {
                 items.push(Located::new(
                     source,
                     Tabular {
-                        row_index,
-                        column_index: col,
+                        row_index: row_index as u32,
+                        column_index: col as u32,
                         start_offset: None,
                         end_offset: None,
                         column_name: self.data.headers.as_ref().and_then(|h| h.get(col).cloned()),
@@ -107,10 +107,11 @@ impl Handle<Tabular> for CsvHandler {
 
     async fn read(&self, location: &Tabular) -> Option<TextData> {
         let (is_header, data_row) = self.resolve_row(location.row_index)?;
+        let col = location.column_index as usize;
         let cell = if is_header {
-            self.data.headers.as_ref()?.get(location.column_index)?
+            self.data.headers.as_ref()?.get(col)?
         } else {
-            self.data.rows.get(data_row)?.get(location.column_index)?
+            self.data.rows.get(data_row)?.get(col)?
         };
         Some(TextData::from(cell.clone()))
     }
@@ -123,11 +124,12 @@ impl Handle<Tabular> for CsvHandler {
         let Some((is_header, data_row)) = self.resolve_row(location.row_index) else {
             return Ok(());
         };
+        let col = location.column_index as usize;
         let cell = if is_header {
             let Some(headers) = self.data.headers.as_mut() else {
                 return Ok(());
             };
-            let Some(cell) = headers.get_mut(location.column_index) else {
+            let Some(cell) = headers.get_mut(col) else {
                 return Ok(());
             };
             cell
@@ -135,7 +137,7 @@ impl Handle<Tabular> for CsvHandler {
             let Some(row) = self.data.rows.get_mut(data_row) else {
                 return Ok(());
             };
-            let Some(cell) = row.get_mut(location.column_index) else {
+            let Some(cell) = row.get_mut(col) else {
                 return Ok(());
             };
             cell
@@ -224,17 +226,16 @@ impl CsvHandler {
     /// Returns `None` when the row index is out of range.
     ///
     /// [`Tabular::row_index`]: nvisy_ontology::modality::Tabular::row_index
-    fn resolve_row(&self, row_index: usize) -> Option<(bool, usize)> {
-        if self.data.headers.is_some() {
+    fn resolve_row(&self, row_index: u32) -> Option<(bool, usize)> {
+        let data_row = if self.data.headers.is_some() {
             if row_index == 0 {
-                Some((true, 0))
-            } else {
-                let data_row = row_index - 1;
-                (data_row < self.data.rows.len()).then_some((false, data_row))
+                return Some((true, 0));
             }
+            (row_index - 1) as usize
         } else {
-            (row_index < self.data.rows.len()).then_some((false, row_index))
-        }
+            row_index as usize
+        };
+        (data_row < self.data.rows.len()).then_some((false, data_row))
     }
 
     /// Serialize to bytes (with CRLF→LF normalization and trailing
@@ -300,7 +301,7 @@ mod tests {
         })
     }
 
-    fn cell_range(row: usize, col: usize, start: usize, end: usize) -> Tabular {
+    fn cell_range(row: u32, col: u32, start: usize, end: usize) -> Tabular {
         Tabular {
             start_offset: Some(start),
             end_offset: Some(end),

--- a/crates/nvisy-ontology/src/modality/tabular.rs
+++ b/crates/nvisy-ontology/src/modality/tabular.rs
@@ -12,9 +12,11 @@ use crate::policy::TabularStrategy;
 #[serde(rename_all = "camelCase")]
 pub struct Tabular {
     /// Row index (0-based).
-    pub row_index: usize,
-    /// Column index (0-based).
-    pub column_index: usize,
+    pub row_index: u32,
+    /// Column index (0-based). Matches the width of
+    /// [`ColumnHeader::column_index`] so cell → header joins never
+    /// need a cast.
+    pub column_index: u32,
     /// Byte offset within the cell where the range starts, if applicable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_offset: Option<usize>,
@@ -33,7 +35,7 @@ impl Tabular {
     /// Create a [`Tabular`] for the given cell coordinates, with every
     /// optional field (intra-cell offsets, column name, sheet name)
     /// unset.
-    pub fn new(row_index: usize, column_index: usize) -> Self {
+    pub fn new(row_index: u32, column_index: u32) -> Self {
         Self {
             row_index,
             column_index,
@@ -190,7 +192,7 @@ impl Mergeable for Tabular {
 mod tests {
     use super::*;
 
-    fn cell_with_offsets(row: usize, col: usize, start: usize, end: usize) -> Tabular {
+    fn cell_with_offsets(row: u32, col: u32, start: usize, end: usize) -> Tabular {
         Tabular {
             start_offset: Some(start),
             end_offset: Some(end),


### PR DESCRIPTION
## Summary

\`Tabular.row_index\` and \`Tabular.column_index\` were \`usize\`; \`ColumnHeader.column_index\` (in \`TabularMetadata.headers\`) was \`u32\`. Same semantic concept, two widths — every cell↔header join needed a cast.

\`u32\` is the right type for both. CSV / XLSX / SQL columns are bounded well below \`u32::MAX\`; \`usize\` was inherited from \`Vec::get\`'s parameter, not chosen for the data model.

Closes #218.

## Changes

**Public API (wire-breaking in theory)**
- \`Tabular::row_index: usize → u32\`
- \`Tabular::column_index: usize → u32\`
- \`Tabular::new(row: u32, col: u32)\` signature
- \`ColumnHeader::column_index\` unchanged (already \`u32\`)

**CSV handler internals**
- Cell construction: \`row_index as u32\` / \`col as u32\` at the \`enumerate()\` boundary.
- \`Vec::get\` lookups: \`location.column_index as usize\` at the call site.
- \`resolve_row\` accepts \`u32\` and returns \`(bool, usize)\` — the \`usize\` is correctly an index into the handler's \`Vec<Vec<String>>\`, so the cast belongs inside the helper.

**Engine**
- \`extraction/tabular.rs\` row-grouping \`BTreeMap<usize, _>\` → \`BTreeMap<u32, _>\`.
- \`detection/lift.rs\` cell passthrough unchanged (the source \`Tabular\` already carries \`u32\`).

**Tests**
- Two helpers (\`cell_with_offsets\`, \`cell_range\`) take \`u32\` row/col now.

## Wire impact

Theoretically wire-breaking if \`usize\` was serialized on a 64-bit target with a value above \`u32::MAX\`. In practice no real CSV / XLSX / SQL document has more than 4B columns, so persisted shapes never differ — wire-compatible-in-practice.

## Test plan

- [x] \`cargo check --workspace --all-features\`
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-features --no-fail-fast\`
- [x] \`cargo doc --workspace --no-deps --all-features\`
- [x] \`cargo +nightly fmt --all -- --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)