### PR TITLE
feat(codec): HTML attribute + comment scanning, script/style policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,6 +2834,7 @@ dependencies = [
  "bytes",
  "csv",
  "derive_more",
+ "ego-tree",
  "hex",
  "hound",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ pdfium-render = { version = "0.9", features = [] }
 
 # Document parsing
 scraper = { version = "0.27", features = [] }
+ego-tree = { version = "0.11", features = [] }
 calamine = { version = "0.35", features = [] }
 zip = { version = "8.4", features = [] }
 quick-xml = { version = "0.40", features = [] }

--- a/crates/nvisy-codec/Cargo.toml
+++ b/crates/nvisy-codec/Cargo.toml
@@ -28,7 +28,7 @@ json = ["internal_text"]
 ## Markdown loader.
 markdown = ["internal_text"]
 ## HTML loader and handler via `scraper`.
-html = ["internal_text", "dep:scraper"]
+html = ["internal_text", "dep:scraper", "dep:ego-tree"]
 
 ## CSV loader and handler via the `csv` crate. Tabular cells reuse the
 ## text redact helper, so this pulls `internal_text`.
@@ -131,6 +131,7 @@ rayon = { workspace = true, optional = true, features = [] }
 # Document parsing (feature-gated)
 csv = { workspace = true, optional = true, features = [] }
 scraper = { workspace = true, optional = true, features = [] }
+ego-tree = { workspace = true, optional = true, features = [] }
 
 # Observability
 tracing = { workspace = true, features = [] }

--- a/crates/nvisy-codec/src/handler/rich/docx_handler.rs
+++ b/crates/nvisy-codec/src/handler/rich/docx_handler.rs
@@ -12,7 +12,6 @@ use nvisy_core::redaction::Redactions;
 
 use super::DocxLoader;
 use crate::content::{ContentData, ContentSource};
-use crate::handler::text::lift_identity;
 use crate::{Chunk, Format, FormatId, Handler};
 
 const TARGET: &str = "nvisy_codec::handler::rich::docx";
@@ -81,7 +80,7 @@ impl Handler<Text> for DocxHandler {
     }
 
     fn lift_chunk(&self, chunk: &Chunk<Text>, value_range: Range<usize>) -> Option<TextLocation> {
-        lift_identity(chunk, value_range)
+        chunk.location.subslice(value_range)
     }
 
     async fn read(&self, _location: &TextLocation) -> Result<Option<TextData>, Error> {

--- a/crates/nvisy-codec/src/handler/rich/pdf_handler.rs
+++ b/crates/nvisy-codec/src/handler/rich/pdf_handler.rs
@@ -28,7 +28,7 @@ use super::PdfLoader;
 use super::pdf_render::PdfRenderer;
 use crate::content::{ContentData, ContentSource};
 use crate::handler::image::PngHandler;
-use crate::handler::text::{lift_identity, redact};
+use crate::handler::text::redact;
 use crate::{Chunk, DocumentHandle, Format, FormatId, Handler};
 
 const TARGET: &str = "nvisy_codec::handler::rich::pdf";
@@ -199,7 +199,7 @@ impl Handler<Text> for PdfHandler {
     }
 
     fn lift_chunk(&self, chunk: &Chunk<Text>, value_range: Range<usize>) -> Option<TextLocation> {
-        lift_identity(chunk, value_range)
+        chunk.location.subslice(value_range)
     }
 
     async fn read(&self, location: &TextLocation) -> Result<Option<TextData>, Error> {
@@ -249,7 +249,7 @@ impl PdfHandler {
         let mut content = self.pages[i].clone();
         let value = replacement.replacement_value().unwrap_or_default();
         let before_len = self.pages[i].len();
-        redact::replace_range(&mut content, value, local_start, local_end, TARGET)?;
+        redact::replace_range(&mut content, value, local_start..local_end, TARGET)?;
 
         // Bake the edit into the raw PDF content stream so the encoded
         // bytes round-trip with the redaction.

--- a/crates/nvisy-codec/src/handler/tabular/csv_handler.rs
+++ b/crates/nvisy-codec/src/handler/tabular/csv_handler.rs
@@ -283,7 +283,7 @@ impl CsvHandler {
         let start = location.start_offset.unwrap_or(0);
         let end = location.end_offset.unwrap_or(cell.len());
         let value = replacement.replacement_value().unwrap_or_default();
-        redact::replace_range(cell, value, start, end, TARGET)
+        redact::replace_range(cell, value, start..end, TARGET)
     }
 
     fn serialize_bytes(&self) -> Result<Vec<u8>, Error> {

--- a/crates/nvisy-codec/src/handler/text/html_encode.rs
+++ b/crates/nvisy-codec/src/handler/text/html_encode.rs
@@ -1,0 +1,172 @@
+//! HTML encode-side machinery: the [`EncodePlan`] that buckets the
+//! handler's [`RedactableItem`] stream by kind so encode's single
+//! DOM walk can answer "what does item-of-kind-X at index N look
+//! like?" in O(1), plus the per-kind DOM mutation helpers.
+
+use ego_tree::NodeId;
+use scraper::Html;
+use scraper::node::Node;
+
+use super::html_handler::{ElementTarget, RedactableItem, RedactableKind};
+
+/// Pre-bucketed view of the loader's items, indexed by kind so
+/// encode's single DOM walk can answer "what does item-of-kind-X at
+/// index N look like?" in O(1).
+pub(super) struct EncodePlan<'a> {
+    /// Indexed by text-node ordinal in document order. `Some(value)`
+    /// when the loader emitted an item for that text node; `None`
+    /// for skipped text nodes (e.g. script / style children when
+    /// the policy is `Skip`).
+    text_values: Vec<Option<&'a str>>,
+    /// Indexed by comment ordinal. Same shape as `text_values`.
+    comment_values: Vec<Option<&'a str>>,
+    /// Indexed by element ordinal. Each entry is the (possibly
+    /// empty) list of element-bound items at that element.
+    element_targets: Vec<Vec<ElementTargetPatch<'a>>>,
+}
+
+/// A single element-bound patch staged for encode.
+struct ElementTargetPatch<'a> {
+    target: &'a ElementTarget,
+    value: &'a str,
+}
+
+impl<'a> EncodePlan<'a> {
+    /// Build a plan from the handler's items list.
+    pub(super) fn from_items(items: &'a [RedactableItem]) -> Self {
+        let mut text_values: Vec<Option<&'a str>> = Vec::new();
+        let mut comment_values: Vec<Option<&'a str>> = Vec::new();
+        let mut element_targets: Vec<Vec<ElementTargetPatch<'a>>> = Vec::new();
+
+        for item in items {
+            match &item.kind {
+                RedactableKind::TextNode { index } => {
+                    grow_to(&mut text_values, *index);
+                    text_values[*index] = Some(item.value.as_str());
+                }
+                RedactableKind::Comment { index } => {
+                    grow_to(&mut comment_values, *index);
+                    comment_values[*index] = Some(item.value.as_str());
+                }
+                RedactableKind::Element {
+                    element_index,
+                    target,
+                } => {
+                    while element_targets.len() <= *element_index {
+                        element_targets.push(Vec::new());
+                    }
+                    element_targets[*element_index].push(ElementTargetPatch {
+                        target,
+                        value: item.value.as_str(),
+                    });
+                }
+            }
+        }
+
+        Self {
+            text_values,
+            comment_values,
+            element_targets,
+        }
+    }
+
+    /// Walk `dom` in document order, applying the per-kind patches
+    /// from this plan against the matching ordinals. Mutates `dom`
+    /// in place.
+    pub(super) fn apply(&self, dom: &mut Html) {
+        let mut text_seen = 0usize;
+        let mut comment_seen = 0usize;
+        let mut element_seen = 0usize;
+
+        let node_ids: Vec<_> = dom.tree.nodes().map(|n| n.id()).collect();
+        for node_id in node_ids {
+            let Some(node) = dom.tree.get(node_id) else {
+                continue;
+            };
+            match node.value() {
+                Node::Text(_) => {
+                    if let Some(value) = self.text_values.get(text_seen).copied().flatten() {
+                        write_text(dom, node_id, value);
+                    }
+                    text_seen += 1;
+                }
+                Node::Comment(_) => {
+                    if let Some(value) = self.comment_values.get(comment_seen).copied().flatten() {
+                        write_comment(dom, node_id, value);
+                    }
+                    comment_seen += 1;
+                }
+                Node::Element(_) => {
+                    if let Some(targets) = self.element_targets.get(element_seen) {
+                        for et in targets {
+                            apply_element_target(dom, node_id, et);
+                        }
+                    }
+                    element_seen += 1;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn grow_to(v: &mut Vec<Option<&str>>, index: usize) {
+    while v.len() <= index {
+        v.push(None);
+    }
+}
+
+fn write_text(dom: &mut Html, node_id: NodeId, value: &str) {
+    if let Some(mut n) = dom.tree.get_mut(node_id)
+        && let Node::Text(t) = n.value()
+        && t.text.as_ref() != value
+    {
+        t.text = value.into();
+    }
+}
+
+fn write_comment(dom: &mut Html, node_id: NodeId, value: &str) {
+    if let Some(mut n) = dom.tree.get_mut(node_id)
+        && let Node::Comment(c) = n.value()
+        && c.comment.as_ref() != value
+    {
+        c.comment = value.into();
+    }
+}
+
+fn apply_element_target(dom: &mut Html, node_id: NodeId, patch: &ElementTargetPatch<'_>) {
+    match patch.target {
+        ElementTarget::Attribute { attr_name } => {
+            write_attribute(dom, node_id, attr_name, patch.value);
+        }
+        ElementTarget::ScriptText | ElementTarget::StyleText => {
+            write_text_child(dom, node_id, patch.value);
+        }
+    }
+}
+
+fn write_attribute(dom: &mut Html, element_id: NodeId, attr_name: &str, value: &str) {
+    if let Some(mut n) = dom.tree.get_mut(element_id)
+        && let Node::Element(e) = n.value()
+    {
+        for (qn, val) in &mut e.attrs {
+            if qn.local.as_ref() == attr_name {
+                if val.as_ref() != value {
+                    *val = value.into();
+                }
+                return;
+            }
+        }
+    }
+}
+
+fn write_text_child(dom: &mut Html, element_id: NodeId, value: &str) {
+    let child_id = dom
+        .tree
+        .get(element_id)
+        .and_then(|n| n.first_child().map(|c| c.id()));
+    let Some(child_id) = child_id else {
+        return;
+    };
+    write_text(dom, child_id, value);
+}

--- a/crates/nvisy-codec/src/handler/text/html_handler.rs
+++ b/crates/nvisy-codec/src/handler/text/html_handler.rs
@@ -16,14 +16,13 @@
 
 use std::ops::Range;
 
-use ego_tree::NodeId;
 use nvisy_core::Error;
 use nvisy_core::modality::{Text, TextData, TextLocation};
 use nvisy_core::redaction::{Redactions, TextReplacement};
 use scraper::Html;
-use scraper::node::Node;
 
-use super::{HtmlLoader, lift_identity, redact};
+use super::html_encode::EncodePlan;
+use super::{HtmlLoader, redact};
 use crate::content::{ContentData, ContentSource};
 use crate::{Chunk, Format, FormatId, Handler};
 
@@ -136,41 +135,7 @@ impl Handler<Text> for HtmlHandler {
     #[tracing::instrument(name = "html.encode", skip_all, fields(output_bytes))]
     fn encode(&self) -> Result<ContentData, Error> {
         let mut dom = Html::parse_document(&self.data.raw);
-        let plan = EncodePlan::from_items(&self.data.items);
-
-        let mut text_seen = 0usize;
-        let mut comment_seen = 0usize;
-        let mut element_seen = 0usize;
-
-        let node_ids: Vec<_> = dom.tree.nodes().map(|n| n.id()).collect();
-        for node_id in node_ids {
-            let Some(node) = dom.tree.get(node_id) else {
-                continue;
-            };
-            match node.value() {
-                Node::Text(_) => {
-                    if let Some(value) = plan.text_value(text_seen) {
-                        write_text(&mut dom, node_id, value);
-                    }
-                    text_seen += 1;
-                }
-                Node::Comment(_) => {
-                    if let Some(value) = plan.comment_value(comment_seen) {
-                        write_comment(&mut dom, node_id, value);
-                    }
-                    comment_seen += 1;
-                }
-                Node::Element(_) => {
-                    if let Some(targets) = plan.element_targets(element_seen) {
-                        for et in targets {
-                            apply_element_target(&mut dom, node_id, et);
-                        }
-                    }
-                    element_seen += 1;
-                }
-                _ => {}
-            }
-        }
+        EncodePlan::from_items(&self.data.items).apply(&mut dom);
 
         let bytes = dom.html().into_bytes();
         tracing::Span::current().record("output_bytes", bytes.len());
@@ -198,7 +163,7 @@ impl Handler<Text> for HtmlHandler {
     }
 
     fn lift_chunk(&self, chunk: &Chunk<Text>, value_range: Range<usize>) -> Option<TextLocation> {
-        lift_identity(chunk, value_range)
+        chunk.location.subslice(value_range)
     }
 
     async fn read(&self, location: &TextLocation) -> Result<Option<TextData>, Error> {
@@ -313,8 +278,7 @@ impl HtmlHandler {
         redact::replace_range(
             &mut self.data.items[i].value,
             value,
-            local_start,
-            local_end,
+            local_start..local_end,
             TARGET,
         )?;
         let delta = self.data.items[i].value.len() as isize - before_len as isize;
@@ -334,149 +298,6 @@ fn compute_item_starts(items: &[RedactableItem]) -> Vec<usize> {
     }
     starts.push(offset);
     starts
-}
-
-/// Pre-bucketed view of the loader's items, indexed by kind so
-/// encode's single DOM walk can answer "what does item-of-kind-X at
-/// index N look like?" in O(1).
-struct EncodePlan<'a> {
-    /// Indexed by text-node ordinal in document order. `Some(value)`
-    /// when the loader emitted an item for that text node;
-    /// `None` for skipped text nodes (e.g. script/style children
-    /// when the policy is Skip).
-    text_values: Vec<Option<&'a str>>,
-    /// Indexed by comment ordinal. Same shape as `text_values`.
-    comment_values: Vec<Option<&'a str>>,
-    /// Indexed by element ordinal. Each entry is the (possibly
-    /// empty) list of element-bound items at that element.
-    element_targets: Vec<Vec<ElementTargetPatch<'a>>>,
-}
-
-/// A single element-bound patch staged for encode.
-struct ElementTargetPatch<'a> {
-    target: &'a ElementTarget,
-    value: &'a str,
-}
-
-impl<'a> EncodePlan<'a> {
-    fn from_items(items: &'a [RedactableItem]) -> Self {
-        let mut text_values: Vec<Option<&'a str>> = Vec::new();
-        let mut comment_values: Vec<Option<&'a str>> = Vec::new();
-        let mut element_targets: Vec<Vec<ElementTargetPatch<'a>>> = Vec::new();
-
-        for item in items {
-            match &item.kind {
-                RedactableKind::TextNode { index } => {
-                    grow_to(&mut text_values, *index);
-                    text_values[*index] = Some(item.value.as_str());
-                }
-                RedactableKind::Comment { index } => {
-                    grow_to(&mut comment_values, *index);
-                    comment_values[*index] = Some(item.value.as_str());
-                }
-                RedactableKind::Element {
-                    element_index,
-                    target,
-                } => {
-                    while element_targets.len() <= *element_index {
-                        element_targets.push(Vec::new());
-                    }
-                    element_targets[*element_index].push(ElementTargetPatch {
-                        target,
-                        value: item.value.as_str(),
-                    });
-                }
-            }
-        }
-
-        Self {
-            text_values,
-            comment_values,
-            element_targets,
-        }
-    }
-
-    fn text_value(&self, ordinal: usize) -> Option<&'a str> {
-        self.text_values.get(ordinal).copied().flatten()
-    }
-
-    fn comment_value(&self, ordinal: usize) -> Option<&'a str> {
-        self.comment_values.get(ordinal).copied().flatten()
-    }
-
-    fn element_targets(&self, ordinal: usize) -> Option<&[ElementTargetPatch<'a>]> {
-        self.element_targets.get(ordinal).map(|v| v.as_slice())
-    }
-}
-
-fn grow_to(v: &mut Vec<Option<&str>>, index: usize) {
-    while v.len() <= index {
-        v.push(None);
-    }
-}
-
-fn write_text(dom: &mut Html, node_id: NodeId, value: &str) {
-    if let Some(mut n) = dom.tree.get_mut(node_id)
-        && let Node::Text(t) = n.value()
-        && t.text.as_ref() != value
-    {
-        t.text = value.into();
-    }
-}
-
-fn write_comment(dom: &mut Html, node_id: NodeId, value: &str) {
-    if let Some(mut n) = dom.tree.get_mut(node_id)
-        && let Node::Comment(c) = n.value()
-        && c.comment.as_ref() != value
-    {
-        c.comment = value.into();
-    }
-}
-
-fn apply_element_target(
-    dom: &mut Html,
-    node_id: NodeId,
-    patch: &ElementTargetPatch<'_>,
-) {
-    match patch.target {
-        ElementTarget::Attribute { attr_name } => {
-            write_attribute(dom, node_id, attr_name, patch.value);
-        }
-        ElementTarget::ScriptText | ElementTarget::StyleText => {
-            write_text_child(dom, node_id, patch.value);
-        }
-    }
-}
-
-fn write_attribute(
-    dom: &mut Html,
-    element_id: NodeId,
-    attr_name: &str,
-    value: &str,
-) {
-    if let Some(mut n) = dom.tree.get_mut(element_id)
-        && let Node::Element(e) = n.value()
-    {
-        for (qn, val) in &mut e.attrs {
-            if qn.local.as_ref() == attr_name {
-                if val.as_ref() != value {
-                    *val = value.into();
-                }
-                return;
-            }
-        }
-    }
-}
-
-fn write_text_child(dom: &mut Html, element_id: NodeId, value: &str) {
-    let child_id = dom
-        .tree
-        .get(element_id)
-        .and_then(|n| n.first_child().map(|c| c.id()));
-    let Some(child_id) = child_id else {
-        return;
-    };
-    write_text(dom, child_id, value);
 }
 
 #[cfg(test)]

--- a/crates/nvisy-codec/src/handler/text/html_handler.rs
+++ b/crates/nvisy-codec/src/handler/text/html_handler.rs
@@ -1,35 +1,29 @@
-//! HTML handler: parses HTML into a heterogeneous stream of
-//! [`RedactableItem`]s — text nodes, comments, element attributes,
-//! URL bodies inside scheme-known attributes, and `<script>` /
-//! `<style>` bodies. Each item participates in the same
-//! `decode → chunk → detect → redact → encode` flow.
+//! HTML handler: holds a parsed HTML document as a stream of
+//! [`RedactableItem`]s — text nodes, comments, element
+//! attributes, and (per [`HtmlLoader::script_policy`] /
+//! [`HtmlLoader::style_policy`]) `<script>` / `<style>` bodies.
 //!
 //! Offsets are cumulative over the redactable-item sequence in
 //! document order, not raw HTML source bytes. [`Handler::encode`]
 //! reconstructs the HTML by re-parsing the original source into a
-//! DOM, replaying each item's mutation in the same order the
-//! loader visited it, and serializing back with [`Html::html`].
-//!
-//! What gets scanned is controlled at decode time via the
-//! [`HtmlLoader`] policy fields ([`scan_attributes`],
-//! [`scan_comments`], [`scan_url_schemes`], [`script_policy`],
-//! [`style_policy`]).
+//! DOM, splicing each mutated value back in document order, and
+//! serializing with [`Html::html`].
 //!
 //! [`Html::html`]: scraper::Html::html
 //! [`HtmlLoader`]: super::HtmlLoader
-//! [`scan_attributes`]: super::HtmlLoader::scan_attributes
-//! [`scan_comments`]: super::HtmlLoader::scan_comments
-//! [`scan_url_schemes`]: super::HtmlLoader::scan_url_schemes
-//! [`script_policy`]: super::HtmlLoader::script_policy
-//! [`style_policy`]: super::HtmlLoader::style_policy
+//! [`HtmlLoader::script_policy`]: super::HtmlLoader::script_policy
+//! [`HtmlLoader::style_policy`]: super::HtmlLoader::style_policy
 
 use std::ops::Range;
 
+use ego_tree::NodeId;
 use nvisy_core::Error;
 use nvisy_core::modality::{Text, TextData, TextLocation};
 use nvisy_core::redaction::{Redactions, TextReplacement};
+use scraper::Html;
+use scraper::node::Node;
 
-use super::{HtmlLoader, UrlScheme, lift_identity, redact};
+use super::{HtmlLoader, lift_identity, redact};
 use crate::content::{ContentData, ContentSource};
 use crate::{Chunk, Format, FormatId, Handler};
 
@@ -55,22 +49,19 @@ pub struct HtmlData {
     /// The raw HTML source. Re-parsed at encode time so the
     /// serialiser can splice mutated values back into a fresh
     /// DOM and emit the result.
-    ///
-    /// [`HtmlLoader::decode`]: super::HtmlLoader
     pub raw: String,
 }
 
 /// One redactable unit yielded by [`HtmlHandler::next_chunk`].
 ///
-/// `value` is the decoded text the recognizer scans and that
+/// `value` is the text the recognizer scans and that
 /// [`HtmlHandler::redact`] mutates in place. `kind` tells encode
 /// where to splice the mutated value back into the document.
 #[derive(Debug, Clone)]
 pub struct RedactableItem {
     /// Where this item lives in the document.
     pub kind: RedactableKind,
-    /// The decoded value: text-node text, comment body, attribute
-    /// value, URL body (without the scheme prefix), or script /
+    /// Text-node text, comment body, attribute value, or script /
     /// style element text.
     pub value: String,
 }
@@ -92,9 +83,8 @@ pub enum RedactableKind {
         /// Document-order index among comments.
         index: usize,
     },
-    /// Any element-bound item: an attribute value, a URL body
-    /// inside a scheme-known attribute, or a script / style
-    /// element's text body.
+    /// Any element-bound item: an attribute value or a script /
+    /// style element's text body.
     Element {
         /// Document-order index among elements.
         element_index: usize,
@@ -111,20 +101,6 @@ pub enum ElementTarget {
     Attribute {
         /// Attribute local name.
         attr_name: String,
-    },
-    /// The body of a scheme-known URL stored in `attr_name`
-    /// (typically `href` or `src`). The item's `value` is the
-    /// scannable body without the `scheme:` prefix and any
-    /// trailing query string; encode re-attaches them.
-    UrlBody {
-        /// Attribute local name carrying the URL (`href` / `src`).
-        attr_name: String,
-        /// URL scheme recognised at decode time.
-        scheme: UrlScheme,
-        /// Optional query / fragment suffix that decode peeled off
-        /// (everything from the first `?` or `#` onwards).
-        /// Re-attached verbatim at encode.
-        suffix: String,
     },
     /// The text body of a `<script>` element scanned as plain text.
     ScriptText,
@@ -159,7 +135,7 @@ impl Handler<Text> for HtmlHandler {
 
     #[tracing::instrument(name = "html.encode", skip_all, fields(output_bytes))]
     fn encode(&self) -> Result<ContentData, Error> {
-        let mut dom = scraper::Html::parse_document(&self.data.raw);
+        let mut dom = Html::parse_document(&self.data.raw);
         let plan = EncodePlan::from_items(&self.data.items);
 
         let mut text_seen = 0usize;
@@ -172,19 +148,19 @@ impl Handler<Text> for HtmlHandler {
                 continue;
             };
             match node.value() {
-                scraper::node::Node::Text(_) => {
+                Node::Text(_) => {
                     if let Some(value) = plan.text_value(text_seen) {
                         write_text(&mut dom, node_id, value);
                     }
                     text_seen += 1;
                 }
-                scraper::node::Node::Comment(_) => {
+                Node::Comment(_) => {
                     if let Some(value) = plan.comment_value(comment_seen) {
                         write_comment(&mut dom, node_id, value);
                     }
                     comment_seen += 1;
                 }
-                scraper::node::Node::Element(_) => {
+                Node::Element(_) => {
                     if let Some(targets) = plan.element_targets(element_seen) {
                         for et in targets {
                             apply_element_target(&mut dom, node_id, et);
@@ -439,18 +415,18 @@ fn grow_to(v: &mut Vec<Option<&str>>, index: usize) {
     }
 }
 
-fn write_text(dom: &mut scraper::Html, node_id: ego_tree::NodeId, value: &str) {
+fn write_text(dom: &mut Html, node_id: NodeId, value: &str) {
     if let Some(mut n) = dom.tree.get_mut(node_id)
-        && let scraper::node::Node::Text(t) = n.value()
+        && let Node::Text(t) = n.value()
         && t.text.as_ref() != value
     {
         t.text = value.into();
     }
 }
 
-fn write_comment(dom: &mut scraper::Html, node_id: ego_tree::NodeId, value: &str) {
+fn write_comment(dom: &mut Html, node_id: NodeId, value: &str) {
     if let Some(mut n) = dom.tree.get_mut(node_id)
-        && let scraper::node::Node::Comment(c) = n.value()
+        && let Node::Comment(c) = n.value()
         && c.comment.as_ref() != value
     {
         c.comment = value.into();
@@ -458,21 +434,13 @@ fn write_comment(dom: &mut scraper::Html, node_id: ego_tree::NodeId, value: &str
 }
 
 fn apply_element_target(
-    dom: &mut scraper::Html,
-    node_id: ego_tree::NodeId,
+    dom: &mut Html,
+    node_id: NodeId,
     patch: &ElementTargetPatch<'_>,
 ) {
     match patch.target {
         ElementTarget::Attribute { attr_name } => {
             write_attribute(dom, node_id, attr_name, patch.value);
-        }
-        ElementTarget::UrlBody {
-            attr_name,
-            scheme,
-            suffix,
-        } => {
-            let rebuilt = format!("{}{}{}", scheme.prefix(), patch.value, suffix);
-            write_attribute(dom, node_id, attr_name, &rebuilt);
         }
         ElementTarget::ScriptText | ElementTarget::StyleText => {
             write_text_child(dom, node_id, patch.value);
@@ -481,13 +449,13 @@ fn apply_element_target(
 }
 
 fn write_attribute(
-    dom: &mut scraper::Html,
-    element_id: ego_tree::NodeId,
+    dom: &mut Html,
+    element_id: NodeId,
     attr_name: &str,
     value: &str,
 ) {
     if let Some(mut n) = dom.tree.get_mut(element_id)
-        && let scraper::node::Node::Element(e) = n.value()
+        && let Node::Element(e) = n.value()
     {
         for (qn, val) in &mut e.attrs {
             if qn.local.as_ref() == attr_name {
@@ -500,7 +468,7 @@ fn write_attribute(
     }
 }
 
-fn write_text_child(dom: &mut scraper::Html, element_id: ego_tree::NodeId, value: &str) {
+fn write_text_child(dom: &mut Html, element_id: NodeId, value: &str) {
     let child_id = dom
         .tree
         .get(element_id)
@@ -621,43 +589,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn url_body_redact_reattaches_scheme() -> Result<(), Error> {
+    async fn href_attribute_carries_url_verbatim() -> Result<(), Error> {
         let raw = r#"<html><head></head><body><a href="mailto:alice@example.com?subject=Hi">contact</a></body></html>"#;
         let mut h = load(raw).await;
-        let mut loc = None;
-        while let Some(chunk) = h.next_chunk().await? {
-            if chunk.data.as_str() == "alice@example.com" {
-                loc = Some(chunk.location);
-                break;
-            }
-        }
-        let loc = loc.expect("mailto body yields a chunk");
-        let mut rs = Redactions::new();
-        rs.push(loc, TextReplacement::substituted("[email]"));
-        h.redact(rs).await?;
-        let out = h.encode()?.as_str().unwrap().to_owned();
-        assert!(
-            out.contains(r#"href="mailto:[email]?subject=Hi""#),
-            "mailto url not rewritten with scheme + suffix: {out}"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn opt_out_of_attribute_scanning() -> Result<(), Error> {
-        let raw = r#"<html><head></head><body><img alt="alice@example.com"></body></html>"#;
-        let loader = HtmlLoader {
-            scan_attributes: Vec::new(),
-            ..HtmlLoader::default()
-        };
-        let mut h = load_with(raw, loader).await;
         let mut emitted = Vec::new();
         while let Some(chunk) = h.next_chunk().await? {
             emitted.push(chunk.data.as_str().to_owned());
         }
         assert!(
-            emitted.iter().all(|v| v != "alice@example.com"),
-            "alt attribute should not have been scanned when opt-out empties the list: {emitted:?}"
+            emitted
+                .iter()
+                .any(|v| v == "mailto:alice@example.com?subject=Hi"),
+            "href emitted as one verbatim attribute item: {emitted:?}"
         );
         Ok(())
     }

--- a/crates/nvisy-codec/src/handler/text/html_handler.rs
+++ b/crates/nvisy-codec/src/handler/text/html_handler.rs
@@ -1,13 +1,27 @@
-//! HTML handler: holds parsed HTML content and streams its text
-//! nodes via [`Handler<Text>`], with random-access reads / redactions
-//! via [`Handler<Text>`].
+//! HTML handler: parses HTML into a heterogeneous stream of
+//! [`RedactableItem`]s — text nodes, comments, element attributes,
+//! URL bodies inside scheme-known attributes, and `<script>` /
+//! `<style>` bodies. Each item participates in the same
+//! `decode → chunk → detect → redact → encode` flow.
 //!
-//! Offsets are cumulative over the **text-node sequence** in document
-//! order, not raw HTML bytes. [`Handler::encode`] reconstructs the
-//! HTML by re-parsing the original source into a DOM, applying
-//! mutations, and serializing back with [`Html::html`].
+//! Offsets are cumulative over the redactable-item sequence in
+//! document order, not raw HTML source bytes. [`Handler::encode`]
+//! reconstructs the HTML by re-parsing the original source into a
+//! DOM, replaying each item's mutation in the same order the
+//! loader visited it, and serializing back with [`Html::html`].
+//!
+//! What gets scanned is controlled at decode time via the
+//! [`HtmlLoader`] policy fields ([`scan_attributes`],
+//! [`scan_comments`], [`scan_url_schemes`], [`script_policy`],
+//! [`style_policy`]).
 //!
 //! [`Html::html`]: scraper::Html::html
+//! [`HtmlLoader`]: super::HtmlLoader
+//! [`scan_attributes`]: super::HtmlLoader::scan_attributes
+//! [`scan_comments`]: super::HtmlLoader::scan_comments
+//! [`scan_url_schemes`]: super::HtmlLoader::scan_url_schemes
+//! [`script_policy`]: super::HtmlLoader::script_policy
+//! [`style_policy`]: super::HtmlLoader::style_policy
 
 use std::ops::Range;
 
@@ -15,7 +29,7 @@ use nvisy_core::Error;
 use nvisy_core::modality::{Text, TextData, TextLocation};
 use nvisy_core::redaction::{Redactions, TextReplacement};
 
-use super::{HtmlLoader, lift_identity, redact};
+use super::{HtmlLoader, UrlScheme, lift_identity, redact};
 use crate::content::{ContentData, ContentSource};
 use crate::{Chunk, Format, FormatId, Handler};
 
@@ -31,28 +45,105 @@ pub fn format() -> Format {
         .with_content_types(["text/html"])
 }
 
-/// Parsed HTML content: extracted text nodes alongside the raw source
-/// (kept for round-trip reconstruction).
+/// Parsed HTML content: the redactable-item stream plus the raw
+/// source bytes (kept for round-trip reconstruction).
 #[derive(Debug, Clone)]
 pub struct HtmlData {
-    /// Text nodes extracted in document order.
-    pub text_nodes: Vec<String>,
-    /// The raw HTML source.
+    /// Redactable items in document order. Decoded once by the
+    /// [`HtmlLoader`] and never re-derived afterwards.
+    pub items: Vec<RedactableItem>,
+    /// The raw HTML source. Re-parsed at encode time so the
+    /// serialiser can splice mutated values back into a fresh
+    /// DOM and emit the result.
+    ///
+    /// [`HtmlLoader::decode`]: super::HtmlLoader
     pub raw: String,
+}
+
+/// One redactable unit yielded by [`HtmlHandler::next_chunk`].
+///
+/// `value` is the decoded text the recognizer scans and that
+/// [`HtmlHandler::redact`] mutates in place. `kind` tells encode
+/// where to splice the mutated value back into the document.
+#[derive(Debug, Clone)]
+pub struct RedactableItem {
+    /// Where this item lives in the document.
+    pub kind: RedactableKind,
+    /// The decoded value: text-node text, comment body, attribute
+    /// value, URL body (without the scheme prefix), or script /
+    /// style element text.
+    pub value: String,
+}
+
+/// Where a [`RedactableItem`] lives inside the parsed HTML
+/// document. Used by encode to splice the mutated `value` back into
+/// a freshly-parsed DOM.
+#[derive(Debug, Clone)]
+pub enum RedactableKind {
+    /// A text node, addressed by its 0-based index in the
+    /// document-order text-node sequence.
+    TextNode {
+        /// Document-order index among text nodes.
+        index: usize,
+    },
+    /// An HTML comment, addressed by its 0-based index in the
+    /// document-order comment sequence.
+    Comment {
+        /// Document-order index among comments.
+        index: usize,
+    },
+    /// Any element-bound item: an attribute value, a URL body
+    /// inside a scheme-known attribute, or a script / style
+    /// element's text body.
+    Element {
+        /// Document-order index among elements.
+        element_index: usize,
+        /// Which part of the element this item addresses.
+        target: ElementTarget,
+    },
+}
+
+/// The element-bound location a [`RedactableKind::Element`] item
+/// points at.
+#[derive(Debug, Clone)]
+pub enum ElementTarget {
+    /// The value of `attr_name` on this element.
+    Attribute {
+        /// Attribute local name.
+        attr_name: String,
+    },
+    /// The body of a scheme-known URL stored in `attr_name`
+    /// (typically `href` or `src`). The item's `value` is the
+    /// scannable body without the `scheme:` prefix and any
+    /// trailing query string; encode re-attaches them.
+    UrlBody {
+        /// Attribute local name carrying the URL (`href` / `src`).
+        attr_name: String,
+        /// URL scheme recognised at decode time.
+        scheme: UrlScheme,
+        /// Optional query / fragment suffix that decode peeled off
+        /// (everything from the first `?` or `#` onwards).
+        /// Re-attached verbatim at encode.
+        suffix: String,
+    },
+    /// The text body of a `<script>` element scanned as plain text.
+    ScriptText,
+    /// The text body of a `<style>` element scanned as plain text.
+    StyleText,
 }
 
 /// Handler for loaded HTML content.
 ///
-/// `node_starts` is a cumulative-offset index over the text-node
-/// sequence: `node_starts[i]` is the byte position of text node `i`,
-/// and `node_starts[text_nodes.len()]` is the total length sentinel.
-/// Maintained on every redaction so random-access reads are
-/// `O(log N)` instead of rebuilding the table per call.
+/// `item_starts` is a cumulative-offset index over the redactable
+/// items: `item_starts[i]` is the byte position of item `i`, and
+/// `item_starts[items.len()]` is the total length sentinel.
+/// Maintained on every redaction so random-access reads run in
+/// `O(log N)`.
 #[derive(Debug)]
 pub struct HtmlHandler {
     source: ContentSource,
     data: HtmlData,
-    node_starts: Vec<usize>,
+    item_starts: Vec<usize>,
     cursor: usize,
 }
 
@@ -69,21 +160,39 @@ impl Handler<Text> for HtmlHandler {
     #[tracing::instrument(name = "html.encode", skip_all, fields(output_bytes))]
     fn encode(&self) -> Result<ContentData, Error> {
         let mut dom = scraper::Html::parse_document(&self.data.raw);
+        let plan = EncodePlan::from_items(&self.data.items);
 
-        let text_node_ids: Vec<_> = dom
-            .tree
-            .nodes()
-            .filter(|node| node.value().is_text())
-            .map(|node| node.id())
-            .collect();
+        let mut text_seen = 0usize;
+        let mut comment_seen = 0usize;
+        let mut element_seen = 0usize;
 
-        for (i, &node_id) in text_node_ids.iter().enumerate() {
-            let current: &str = &self.data.text_nodes[i];
-            if let Some(mut node_mut) = dom.tree.get_mut(node_id)
-                && let scraper::node::Node::Text(t) = node_mut.value()
-                && t.text.as_ref() != current
-            {
-                t.text = current.into();
+        let node_ids: Vec<_> = dom.tree.nodes().map(|n| n.id()).collect();
+        for node_id in node_ids {
+            let Some(node) = dom.tree.get(node_id) else {
+                continue;
+            };
+            match node.value() {
+                scraper::node::Node::Text(_) => {
+                    if let Some(value) = plan.text_value(text_seen) {
+                        write_text(&mut dom, node_id, value);
+                    }
+                    text_seen += 1;
+                }
+                scraper::node::Node::Comment(_) => {
+                    if let Some(value) = plan.comment_value(comment_seen) {
+                        write_comment(&mut dom, node_id, value);
+                    }
+                    comment_seen += 1;
+                }
+                scraper::node::Node::Element(_) => {
+                    if let Some(targets) = plan.element_targets(element_seen) {
+                        for et in targets {
+                            apply_element_target(&mut dom, node_id, et);
+                        }
+                    }
+                    element_seen += 1;
+                }
+                _ => {}
             }
         }
 
@@ -94,13 +203,13 @@ impl Handler<Text> for HtmlHandler {
     }
 
     async fn next_chunk(&mut self) -> Result<Option<Chunk<Text>>, Error> {
-        if self.cursor >= self.data.text_nodes.len() {
+        if self.cursor >= self.data.items.len() {
             return Ok(None);
         }
         let i = self.cursor;
-        let start = self.node_starts[i];
-        let end = self.node_starts[i + 1];
-        let text = &self.data.text_nodes[i];
+        let start = self.item_starts[i];
+        let end = self.item_starts[i + 1];
+        let value = &self.data.items[i].value;
         self.cursor += 1;
         Ok(Some(Chunk {
             location: TextLocation {
@@ -108,7 +217,7 @@ impl Handler<Text> for HtmlHandler {
                 end,
                 ..Default::default()
             },
-            data: TextData::from(text.as_str()),
+            data: TextData::from(value.as_str()),
         }))
     }
 
@@ -117,17 +226,18 @@ impl Handler<Text> for HtmlHandler {
     }
 
     async fn read(&self, location: &TextLocation) -> Result<Option<TextData>, Error> {
-        let Some(i) = self.node_for(location.start) else {
+        let Some(i) = self.item_for(location.start) else {
             return Ok(None);
         };
-        let node_start = self.node_starts[i];
-        let node_end = self.node_starts[i + 1];
-        if location.end > node_end {
+        let item_start = self.item_starts[i];
+        let item_end = self.item_starts[i + 1];
+        if location.end > item_end {
             return Ok(None);
         }
-        let local_start = location.start - node_start;
-        let local_end = location.end - node_start;
-        Ok(self.data.text_nodes[i]
+        let local_start = location.start - item_start;
+        let local_end = location.end - item_start;
+        Ok(self.data.items[i]
+            .value
             .get(local_start..local_end)
             .map(TextData::from))
     }
@@ -142,13 +252,13 @@ impl Handler<Text> for HtmlHandler {
 }
 
 impl HtmlHandler {
-    /// Create a new handler from parsed HTML data.
+    /// Build a handler from a populated [`HtmlData`].
     pub fn new(data: HtmlData) -> Self {
-        let node_starts = compute_node_starts(&data.text_nodes);
+        let item_starts = compute_item_starts(&data.items);
         Self {
             source: ContentSource::new(),
             data,
-            node_starts,
+            item_starts,
             cursor: 0,
         }
     }
@@ -159,24 +269,19 @@ impl HtmlHandler {
         self
     }
 
-    /// All extracted text nodes in document order.
-    pub fn text_nodes(&self) -> &[String] {
-        &self.data.text_nodes
+    /// All redactable items in document order.
+    pub fn items(&self) -> &[RedactableItem] {
+        &self.data.items
     }
 
-    /// A specific text node by 0-based index.
-    pub fn text_node(&self, index: usize) -> Option<&str> {
-        self.data.text_nodes.get(index).map(String::as_str)
-    }
-
-    /// Total number of text nodes.
+    /// Total number of redactable items.
     pub fn len(&self) -> usize {
-        self.data.text_nodes.len()
+        self.data.items.len()
     }
 
-    /// Whether the document has no text nodes.
+    /// Whether the document has no redactable items.
     pub fn is_empty(&self) -> bool {
-        self.data.text_nodes.is_empty()
+        self.data.items.is_empty()
     }
 
     /// The raw HTML source.
@@ -194,11 +299,11 @@ impl HtmlHandler {
         self.cursor = 0;
     }
 
-    fn node_for(&self, byte_offset: usize) -> Option<usize> {
-        match self.node_starts.binary_search(&byte_offset) {
-            Ok(i) if i < self.data.text_nodes.len() => Some(i),
+    fn item_for(&self, byte_offset: usize) -> Option<usize> {
+        match self.item_starts.binary_search(&byte_offset) {
+            Ok(i) if i < self.data.items.len() => Some(i),
             Ok(_) => None,
-            Err(i) if i > 0 && i <= self.data.text_nodes.len() => Some(i - 1),
+            Err(i) if i > 0 && i <= self.data.items.len() => Some(i - 1),
             _ => None,
         }
     }
@@ -207,7 +312,7 @@ impl HtmlHandler {
         if delta == 0 {
             return;
         }
-        for s in &mut self.node_starts[i + 1..] {
+        for s in &mut self.item_starts[i + 1..] {
             *s = (*s as isize + delta) as usize;
         }
     }
@@ -217,40 +322,193 @@ impl HtmlHandler {
         location: &TextLocation,
         replacement: TextReplacement,
     ) -> Result<(), Error> {
-        let Some(i) = self.node_for(location.start) else {
+        let Some(i) = self.item_for(location.start) else {
             return Ok(());
         };
-        let node_start = self.node_starts[i];
-        let node_end = self.node_starts[i + 1];
-        if location.end > node_end {
+        let item_start = self.item_starts[i];
+        let item_end = self.item_starts[i + 1];
+        if location.end > item_end {
             return Ok(());
         }
-        let local_start = location.start - node_start;
-        let local_end = location.end - node_start;
+        let local_start = location.start - item_start;
+        let local_end = location.end - item_start;
         let value = replacement.replacement_value().unwrap_or_default();
-        let before_len = self.data.text_nodes[i].len();
+        let before_len = self.data.items[i].value.len();
         redact::replace_range(
-            &mut self.data.text_nodes[i],
+            &mut self.data.items[i].value,
             value,
             local_start,
             local_end,
             TARGET,
         )?;
-        let delta = self.data.text_nodes[i].len() as isize - before_len as isize;
+        let delta = self.data.items[i].value.len() as isize - before_len as isize;
         self.shift_starts_after(i, delta);
         Ok(())
     }
 }
 
-fn compute_node_starts(text_nodes: &[String]) -> Vec<usize> {
-    let mut starts = Vec::with_capacity(text_nodes.len() + 1);
+/// Cumulative byte-offset table over the redactable items: `[0, len(item[0]),
+/// len(item[0]) + len(item[1]), …, total]`.
+fn compute_item_starts(items: &[RedactableItem]) -> Vec<usize> {
+    let mut starts = Vec::with_capacity(items.len() + 1);
     let mut offset = 0usize;
-    for text in text_nodes {
+    for item in items {
         starts.push(offset);
-        offset += text.len();
+        offset += item.value.len();
     }
     starts.push(offset);
     starts
+}
+
+/// Pre-bucketed view of the loader's items, indexed by kind so
+/// encode's single DOM walk can answer "what does item-of-kind-X at
+/// index N look like?" in O(1).
+struct EncodePlan<'a> {
+    /// Indexed by text-node ordinal in document order. `Some(value)`
+    /// when the loader emitted an item for that text node;
+    /// `None` for skipped text nodes (e.g. script/style children
+    /// when the policy is Skip).
+    text_values: Vec<Option<&'a str>>,
+    /// Indexed by comment ordinal. Same shape as `text_values`.
+    comment_values: Vec<Option<&'a str>>,
+    /// Indexed by element ordinal. Each entry is the (possibly
+    /// empty) list of element-bound items at that element.
+    element_targets: Vec<Vec<ElementTargetPatch<'a>>>,
+}
+
+/// A single element-bound patch staged for encode.
+struct ElementTargetPatch<'a> {
+    target: &'a ElementTarget,
+    value: &'a str,
+}
+
+impl<'a> EncodePlan<'a> {
+    fn from_items(items: &'a [RedactableItem]) -> Self {
+        let mut text_values: Vec<Option<&'a str>> = Vec::new();
+        let mut comment_values: Vec<Option<&'a str>> = Vec::new();
+        let mut element_targets: Vec<Vec<ElementTargetPatch<'a>>> = Vec::new();
+
+        for item in items {
+            match &item.kind {
+                RedactableKind::TextNode { index } => {
+                    grow_to(&mut text_values, *index);
+                    text_values[*index] = Some(item.value.as_str());
+                }
+                RedactableKind::Comment { index } => {
+                    grow_to(&mut comment_values, *index);
+                    comment_values[*index] = Some(item.value.as_str());
+                }
+                RedactableKind::Element {
+                    element_index,
+                    target,
+                } => {
+                    while element_targets.len() <= *element_index {
+                        element_targets.push(Vec::new());
+                    }
+                    element_targets[*element_index].push(ElementTargetPatch {
+                        target,
+                        value: item.value.as_str(),
+                    });
+                }
+            }
+        }
+
+        Self {
+            text_values,
+            comment_values,
+            element_targets,
+        }
+    }
+
+    fn text_value(&self, ordinal: usize) -> Option<&'a str> {
+        self.text_values.get(ordinal).copied().flatten()
+    }
+
+    fn comment_value(&self, ordinal: usize) -> Option<&'a str> {
+        self.comment_values.get(ordinal).copied().flatten()
+    }
+
+    fn element_targets(&self, ordinal: usize) -> Option<&[ElementTargetPatch<'a>]> {
+        self.element_targets.get(ordinal).map(|v| v.as_slice())
+    }
+}
+
+fn grow_to(v: &mut Vec<Option<&str>>, index: usize) {
+    while v.len() <= index {
+        v.push(None);
+    }
+}
+
+fn write_text(dom: &mut scraper::Html, node_id: ego_tree::NodeId, value: &str) {
+    if let Some(mut n) = dom.tree.get_mut(node_id)
+        && let scraper::node::Node::Text(t) = n.value()
+        && t.text.as_ref() != value
+    {
+        t.text = value.into();
+    }
+}
+
+fn write_comment(dom: &mut scraper::Html, node_id: ego_tree::NodeId, value: &str) {
+    if let Some(mut n) = dom.tree.get_mut(node_id)
+        && let scraper::node::Node::Comment(c) = n.value()
+        && c.comment.as_ref() != value
+    {
+        c.comment = value.into();
+    }
+}
+
+fn apply_element_target(
+    dom: &mut scraper::Html,
+    node_id: ego_tree::NodeId,
+    patch: &ElementTargetPatch<'_>,
+) {
+    match patch.target {
+        ElementTarget::Attribute { attr_name } => {
+            write_attribute(dom, node_id, attr_name, patch.value);
+        }
+        ElementTarget::UrlBody {
+            attr_name,
+            scheme,
+            suffix,
+        } => {
+            let rebuilt = format!("{}{}{}", scheme.prefix(), patch.value, suffix);
+            write_attribute(dom, node_id, attr_name, &rebuilt);
+        }
+        ElementTarget::ScriptText | ElementTarget::StyleText => {
+            write_text_child(dom, node_id, patch.value);
+        }
+    }
+}
+
+fn write_attribute(
+    dom: &mut scraper::Html,
+    element_id: ego_tree::NodeId,
+    attr_name: &str,
+    value: &str,
+) {
+    if let Some(mut n) = dom.tree.get_mut(element_id)
+        && let scraper::node::Node::Element(e) = n.value()
+    {
+        for (qn, val) in &mut e.attrs {
+            if qn.local.as_ref() == attr_name {
+                if val.as_ref() != value {
+                    *val = value.into();
+                }
+                return;
+            }
+        }
+    }
+}
+
+fn write_text_child(dom: &mut scraper::Html, element_id: ego_tree::NodeId, value: &str) {
+    let child_id = dom
+        .tree
+        .get(element_id)
+        .and_then(|n| n.first_child().map(|c| c.id()));
+    let Some(child_id) = child_id else {
+        return;
+    };
+    write_text(dom, child_id, value);
 }
 
 #[cfg(test)]
@@ -258,60 +516,149 @@ mod tests {
     use nvisy_core::Error;
     use nvisy_core::redaction::TextReplacement;
 
+    use super::super::HtmlLoader;
     use super::*;
+    use crate::Loader;
+    use crate::content::{ContentData, ContentSource};
 
-    fn handler_from_html(raw: &str) -> HtmlHandler {
-        let dom = scraper::Html::parse_document(raw);
-        let text_nodes: Vec<String> = dom
-            .tree
-            .nodes()
-            .filter_map(|node| {
-                if let scraper::node::Node::Text(t) = node.value() {
-                    Some(t.text.to_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        HtmlHandler::new(HtmlData {
-            text_nodes,
-            raw: raw.to_string(),
-        })
+    async fn load(raw: &str) -> HtmlHandler {
+        load_with(raw, HtmlLoader::default()).await
     }
 
-    #[test]
-    fn encode_unchanged() -> Result<(), Error> {
+    async fn load_with(raw: &str, loader: HtmlLoader) -> HtmlHandler {
+        let content = ContentData::new(ContentSource::new(), bytes::Bytes::from(raw.to_owned()));
+        loader.decode(content).await.expect("html decode succeeds")
+    }
+
+    #[tokio::test]
+    async fn encode_unchanged_round_trips() -> Result<(), Error> {
         let raw = "<html><head></head><body><p>Hello</p></body></html>";
-        let h = handler_from_html(raw);
+        let h = load(raw).await;
         let content = h.encode()?;
         assert_eq!(content.as_str().unwrap(), raw);
         Ok(())
     }
 
     #[tokio::test]
-    async fn encode_after_redact() -> Result<(), Error> {
+    async fn redact_replaces_text_node() -> Result<(), Error> {
         let raw = "<html><head></head><body><p>Hello</p><p>World</p></body></html>";
-        let mut h = handler_from_html(raw);
+        let mut h = load(raw).await;
         let first = h.next_chunk().await?.unwrap();
-        let loc = first.location.clone();
         let mut rs = Redactions::new();
-        rs.push(loc, TextReplacement::substituted("[REDACTED]"));
+        rs.push(first.location, TextReplacement::substituted("[REDACTED]"));
         h.redact(rs).await?;
-        let result = h.encode()?.as_str().unwrap().to_owned();
-        assert!(result.contains("[REDACTED]"));
-        assert!(result.contains("World"));
+        let out = h.encode()?.as_str().unwrap().to_owned();
+        assert!(out.contains("[REDACTED]"));
+        assert!(out.contains("World"));
         Ok(())
     }
 
     #[tokio::test]
-    async fn stream_yields_each_text_node() -> Result<(), Error> {
-        let mut h =
-            handler_from_html("<html><head></head><body><p>Alpha</p><p>Beta</p></body></html>");
-        let mut count = 0;
-        while h.next_chunk().await?.is_some() {
-            count += 1;
+    async fn stream_yields_text_attribute_and_comment() -> Result<(), Error> {
+        let raw = r#"<html><head></head><body><!-- secret 1 --><img alt="hello" title="alt"></body></html>"#;
+        let mut h = load(raw).await;
+        let mut values: Vec<String> = Vec::new();
+        while let Some(chunk) = h.next_chunk().await? {
+            values.push(chunk.data.as_str().to_owned());
         }
-        assert_eq!(count, 2);
+        assert!(values.iter().any(|v| v == " secret 1 "));
+        assert!(values.iter().any(|v| v == "hello"));
+        assert!(values.iter().any(|v| v == "alt"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn attribute_redact_round_trips() -> Result<(), Error> {
+        let raw = r#"<html><head></head><body><img alt="alice@example.com"></body></html>"#;
+        let mut h = load(raw).await;
+        // Find the attribute chunk.
+        let mut loc = None;
+        while let Some(chunk) = h.next_chunk().await? {
+            if chunk.data.as_str() == "alice@example.com" {
+                loc = Some(chunk.location);
+                break;
+            }
+        }
+        let loc = loc.expect("alt attribute yields a chunk");
+        let mut rs = Redactions::new();
+        rs.push(loc, TextReplacement::substituted("[email]"));
+        h.redact(rs).await?;
+        let out = h.encode()?.as_str().unwrap().to_owned();
+        assert!(
+            out.contains(r#"alt="[email]""#),
+            "alt attribute not rewritten: {out}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn comment_redact_round_trips() -> Result<(), Error> {
+        let raw = "<html><head></head><body><!-- alice@example.com --></body></html>";
+        let mut h = load(raw).await;
+        let mut loc = None;
+        while let Some(chunk) = h.next_chunk().await? {
+            if chunk.data.as_str().contains("alice@example.com") {
+                loc = Some(TextLocation {
+                    start: chunk.location.start + chunk.data.as_str().find("alice").unwrap(),
+                    end: chunk.location.start
+                        + chunk.data.as_str().find("alice").unwrap()
+                        + "alice@example.com".len(),
+                    ..Default::default()
+                });
+                break;
+            }
+        }
+        let loc = loc.expect("comment yields a chunk containing the email");
+        let mut rs = Redactions::new();
+        rs.push(loc, TextReplacement::substituted("[email]"));
+        h.redact(rs).await?;
+        let out = h.encode()?.as_str().unwrap().to_owned();
+        assert!(
+            out.contains("<!-- [email] -->"),
+            "comment not rewritten: {out}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn url_body_redact_reattaches_scheme() -> Result<(), Error> {
+        let raw = r#"<html><head></head><body><a href="mailto:alice@example.com?subject=Hi">contact</a></body></html>"#;
+        let mut h = load(raw).await;
+        let mut loc = None;
+        while let Some(chunk) = h.next_chunk().await? {
+            if chunk.data.as_str() == "alice@example.com" {
+                loc = Some(chunk.location);
+                break;
+            }
+        }
+        let loc = loc.expect("mailto body yields a chunk");
+        let mut rs = Redactions::new();
+        rs.push(loc, TextReplacement::substituted("[email]"));
+        h.redact(rs).await?;
+        let out = h.encode()?.as_str().unwrap().to_owned();
+        assert!(
+            out.contains(r#"href="mailto:[email]?subject=Hi""#),
+            "mailto url not rewritten with scheme + suffix: {out}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn opt_out_of_attribute_scanning() -> Result<(), Error> {
+        let raw = r#"<html><head></head><body><img alt="alice@example.com"></body></html>"#;
+        let loader = HtmlLoader {
+            scan_attributes: Vec::new(),
+            ..HtmlLoader::default()
+        };
+        let mut h = load_with(raw, loader).await;
+        let mut emitted = Vec::new();
+        while let Some(chunk) = h.next_chunk().await? {
+            emitted.push(chunk.data.as_str().to_owned());
+        }
+        assert!(
+            emitted.iter().all(|v| v != "alice@example.com"),
+            "alt attribute should not have been scanned when opt-out empties the list: {emitted:?}"
+        );
         Ok(())
     }
 }

--- a/crates/nvisy-codec/src/handler/text/html_loader.rs
+++ b/crates/nvisy-codec/src/handler/text/html_loader.rs
@@ -1,55 +1,328 @@
-//! HTML loader: validates and parses raw HTML content into an
-//! [`HtmlHandler`].
+//! HTML loader: validates and parses raw HTML into an
+//! [`HtmlHandler`] populated with a heterogeneous
+//! [`RedactableItem`] stream.
 //!
-//! Parses the input using [`scraper`], extracts text nodes in document
-//! order, and produces a handler backed by those nodes plus the raw
-//! source (used to reconstruct the HTML after edits).
+//! What gets included in the stream is controlled by the policy
+//! fields on [`HtmlLoader`] — attributes ([`scan_attributes`]),
+//! comments ([`scan_comments`]), URL bodies inside scheme-known
+//! attributes ([`scan_url_schemes`]), and `<script>` / `<style>`
+//! element bodies ([`script_policy`] / [`style_policy`]).
+//!
+//! [`scan_attributes`]: HtmlLoader::scan_attributes
+//! [`scan_comments`]: HtmlLoader::scan_comments
+//! [`scan_url_schemes`]: HtmlLoader::scan_url_schemes
+//! [`script_policy`]: HtmlLoader::script_policy
+//! [`style_policy`]: HtmlLoader::style_policy
+//! [`RedactableItem`]: super::RedactableItem
+
+use std::borrow::Cow;
 
 use nvisy_core::Error;
 use nvisy_core::modality::Text;
 use scraper::Html;
 
-use super::{HtmlData, HtmlHandler};
+use super::html_handler::{ElementTarget, HtmlData, HtmlHandler, RedactableItem, RedactableKind};
 use crate::Loader;
 use crate::content::{ContentData, ContentSource, TextEncoding};
 
+const TARGET: &str = "nvisy_codec::handler::text::html";
+
 /// Loader for HTML files. Produces one [`HtmlHandler`] per input.
-#[derive(Debug, Default)]
+///
+/// Every policy field has a default that enables a reasonable
+/// scanning surface for typical web pages; set fields explicitly to
+/// narrow (or widen) what gets fed through detection.
+#[derive(Debug, Clone)]
 pub struct HtmlLoader {
     /// Character encoding of the input bytes. Defaults to UTF-8.
     pub encoding: TextEncoding,
+    /// Attribute local names whose values get scanned. Entries
+    /// ending with `*` are treated as prefix wildcards (so
+    /// `"data-*"` matches every `data-` attribute). Default:
+    /// [`default_scan_attributes`].
+    pub scan_attributes: Vec<Cow<'static, str>>,
+    /// Whether HTML comment bodies get scanned. Default: `true` —
+    /// comments are a known PII leak vector (debug notes that ship
+    /// to production).
+    pub scan_comments: bool,
+    /// URL schemes whose body (the text after `scheme:`) gets
+    /// scanned when the loader sees one of those URLs in `href` or
+    /// `src`. Default: every [`UrlScheme`] variant.
+    pub scan_url_schemes: Vec<UrlScheme>,
+    /// What to do with `<script>` element bodies. Default:
+    /// [`ScriptPolicy::Skip`] — script bodies are usually code and
+    /// scanning them for PII produces false positives.
+    pub script_policy: ScriptPolicy,
+    /// What to do with `<style>` element bodies. Default:
+    /// [`ScriptPolicy::Skip`] — CSS rarely carries PII.
+    pub style_policy: ScriptPolicy,
+}
+
+impl Default for HtmlLoader {
+    fn default() -> Self {
+        Self {
+            encoding: TextEncoding::Utf8,
+            scan_attributes: default_scan_attributes(),
+            scan_comments: true,
+            scan_url_schemes: vec![
+                UrlScheme::Mailto,
+                UrlScheme::Tel,
+                UrlScheme::Sms,
+                UrlScheme::Callto,
+            ],
+            script_policy: ScriptPolicy::Skip,
+            style_policy: ScriptPolicy::Skip,
+        }
+    }
+}
+
+/// Default attribute scan list: text-bearing attributes that
+/// commonly carry user data.
+///
+/// - `alt` — image text alternatives, often readable sentences.
+/// - `title` — tooltip text shown on hover.
+/// - `value` — form input values; can be pre-seeded with PII.
+/// - `placeholder` — form hints.
+/// - `aria-label` / `aria-describedby` — accessibility text
+///   vocalised by screen readers.
+/// - `data-*` — application-specific data attributes; common
+///   dumping ground for hydration payloads.
+#[must_use]
+pub fn default_scan_attributes() -> Vec<Cow<'static, str>> {
+    vec![
+        Cow::Borrowed("alt"),
+        Cow::Borrowed("title"),
+        Cow::Borrowed("value"),
+        Cow::Borrowed("placeholder"),
+        Cow::Borrowed("aria-label"),
+        Cow::Borrowed("aria-describedby"),
+        Cow::Borrowed("data-*"),
+    ]
+}
+
+/// URL schemes whose body gets scanned when present in `href` or
+/// `src` attributes. Each variant matches a single RFC-defined
+/// scheme prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UrlScheme {
+    /// `mailto:user@host(?query)` — RFC 6068. Body is everything
+    /// after `mailto:` up to the first `?` or `#`.
+    Mailto,
+    /// `tel:+1-415-555-0142` — RFC 3966. Body is everything after
+    /// `tel:` up to the first `?` or `#`.
+    Tel,
+    /// `sms:+1-415-555-0142` — RFC 5724. Same shape as `tel:`.
+    Sms,
+    /// `callto:+1-415-555-0142` — Skype legacy. Same shape as
+    /// `tel:`.
+    Callto,
+}
+
+impl UrlScheme {
+    /// The `scheme:` prefix encode reattaches when reassembling the
+    /// URL value after a redact.
+    #[must_use]
+    pub fn prefix(self) -> &'static str {
+        match self {
+            Self::Mailto => "mailto:",
+            Self::Tel => "tel:",
+            Self::Sms => "sms:",
+            Self::Callto => "callto:",
+        }
+    }
+
+    fn parse(value: &str) -> Option<(Self, &str, &str)> {
+        for scheme in [Self::Mailto, Self::Tel, Self::Sms, Self::Callto] {
+            if let Some(rest) = value.strip_prefix(scheme.prefix()) {
+                let split_at = rest.find(['?', '#']).unwrap_or(rest.len());
+                let (body, suffix) = rest.split_at(split_at);
+                return Some((scheme, body, suffix));
+            }
+        }
+        None
+    }
+}
+
+/// How the loader handles `<script>` or `<style>` element bodies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScriptPolicy {
+    /// Skip the element entirely — its body never enters the
+    /// detection stream.
+    Skip,
+    /// Treat the element body as plain text and scan it like a
+    /// regular text node.
+    ScanText,
+    /// Parse the element body as JSON and route it through the
+    /// JSON handler's slot model.
+    ///
+    /// **Not yet implemented** — a loader configured with this
+    /// policy returns an error at decode time. Tracked in
+    /// <https://github.com/nvisycom/runtime/issues/266>.
+    ScanJson,
 }
 
 #[async_trait::async_trait]
 impl Loader<Text> for HtmlLoader {
     type Handler = HtmlHandler;
 
-    #[tracing::instrument(name = "html.decode", skip_all, fields(input_bytes, text_nodes))]
+    #[tracing::instrument(name = "html.decode", skip_all, fields(input_bytes, items))]
     async fn decode(&self, content: ContentData) -> Result<HtmlHandler, Error> {
+        if matches!(self.script_policy, ScriptPolicy::ScanJson)
+            || matches!(self.style_policy, ScriptPolicy::ScanJson)
+        {
+            return Err(Error::validation(
+                "ScriptPolicy::ScanJson is not yet implemented; see https://github.com/nvisycom/runtime/issues/266",
+                TARGET,
+            ));
+        }
+
         let parent = content.content_source;
         let raw = content.to_bytes();
         tracing::Span::current().record("input_bytes", raw.len());
-        let text = self.encoding.decode_bytes(&raw, "html-loader")?;
+        let text = self.encoding.decode_bytes(&raw, TARGET)?;
         let dom = Html::parse_document(&text);
-
-        let text_nodes: Vec<String> = dom
-            .tree
-            .nodes()
-            .filter_map(|node| {
-                if let scraper::node::Node::Text(t) = node.value() {
-                    Some(t.text.to_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        tracing::Span::current().record("text_nodes", text_nodes.len());
+        let items = build_items(&dom, self);
+        tracing::Span::current().record("items", items.len());
 
         let source = ContentSource::new().with_parent(&parent);
-        Ok(HtmlHandler::new(HtmlData {
-            text_nodes,
-            raw: text,
+        Ok(HtmlHandler::new(HtmlData { items, raw: text }).with_source(source))
+    }
+}
+
+fn build_items(dom: &Html, loader: &HtmlLoader) -> Vec<RedactableItem> {
+    let mut items = Vec::new();
+    let mut text_index: usize = 0;
+    let mut comment_index: usize = 0;
+    let mut element_index: usize = 0;
+
+    for node in dom.tree.nodes() {
+        match node.value() {
+            scraper::node::Node::Text(t) => {
+                if !skip_text_under(node) {
+                    items.push(RedactableItem {
+                        kind: RedactableKind::TextNode { index: text_index },
+                        value: t.text.to_string(),
+                    });
+                }
+                text_index += 1;
+            }
+            scraper::node::Node::Comment(c) => {
+                if loader.scan_comments {
+                    items.push(RedactableItem {
+                        kind: RedactableKind::Comment {
+                            index: comment_index,
+                        },
+                        value: c.comment.to_string(),
+                    });
+                }
+                comment_index += 1;
+            }
+            scraper::node::Node::Element(e) => {
+                let element_name = e.name.local.as_ref();
+
+                // Attribute-bound items (Attribute + UrlBody) at this element.
+                for (qn, val) in &e.attrs {
+                    let attr_name = qn.local.as_ref();
+                    let is_url_attr =
+                        matches!(attr_name, "href" | "src") && !loader.scan_url_schemes.is_empty();
+                    if is_url_attr
+                        && let Some((scheme, body, suffix)) = UrlScheme::parse(val.as_ref())
+                        && loader.scan_url_schemes.contains(&scheme)
+                    {
+                        items.push(RedactableItem {
+                            kind: RedactableKind::Element {
+                                element_index,
+                                target: ElementTarget::UrlBody {
+                                    attr_name: attr_name.to_owned(),
+                                    scheme,
+                                    suffix: suffix.to_owned(),
+                                },
+                            },
+                            value: body.to_owned(),
+                        });
+                        continue;
+                    }
+                    if matches_scan_attribute(&loader.scan_attributes, attr_name) {
+                        items.push(RedactableItem {
+                            kind: RedactableKind::Element {
+                                element_index,
+                                target: ElementTarget::Attribute {
+                                    attr_name: attr_name.to_owned(),
+                                },
+                            },
+                            value: val.to_string(),
+                        });
+                    }
+                }
+
+                // `<script>` / `<style>` body, when policy says ScanText.
+                let policy = match element_name {
+                    "script" => Some(loader.script_policy),
+                    "style" => Some(loader.style_policy),
+                    _ => None,
+                };
+                if let Some(ScriptPolicy::ScanText) = policy
+                    && let Some(body) = first_child_text(node)
+                {
+                    let target = if element_name == "script" {
+                        ElementTarget::ScriptText
+                    } else {
+                        ElementTarget::StyleText
+                    };
+                    items.push(RedactableItem {
+                        kind: RedactableKind::Element {
+                            element_index,
+                            target,
+                        },
+                        value: body,
+                    });
+                }
+
+                element_index += 1;
+            }
+            _ => {}
+        }
+    }
+
+    items
+}
+
+/// Match an attribute name against the configured scan list,
+/// honouring `*`-suffixed prefix wildcards (e.g. `data-*` matches
+/// every attribute starting with `data-`).
+fn matches_scan_attribute(scan_list: &[Cow<'static, str>], name: &str) -> bool {
+    for entry in scan_list {
+        if let Some(prefix) = entry.strip_suffix('*') {
+            if name.starts_with(prefix) {
+                return true;
+            }
+        } else if entry.as_ref() == name {
+            return true;
+        }
+    }
+    false
+}
+
+/// Don't emit text-node items for text that lives directly inside
+/// a `<script>` or `<style>` element — those bodies are handled by
+/// the script / style policy on the parent element instead. The
+/// `text_index` counter still advances so encode's
+/// document-order index lines up with decode.
+fn skip_text_under(text_node: ego_tree::NodeRef<'_, scraper::node::Node>) -> bool {
+    text_node
+        .parent()
+        .and_then(|p| p.value().as_element())
+        .map(|e| {
+            let name = e.name.local.as_ref();
+            matches!(name, "script" | "style")
         })
-        .with_source(source))
+        .unwrap_or(false)
+}
+
+fn first_child_text(node: ego_tree::NodeRef<'_, scraper::node::Node>) -> Option<String> {
+    let child = node.first_child()?;
+    match child.value() {
+        scraper::node::Node::Text(t) => Some(t.text.to_string()),
+        _ => None,
     }
 }

--- a/crates/nvisy-codec/src/handler/text/html_loader.rs
+++ b/crates/nvisy-codec/src/handler/text/html_loader.rs
@@ -1,25 +1,20 @@
-//! HTML loader: validates and parses raw HTML into an
-//! [`HtmlHandler`] populated with a heterogeneous
-//! [`RedactableItem`] stream.
+//! HTML loader: parses raw HTML into an [`HtmlHandler`] populated
+//! with a heterogeneous [`RedactableItem`] stream.
 //!
-//! What gets included in the stream is controlled by the policy
-//! fields on [`HtmlLoader`] — attributes ([`scan_attributes`]),
-//! comments ([`scan_comments`]), URL bodies inside scheme-known
-//! attributes ([`scan_url_schemes`]), and `<script>` / `<style>`
-//! element bodies ([`script_policy`] / [`style_policy`]).
+//! Text nodes, every element attribute, and HTML comments are
+//! emitted as items. Attribute values pass through verbatim;
+//! percent-encoded URL values are a known gap, tracked at
+//! <https://github.com/nvisycom/runtime/issues/267>. `<script>`
+//! and `<style>` bodies follow [`HtmlLoader::script_policy`] /
+//! [`HtmlLoader::style_policy`].
 //!
-//! [`scan_attributes`]: HtmlLoader::scan_attributes
-//! [`scan_comments`]: HtmlLoader::scan_comments
-//! [`scan_url_schemes`]: HtmlLoader::scan_url_schemes
-//! [`script_policy`]: HtmlLoader::script_policy
-//! [`style_policy`]: HtmlLoader::style_policy
 //! [`RedactableItem`]: super::RedactableItem
 
-use std::borrow::Cow;
-
+use ego_tree::NodeRef;
 use nvisy_core::Error;
 use nvisy_core::modality::Text;
 use scraper::Html;
+use scraper::node::Node;
 
 use super::html_handler::{ElementTarget, HtmlData, HtmlHandler, RedactableItem, RedactableKind};
 use crate::Loader;
@@ -28,33 +23,13 @@ use crate::content::{ContentData, ContentSource, TextEncoding};
 const TARGET: &str = "nvisy_codec::handler::text::html";
 
 /// Loader for HTML files. Produces one [`HtmlHandler`] per input.
-///
-/// Every policy field has a default that enables a reasonable
-/// scanning surface for typical web pages; set fields explicitly to
-/// narrow (or widen) what gets fed through detection.
 #[derive(Debug, Clone)]
 pub struct HtmlLoader {
-    /// Character encoding of the input bytes. Defaults to UTF-8.
+    /// Character encoding of the input bytes.
     pub encoding: TextEncoding,
-    /// Attribute local names whose values get scanned. Entries
-    /// ending with `*` are treated as prefix wildcards (so
-    /// `"data-*"` matches every `data-` attribute). Default:
-    /// [`default_scan_attributes`].
-    pub scan_attributes: Vec<Cow<'static, str>>,
-    /// Whether HTML comment bodies get scanned. Default: `true` —
-    /// comments are a known PII leak vector (debug notes that ship
-    /// to production).
-    pub scan_comments: bool,
-    /// URL schemes whose body (the text after `scheme:`) gets
-    /// scanned when the loader sees one of those URLs in `href` or
-    /// `src`. Default: every [`UrlScheme`] variant.
-    pub scan_url_schemes: Vec<UrlScheme>,
-    /// What to do with `<script>` element bodies. Default:
-    /// [`ScriptPolicy::Skip`] — script bodies are usually code and
-    /// scanning them for PII produces false positives.
+    /// How `<script>` element bodies enter the detection stream.
     pub script_policy: ScriptPolicy,
-    /// What to do with `<style>` element bodies. Default:
-    /// [`ScriptPolicy::Skip`] — CSS rarely carries PII.
+    /// How `<style>` element bodies enter the detection stream.
     pub style_policy: ScriptPolicy,
 }
 
@@ -62,84 +37,9 @@ impl Default for HtmlLoader {
     fn default() -> Self {
         Self {
             encoding: TextEncoding::Utf8,
-            scan_attributes: default_scan_attributes(),
-            scan_comments: true,
-            scan_url_schemes: vec![
-                UrlScheme::Mailto,
-                UrlScheme::Tel,
-                UrlScheme::Sms,
-                UrlScheme::Callto,
-            ],
             script_policy: ScriptPolicy::Skip,
             style_policy: ScriptPolicy::Skip,
         }
-    }
-}
-
-/// Default attribute scan list: text-bearing attributes that
-/// commonly carry user data.
-///
-/// - `alt` — image text alternatives, often readable sentences.
-/// - `title` — tooltip text shown on hover.
-/// - `value` — form input values; can be pre-seeded with PII.
-/// - `placeholder` — form hints.
-/// - `aria-label` / `aria-describedby` — accessibility text
-///   vocalised by screen readers.
-/// - `data-*` — application-specific data attributes; common
-///   dumping ground for hydration payloads.
-#[must_use]
-pub fn default_scan_attributes() -> Vec<Cow<'static, str>> {
-    vec![
-        Cow::Borrowed("alt"),
-        Cow::Borrowed("title"),
-        Cow::Borrowed("value"),
-        Cow::Borrowed("placeholder"),
-        Cow::Borrowed("aria-label"),
-        Cow::Borrowed("aria-describedby"),
-        Cow::Borrowed("data-*"),
-    ]
-}
-
-/// URL schemes whose body gets scanned when present in `href` or
-/// `src` attributes. Each variant matches a single RFC-defined
-/// scheme prefix.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum UrlScheme {
-    /// `mailto:user@host(?query)` — RFC 6068. Body is everything
-    /// after `mailto:` up to the first `?` or `#`.
-    Mailto,
-    /// `tel:+1-415-555-0142` — RFC 3966. Body is everything after
-    /// `tel:` up to the first `?` or `#`.
-    Tel,
-    /// `sms:+1-415-555-0142` — RFC 5724. Same shape as `tel:`.
-    Sms,
-    /// `callto:+1-415-555-0142` — Skype legacy. Same shape as
-    /// `tel:`.
-    Callto,
-}
-
-impl UrlScheme {
-    /// The `scheme:` prefix encode reattaches when reassembling the
-    /// URL value after a redact.
-    #[must_use]
-    pub fn prefix(self) -> &'static str {
-        match self {
-            Self::Mailto => "mailto:",
-            Self::Tel => "tel:",
-            Self::Sms => "sms:",
-            Self::Callto => "callto:",
-        }
-    }
-
-    fn parse(value: &str) -> Option<(Self, &str, &str)> {
-        for scheme in [Self::Mailto, Self::Tel, Self::Sms, Self::Callto] {
-            if let Some(rest) = value.strip_prefix(scheme.prefix()) {
-                let split_at = rest.find(['?', '#']).unwrap_or(rest.len());
-                let (body, suffix) = rest.split_at(split_at);
-                return Some((scheme, body, suffix));
-            }
-        }
-        None
     }
 }
 
@@ -197,7 +97,7 @@ fn build_items(dom: &Html, loader: &HtmlLoader) -> Vec<RedactableItem> {
 
     for node in dom.tree.nodes() {
         match node.value() {
-            scraper::node::Node::Text(t) => {
+            Node::Text(t) => {
                 if !skip_text_under(node) {
                     items.push(RedactableItem {
                         kind: RedactableKind::TextNode { index: text_index },
@@ -206,53 +106,32 @@ fn build_items(dom: &Html, loader: &HtmlLoader) -> Vec<RedactableItem> {
                 }
                 text_index += 1;
             }
-            scraper::node::Node::Comment(c) => {
-                if loader.scan_comments {
-                    items.push(RedactableItem {
-                        kind: RedactableKind::Comment {
-                            index: comment_index,
-                        },
-                        value: c.comment.to_string(),
-                    });
-                }
+            Node::Comment(c) => {
+                items.push(RedactableItem {
+                    kind: RedactableKind::Comment {
+                        index: comment_index,
+                    },
+                    value: c.comment.to_string(),
+                });
                 comment_index += 1;
             }
-            scraper::node::Node::Element(e) => {
+            Node::Element(e) => {
                 let element_name = e.name.local.as_ref();
 
-                // Attribute-bound items (Attribute + UrlBody) at this element.
+                // Every attribute on this element. Values pass
+                // through verbatim — URLs like `mailto:alice@x.com`
+                // have the email matched in place by the
+                // recognizer.
                 for (qn, val) in &e.attrs {
-                    let attr_name = qn.local.as_ref();
-                    let is_url_attr =
-                        matches!(attr_name, "href" | "src") && !loader.scan_url_schemes.is_empty();
-                    if is_url_attr
-                        && let Some((scheme, body, suffix)) = UrlScheme::parse(val.as_ref())
-                        && loader.scan_url_schemes.contains(&scheme)
-                    {
-                        items.push(RedactableItem {
-                            kind: RedactableKind::Element {
-                                element_index,
-                                target: ElementTarget::UrlBody {
-                                    attr_name: attr_name.to_owned(),
-                                    scheme,
-                                    suffix: suffix.to_owned(),
-                                },
+                    items.push(RedactableItem {
+                        kind: RedactableKind::Element {
+                            element_index,
+                            target: ElementTarget::Attribute {
+                                attr_name: qn.local.as_ref().to_owned(),
                             },
-                            value: body.to_owned(),
-                        });
-                        continue;
-                    }
-                    if matches_scan_attribute(&loader.scan_attributes, attr_name) {
-                        items.push(RedactableItem {
-                            kind: RedactableKind::Element {
-                                element_index,
-                                target: ElementTarget::Attribute {
-                                    attr_name: attr_name.to_owned(),
-                                },
-                            },
-                            value: val.to_string(),
-                        });
-                    }
+                        },
+                        value: val.to_string(),
+                    });
                 }
 
                 // `<script>` / `<style>` body, when policy says ScanText.
@@ -287,28 +166,12 @@ fn build_items(dom: &Html, loader: &HtmlLoader) -> Vec<RedactableItem> {
     items
 }
 
-/// Match an attribute name against the configured scan list,
-/// honouring `*`-suffixed prefix wildcards (e.g. `data-*` matches
-/// every attribute starting with `data-`).
-fn matches_scan_attribute(scan_list: &[Cow<'static, str>], name: &str) -> bool {
-    for entry in scan_list {
-        if let Some(prefix) = entry.strip_suffix('*') {
-            if name.starts_with(prefix) {
-                return true;
-            }
-        } else if entry.as_ref() == name {
-            return true;
-        }
-    }
-    false
-}
-
 /// Don't emit text-node items for text that lives directly inside
 /// a `<script>` or `<style>` element — those bodies are handled by
 /// the script / style policy on the parent element instead. The
 /// `text_index` counter still advances so encode's
 /// document-order index lines up with decode.
-fn skip_text_under(text_node: ego_tree::NodeRef<'_, scraper::node::Node>) -> bool {
+fn skip_text_under(text_node: NodeRef<'_, Node>) -> bool {
     text_node
         .parent()
         .and_then(|p| p.value().as_element())
@@ -319,10 +182,10 @@ fn skip_text_under(text_node: ego_tree::NodeRef<'_, scraper::node::Node>) -> boo
         .unwrap_or(false)
 }
 
-fn first_child_text(node: ego_tree::NodeRef<'_, scraper::node::Node>) -> Option<String> {
+fn first_child_text(node: NodeRef<'_, Node>) -> Option<String> {
     let child = node.first_child()?;
     match child.value() {
-        scraper::node::Node::Text(t) => Some(t.text.to_string()),
+        Node::Text(t) => Some(t.text.to_string()),
         _ => None,
     }
 }

--- a/crates/nvisy-codec/src/handler/text/json_handler.rs
+++ b/crates/nvisy-codec/src/handler/text/json_handler.rs
@@ -200,7 +200,7 @@ impl Handler<Text> for JsonHandler {
             let Slot::Leaf(leaf) = &mut self.slots[idx] else {
                 continue;
             };
-            redact::replace_range(&mut leaf.value, &value, value_start, value_end, TARGET)?;
+            redact::replace_range(&mut leaf.value, &value, value_start..value_end, TARGET)?;
             leaf.render();
         }
         self.cursor = 0;

--- a/crates/nvisy-codec/src/handler/text/mod.rs
+++ b/crates/nvisy-codec/src/handler/text/mod.rs
@@ -60,7 +60,7 @@ pub use self::html_handler::{
     ElementTarget, HtmlData, HtmlHandler, RedactableItem, RedactableKind, format as html_format,
 };
 #[cfg(feature = "html")]
-pub use self::html_loader::{HtmlLoader, ScriptPolicy, UrlScheme, default_scan_attributes};
+pub use self::html_loader::{HtmlLoader, ScriptPolicy};
 #[cfg(feature = "json")]
 pub use self::json_handler::{JsonHandler, format as json_format};
 #[cfg(feature = "json")]

--- a/crates/nvisy-codec/src/handler/text/mod.rs
+++ b/crates/nvisy-codec/src/handler/text/mod.rs
@@ -8,38 +8,10 @@
 //! [`Handler::redact`]: crate::Handler::redact
 //! [`TextReplacement`]: nvisy_core::redaction::TextReplacement
 
-use std::ops::Range;
-
-use nvisy_core::modality::{Text, TextLocation};
-
-use crate::Chunk;
-
-/// Identity lift for handlers where `chunk.data` is byte-for-byte
-/// a slice of the source covered by `chunk.location` — no
-/// escapes, no decoding. The default implementation backing
-/// [`Handler::lift_chunk`] for TXT lines, HTML text nodes,
-/// PDF page text, and DOCX text runs.
-///
-/// Adds `value_range` to `chunk.location.start` and copies
-/// `page_number` / `context` through. Returns `None` when the
-/// range falls outside the chunk's value.
-///
-/// [`Handler::lift_chunk`]: crate::Handler::lift_chunk
-pub fn lift_identity(chunk: &Chunk<Text>, value_range: Range<usize>) -> Option<TextLocation> {
-    let len = chunk.location.end.checked_sub(chunk.location.start)?;
-    if value_range.start > value_range.end || value_range.end > len {
-        return None;
-    }
-    Some(TextLocation {
-        start: chunk.location.start + value_range.start,
-        end: chunk.location.start + value_range.end,
-        context: chunk.location.context,
-        page_number: chunk.location.page_number,
-    })
-}
-
 pub(crate) mod redact;
 
+#[cfg(feature = "html")]
+mod html_encode;
 #[cfg(feature = "html")]
 mod html_handler;
 #[cfg(feature = "html")]

--- a/crates/nvisy-codec/src/handler/text/mod.rs
+++ b/crates/nvisy-codec/src/handler/text/mod.rs
@@ -56,9 +56,11 @@ mod txt_handler;
 mod txt_loader;
 
 #[cfg(feature = "html")]
-pub use self::html_handler::{HtmlData, HtmlHandler, format as html_format};
+pub use self::html_handler::{
+    ElementTarget, HtmlData, HtmlHandler, RedactableItem, RedactableKind, format as html_format,
+};
 #[cfg(feature = "html")]
-pub use self::html_loader::HtmlLoader;
+pub use self::html_loader::{HtmlLoader, ScriptPolicy, UrlScheme, default_scan_attributes};
 #[cfg(feature = "json")]
 pub use self::json_handler::{JsonHandler, format as json_format};
 #[cfg(feature = "json")]

--- a/crates/nvisy-codec/src/handler/text/redact.rs
+++ b/crates/nvisy-codec/src/handler/text/redact.rs
@@ -3,25 +3,26 @@
 //! the PDF rich handler) plus the tabular cell handlers (CSV, XLSX
 //! cells are flat strings).
 //!
-//! Replaces `content[start..end]` with `value`. Clamps offsets to
-//! `content.len()`; errors when either offset falls mid-character.
+//! Replaces `buf[range]` with `value`. Clamps the range endpoints
+//! to `buf.len()`; errors when either endpoint falls mid-character.
+
+use std::ops::Range;
 
 use nvisy_core::Error;
 
-/// Replace `buf[start..end]` with `value` in place.
+/// Replace `buf[range]` with `value` in place.
 ///
-/// Returns an error if either offset falls mid-character. Offsets are
-/// clamped to `buf.len()`; an empty replacement against an empty range
-/// is a no-op.
+/// Returns an error if either endpoint falls mid-character. The
+/// range endpoints are clamped to `buf.len()`; an empty range is
+/// a no-op.
 pub(crate) fn replace_range(
     buf: &mut String,
     value: &str,
-    start: usize,
-    end: usize,
+    range: Range<usize>,
     target: &'static str,
 ) -> Result<(), Error> {
-    let s = start.min(buf.len());
-    let e = end.min(buf.len());
+    let s = range.start.min(buf.len());
+    let e = range.end.min(buf.len());
     if s >= e {
         return Ok(());
     }
@@ -29,7 +30,9 @@ pub(crate) fn replace_range(
         return Err(Error::validation(
             format!(
                 "redaction offset falls mid-character \
-                 (start={start}, end={end}, len={})",
+                 (start={}, end={}, len={})",
+                range.start,
+                range.end,
                 buf.len()
             ),
             target,
@@ -46,28 +49,28 @@ mod tests {
     #[test]
     fn single_replacement() {
         let mut s = String::from("hello world");
-        replace_range(&mut s, "[X]", 0, 5, "test").unwrap();
+        replace_range(&mut s, "[X]", 0..5, "test").unwrap();
         assert_eq!(s, "[X] world");
     }
 
     #[test]
     fn remove_empty_value() {
         let mut s = String::from("hello world");
-        replace_range(&mut s, "", 5, 11, "test").unwrap();
+        replace_range(&mut s, "", 5..11, "test").unwrap();
         assert_eq!(s, "hello");
     }
 
     #[test]
     fn out_of_bounds_clipped() {
         let mut s = String::from("short");
-        replace_range(&mut s, "[X]", 0, 999, "test").unwrap();
+        replace_range(&mut s, "[X]", 0..999, "test").unwrap();
         assert_eq!(s, "[X]");
     }
 
     #[test]
     fn mid_character_rejected() {
         let mut s = String::from("héllo"); // 'é' is 2 bytes
-        let err = replace_range(&mut s, "[X]", 0, 2, "test").unwrap_err();
+        let err = replace_range(&mut s, "[X]", 0..2, "test").unwrap_err();
         assert!(err.to_string().contains("mid-character"));
     }
 }

--- a/crates/nvisy-codec/src/handler/text/txt_handler.rs
+++ b/crates/nvisy-codec/src/handler/text/txt_handler.rs
@@ -12,7 +12,7 @@ use nvisy_core::Error;
 use nvisy_core::modality::{Text, TextData, TextLocation};
 use nvisy_core::redaction::{Redactions, TextReplacement};
 
-use super::{TxtLoader, lift_identity, redact};
+use super::{TxtLoader, redact};
 use crate::content::{ContentData, ContentSource};
 use crate::{Chunk, Format, FormatId, Handler};
 
@@ -88,7 +88,7 @@ impl Handler<Text> for TxtHandler {
     }
 
     fn lift_chunk(&self, chunk: &Chunk<Text>, value_range: Range<usize>) -> Option<TextLocation> {
-        lift_identity(chunk, value_range)
+        chunk.location.subslice(value_range)
     }
 
     async fn read(&self, location: &TextLocation) -> Result<Option<TextData>, Error> {
@@ -206,7 +206,7 @@ impl TxtHandler {
         let local_end = location.end - line_start;
         let value = replacement.replacement_value().unwrap_or_default();
         let before_len = self.lines[i].len();
-        redact::replace_range(&mut self.lines[i], value, local_start, local_end, TARGET)?;
+        redact::replace_range(&mut self.lines[i], value, local_start..local_end, TARGET)?;
         let after_len = self.lines[i].len();
         self.shift_starts_after(i, after_len as isize - before_len as isize);
         Ok(())

--- a/crates/nvisy-core/src/modality/text.rs
+++ b/crates/nvisy-core/src/modality/text.rs
@@ -2,6 +2,8 @@
 //! [`TextData`] per-call payload, and [`TextExtraction`] provenance
 //! enum.
 
+use std::ops::Range;
+
 use derive_more::{AsRef, Deref, Display, From};
 use hipstr::HipStr;
 use schemars::JsonSchema;
@@ -89,6 +91,31 @@ impl TextLocation {
     /// Whether the range is empty (zero length).
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Translate a value-local byte range to a parent-local
+    /// [`TextLocation`], assuming the value is a verbatim slice of
+    /// the source covered by `self` (no escapes, no decoding).
+    ///
+    /// Returns `None` when `value_range.end > self.len()` or the
+    /// range is malformed (`start > end`).
+    ///
+    /// Used by [`Handler::lift_chunk`] implementations whose chunk
+    /// data and source bytes coincide — TXT lines, HTML text
+    /// nodes, PDF page text, DOCX text runs, etc.
+    ///
+    /// [`Handler::lift_chunk`]: # "see nvisy-codec"
+    #[must_use]
+    pub fn subslice(&self, value_range: Range<usize>) -> Option<TextLocation> {
+        if value_range.start > value_range.end || value_range.end > self.len() {
+            return None;
+        }
+        Some(TextLocation {
+            start: self.start + value_range.start,
+            end: self.start + value_range.end,
+            context: self.context,
+            page_number: self.page_number,
+        })
     }
 }
 

--- a/crates/nvisy-toolkit/testdata/contact.html
+++ b/crates/nvisy-toolkit/testdata/contact.html
@@ -5,6 +5,7 @@
     <title>Customer onboarding</title>
 </head>
 <body>
+    <!-- Reviewer: Alice Johnson handles bob.smith@example.com inbox -->
     <h1>Customer onboarding</h1>
     <p>Reach out to <strong>alice.johnson@example.com</strong> with any questions
        about the proposal. For urgent matters, call <em>+1 (415) 555-0142</em>
@@ -12,6 +13,14 @@
     <p>Wire transfers use IBAN <code>GB29 NWBK 6016 1331 9268 19</code>.
        The customer's US tax id is <code>123-45-6789</code>. Our staging API
        runs at <code>192.168.1.42</code>.</p>
+    <p>
+        <img src="/avatars/alice.png"
+             alt="Avatar for alice.johnson@example.com">
+        <a href="mailto:alice.johnson@example.com?subject=Welcome">Email Alice</a> ·
+        <a href="tel:+14155550142" aria-label="Call Alice at +1 (415) 555-0142">Call</a>
+        <input type="text" placeholder="Backup contact e.g. carol.lee@example.com"
+               data-staging-host="192.168.1.42">
+    </p>
     <p>Best,<br>Bob</p>
 </body>
 </html>

--- a/crates/nvisy-toolkit/tests/codec_e2e_html.rs
+++ b/crates/nvisy-toolkit/tests/codec_e2e_html.rs
@@ -1,18 +1,26 @@
-//! End-to-end HTML codec. The HTML loader chunks the source on
-//! text nodes; this test exercises:
+//! End-to-end HTML codec. The HTML loader chunks the source on a
+//! heterogeneous redactable-item stream — text nodes, comments,
+//! scanned attributes, and URL bodies inside scheme-known
+//! attributes (`mailto:`, `tel:`, `sms:`, `callto:`). This test
+//! exercises:
 //!
-//! 1. Entity detection inside per-tag text nodes (PII split across
-//!    `<strong>`, `<em>`, `<code>` resolves and feeds the redactor).
-//! 2. Tag preservation: `Handler::encode` rebuilds the document
-//!    from the parsed tree so `<p>`, `<strong>`, `<em>`, `<code>`,
-//!    `<h1>`, etc. survive alongside the rewritten text.
+//! 1. Detection inside per-tag text nodes.
+//! 2. Detection inside the default-scanned attributes (`alt`,
+//!    `title`, `value`, `placeholder`, `aria-label`,
+//!    `aria-describedby`, `data-*`).
+//! 3. Detection inside HTML comments (scanned by default).
+//! 4. Detection inside `mailto:` and `tel:` URL bodies, with the
+//!    scheme prefix and any trailing query suffix re-attached
+//!    after redact.
+//! 5. Tag preservation: `Handler::encode` rebuilds the document
+//!    from the parsed tree so structural elements survive
+//!    alongside the rewritten content.
 //!
-//! Note: entity locations on HTML are text-stream coords (relative
-//! to the concatenated text nodes), not raw HTML source byte
-//! offsets, so this test asserts by entity-kind presence rather
-//! than slicing the source at each entity's range. See
-//! `.ignore/html-handler-improvements.md` for the longer-term
-//! roadmap (attribute scanning, URL scheme awareness, …).
+//! Note: entity locations on HTML are item-stream coords (relative
+//! to the concatenated text + attribute + comment + URL-body
+//! stream), not raw HTML source byte offsets, so this test asserts
+//! by entity-kind presence rather than slicing the source at each
+//! entity's range. See `.ignore/html-handler-improvements.md`.
 
 mod fixtures;
 
@@ -53,15 +61,28 @@ async fn html_codec_detects_and_redacts() {
         );
     }
 
+    // Cover every PII string in the fixture — text-node, attribute,
+    // comment, and URL-body locations. If any of these survive,
+    // it's a regression somewhere in the redactable-item pipeline.
     assert_pii_removed(
         &outcome.redacted,
         &[
+            // Text-node values.
             "alice.johnson@example.com",
             "+1 (415) 555-0142",
             "4111 1111 1111 1111",
             "GB29 NWBK 6016 1331 9268 19",
             "123-45-6789",
             "192.168.1.42",
+            // Attribute values (alt, aria-label, placeholder, data-*).
+            "Avatar for alice.johnson@example.com",
+            "Call Alice at +1 (415) 555-0142",
+            "Backup contact e.g. carol.lee@example.com",
+            // Comment body.
+            "bob.smith@example.com",
+            // URL bodies (mailto: + tel:).
+            "mailto:alice.johnson@example.com",
+            "tel:+14155550142",
         ],
     );
     assert_tokens_present(
@@ -109,6 +130,30 @@ async fn html_codec_detects_and_redacts() {
     assert!(
         outcome.redacted.contains("<code>"),
         "code tag lost: {}",
+        outcome.redacted,
+    );
+    // URL scheme prefixes survive: redact only edits the body and
+    // re-attaches `scheme:` plus any trailing `?…` / `#…` suffix.
+    assert!(
+        outcome.redacted.contains("href=\"mailto:"),
+        "mailto: scheme prefix lost: {}",
+        outcome.redacted,
+    );
+    assert!(
+        outcome.redacted.contains("?subject=Welcome"),
+        "mailto: query suffix lost: {}",
+        outcome.redacted,
+    );
+    assert!(
+        outcome.redacted.contains("href=\"tel:"),
+        "tel: scheme prefix lost: {}",
+        outcome.redacted,
+    );
+    // Comments survive as `<!-- … -->` after their bodies are
+    // rewritten.
+    assert!(
+        outcome.redacted.contains("<!--"),
+        "comment delimiter lost: {}",
         outcome.redacted,
     );
 }

--- a/crates/nvisy-toolkit/tests/codec_e2e_html.rs
+++ b/crates/nvisy-toolkit/tests/codec_e2e_html.rs
@@ -1,26 +1,23 @@
-//! End-to-end HTML codec. The HTML loader chunks the source on a
-//! heterogeneous redactable-item stream — text nodes, comments,
-//! scanned attributes, and URL bodies inside scheme-known
-//! attributes (`mailto:`, `tel:`, `sms:`, `callto:`). This test
-//! exercises:
+//! End-to-end HTML codec. The HTML loader emits a redactable-item
+//! stream: text nodes, every element attribute, and HTML comments.
+//! `mailto:` / `tel:` URLs are scanned in place — the recognizer
+//! matches the PII substring inside the attribute value, redact
+//! rewrites only that range, and the scheme prefix + query suffix
+//! pass through untouched. This test exercises:
 //!
 //! 1. Detection inside per-tag text nodes.
-//! 2. Detection inside the default-scanned attributes (`alt`,
-//!    `title`, `value`, `placeholder`, `aria-label`,
-//!    `aria-describedby`, `data-*`).
-//! 3. Detection inside HTML comments (scanned by default).
-//! 4. Detection inside `mailto:` and `tel:` URL bodies, with the
-//!    scheme prefix and any trailing query suffix re-attached
-//!    after redact.
-//! 5. Tag preservation: `Handler::encode` rebuilds the document
-//!    from the parsed tree so structural elements survive
-//!    alongside the rewritten content.
+//! 2. Detection inside attributes (`alt`, `aria-label`,
+//!    `placeholder`, `data-*`).
+//! 3. Detection inside HTML comments.
+//! 4. PII matching inside URL attribute values without explicit
+//!    scheme parsing.
+//! 5. Tag preservation through encode.
 //!
 //! Note: entity locations on HTML are item-stream coords (relative
-//! to the concatenated text + attribute + comment + URL-body
-//! stream), not raw HTML source byte offsets, so this test asserts
-//! by entity-kind presence rather than slicing the source at each
-//! entity's range. See `.ignore/html-handler-improvements.md`.
+//! to the concatenated item stream), not raw HTML source byte
+//! offsets, so this test asserts by entity-kind presence rather
+//! than slicing the source at each entity's range. See
+//! `.ignore/html-handler-improvements.md`.
 
 mod fixtures;
 
@@ -132,8 +129,9 @@ async fn html_codec_detects_and_redacts() {
         "code tag lost: {}",
         outcome.redacted,
     );
-    // URL scheme prefixes survive: redact only edits the body and
-    // re-attaches `scheme:` plus any trailing `?…` / `#…` suffix.
+    // URL `scheme:` prefixes survive verbatim because attribute
+    // values pass through and the recognizer matches only the PII
+    // substring (`alice@example.com` inside `mailto:...`).
     assert!(
         outcome.redacted.contains("href=\"mailto:"),
         "mailto: scheme prefix lost: {}",
@@ -149,8 +147,6 @@ async fn html_codec_detects_and_redacts() {
         "tel: scheme prefix lost: {}",
         outcome.redacted,
     );
-    // Comments survive as `<!-- … -->` after their bodies are
-    // rewritten.
     assert!(
         outcome.redacted.contains("<!--"),
         "comment delimiter lost: {}",


### PR DESCRIPTION
## Summary

Extends the HTML codec to scan every common PII surface in
HTML — text nodes, every element attribute, HTML comments, and
optionally `<script>` / `<style>` element bodies — instead of just
text nodes.

## Behaviour

The handler decodes the source into a single ordered stream of
redactable items. For each item the recognizer sees the raw
attribute / text / comment value; the redactor mutates that value
in place; encode walks the parsed DOM in document order and
splices the mutated values back.

Scanning is exhaustive by default. The only configurable surface
is what to do with `<script>` and `<style>` element bodies, via
`HtmlLoader::script_policy` and `HtmlLoader::style_policy`. Both
default to `ScriptPolicy::Skip`. `ScriptPolicy::ScanText` works
end-to-end. `ScriptPolicy::ScanJson` is reserved on the enum but
returns an error at decode pending the cross-handler embedded
sub-handler design tracked in nvisycom/elide#54.

URLs in attribute values (`mailto:`, `tel:`, `https:`, …) are not
parsed. The recognizer matches PII substrings inside the raw URL
value (`mailto:alice@x.com` → `mailto:[email]`) without any
scheme-aware logic. Percent-encoded URL values
(`mailto:alice%40x.com`) are a known gap, tracked in
nvisycom/elide#55.

## Internal model

`HtmlHandler` owns `Vec<RedactableItem>` with a cumulative offset
table over the heterogeneous item stream. Encode re-parses the
source, builds an `EncodePlan` bucketing items by kind, and
applies them in a single DOM walk. O(N) at encode; no NodeId
tables stored on the handler.

Adds `ego-tree = "0.11"` (workspace + codec `html` feature) for
the `NodeId` type `scraper` uses but doesn't re-export.

A few unrelated codec polish items landed in the same PR because
they touched the same modules:

- `TextLocation::subslice(value_range)` added to nvisy-core,
  replacing the codec-side `lift_identity` free function. TXT,
  HTML, PDF, and DOCX `lift_chunk` impls become
  `chunk.location.subslice(value_range)`.
- `replace_range` takes a single `Range<usize>` instead of
  separate `start, end` parameters; CSV, JSON, TXT, HTML, and PDF
  call sites updated.
- `html_handler.rs` split: the `EncodePlan` and per-kind DOM
  write helpers move to a new `html_encode` module exposing
  `EncodePlan::apply(&self, &mut Html)`. The handler file keeps
  the struct, the trait impl, the inherent methods, and the
  offset-table helper.

## Public surface delta

**Added:**
- `HtmlLoader::script_policy: ScriptPolicy`
- `HtmlLoader::style_policy: ScriptPolicy`
- `ScriptPolicy { Skip, ScanText, ScanJson }`
- `RedactableItem`, `RedactableKind`, `ElementTarget`
- `HtmlData::items`
- `TextLocation::subslice(value_range)` on nvisy-core

**Removed:**
- `HtmlData::text_nodes` field
- `HtmlHandler::text_nodes()`, `text_node(i)`, `len()`,
  `is_empty()` accessors (replaced with `items()` and updated
  semantics)
- `handler::text::lift_identity` free function (replaced by
  `TextLocation::subslice`)

**Signature changed:**
- `replace_range(buf, value, start, end, target)` →
  `replace_range(buf, value, range, target)` (single
  `Range<usize>`)

## Test plan

- [x] `cargo test --workspace --all-features` — 373 passed, 0
      failed
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps` — clean
- [x] Codec E2E `tests/codec_e2e_html.rs` — fixture covers a
      comment, `alt` / `aria-label` / `placeholder` / `data-*`
      attributes, and `mailto:` / `tel:` URLs; assertions cover
      every PII string and the structural elements that should
      survive
- [x] 7 in-crate unit tests on `HtmlHandler` (round-trip,
      text-node redact, mixed-kind chunk stream, attribute
      redact, comment redact, href-verbatim, script-policy skip)
- [ ] Inspect `crates/nvisy-toolkit/testdata/contact.redacted.html`
      against `contact.html` for the human-readable shape

## Reviewer notes

- `ScriptPolicy::ScanJson` is reserved on the enum but errors at
  decode — intentional. Cross-handler embed design (HTML script
  body routed through `JsonHandler`) lands separately when
  PDF/DOCX embeds give us two real users
  (nvisycom/elide#54).
- Percent-encoded URL leak is documented;
  nvisycom/elide#55 tracks the fix for when there's a real
  forcing function.
- `Vec<RedactableItem>` plus the cumulative-offset machinery is
  structurally similar to JSON's `Vec<Slot>` and other text
  handlers' `Vec<String>` + `*_starts` table. An abstraction
  isn't extracted yet — wait for a third user.
- No legacy paths, no deprecated shims. `HtmlData::text_nodes`
  is gone; callers use `items()` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
