### PR TITLE
chore(deps): bump bentoml 0.3 → 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bentoml"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9bf69783b57a8d1e93117c19cf6beeebb33c18cd8702ee578e76a9d681f279"
+checksum = "c65f4e07f4eac57a9e81aa97cf1c9d297cc01aad185767b613c1bcf112c469d8"
 dependencies = [
  "bytes",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ nvisy-pattern = { path = "./crates/nvisy-pattern", version = "0.1.0" }
 nvisy-server = { path = "./crates/nvisy-server", version = "0.1.0" }
 
 # Inference & AI frameworks
-bentoml = { version = "0.3", default-features = false, features = ["rustls-tls", "tracing"] }
+bentoml = { version = "0.5", default-features = false, features = ["rustls-tls", "tracing"] }
 rig = { version = "0.37", features = [], default-features = false }
 
 # HTTP client and middleware

--- a/crates/nvisy-ner/src/backend/bento_backend.rs
+++ b/crates/nvisy-ner/src/backend/bento_backend.rs
@@ -52,7 +52,7 @@ impl BentoParams {
 /// service over HTTP.
 #[derive(Debug)]
 pub struct BentoBackend {
-    client: Client,
+    endpoint: Endpoint,
 }
 
 impl BentoBackend {
@@ -67,7 +67,9 @@ impl BentoBackend {
             .with_base_url(&params.base_url)
             .build()
             .map_err(|e| Error::runtime(format!("bentoml client init: {e}"), COMPONENT, false))?;
-        Ok(Self { client })
+        Ok(Self {
+            endpoint: client.endpoint(RECOGNIZE_ROUTE),
+        })
     }
 }
 
@@ -103,10 +105,10 @@ impl Backend for BentoBackend {
         let request_id = ctx.correlation_id.unwrap_or_else(Uuid::now_v7).to_string();
 
         let responses: Vec<WireResponse> = self
-            .client
-            .endpoint(RECOGNIZE_ROUTE)
+            .endpoint
+            .clone()
             .with_request_id(&request_id)
-            .call(&WireBatch {
+            .invoke(&WireBatch {
                 requests: wire_requests,
             })
             .await


### PR DESCRIPTION
## Summary

- Bump workspace `bentoml` from 0.3 → 0.5.
- In 0.5 the `Endpoint::call` family returns a raw `EndpointReply`; for JSON-in, JSON-out use `.invoke(&body)` which is the direct equivalent of the 0.3 behaviour.
- Build the `recognize` endpoint once in `BentoBackend::new` and cache it on the struct. Each call clones the handle (cheap — internal `Cow<'static, str>` + `Arc` for the client) only to layer on the per-request `x-request-id` header.
- OCR backend is still scaffolding (#128) and doesn't issue real calls; no changes needed there beyond the workspace bump.

## Test plan

- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)