### PR TITLE
docs: rewrite docs/ as academic white papers

### DIFF
--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -1,77 +1,250 @@
-# Compliance & Audit
+# Compliance and Audit
 
-## 1. Overview
+## 1. Framing
 
-Enterprises do not purchase redaction tools; they purchase compliance guarantees. The value of automated redaction is realized only when the organization can demonstrate to regulators, auditors, and legal counsel that sensitive data was identified, handled, and redacted in accordance with applicable policy.
+Compliance is a sociotechnical concern, not a software feature. No runtime can deliver
+"compliance with GDPR" or "SOC 2 certification" on its own; only an organization can,
+through audit-defensible processes that span legal review, organizational policy,
+operational controls, personnel training, and a body of evidence far larger than any
+single piece of software. A redaction engine cannot certify a hospital, a bank, or a
+data processor; it can only supply one of the load-bearing components such a
+certification depends on.
 
-This requires two complementary capabilities: a policy engine that encodes regulatory and organizational rules into executable redaction policies, and an audit system that records every decision, action, and outcome with sufficient detail to reconstruct the chain of custody for any piece of content.
+This document describes that component. The runtime described here provides an
+auditable detection-and-redaction pipeline: a mechanism for identifying sensitive
+entities in unstructured content, deciding what to do with each one under a stated
+policy, executing those decisions, and recording every step in a form that a downstream
+auditor can read, replay, and challenge. The pipeline is a building block. The
+compliance posture is the building.
 
-## 2. Policy Engine
+The remainder of this paper describes the conceptual model that makes the runtime
+auditable, the boundaries of what it is responsible for, and the boundaries of what it
+deliberately leaves to layers above and below it. The intended reader is a compliance
+engineer, internal auditor, or external assessor evaluating whether this component is
+suitable for inclusion in a controlled environment.
 
-### 2.1 Policy Definition
+## 2. The Audit Trail
 
-Policies express conditions over entity types, document classifications, confidence thresholds, and organizational context. Each policy is a versioned collection of rules that the engine evaluates during the redaction stage.
+Every entity that survives detection generates an audit record. By "survives detection"
+we mean that one or more recognizers asserted the entity's existence, the assertion was
+not filtered out by confidence thresholds or deduplication, and the entity entered the
+decision stage. Whether the entity was then redacted, suppressed, or passed through
+unchanged, an audit record is produced.
 
-### 2.2 Regulation Packs
+Each record captures five dimensions:
 
-Prebuilt policy packs aligned to common regulatory frameworks are shipped as JSON templates in the repository (see [REDACTION.md](REDACTION.md) Section 3). Available packs:
+**Identity.** A stable identifier for the entity instance, scoped to the redaction pass.
+Re-running the same input under the same configuration produces the same identifiers
+for the same entities. The identifier is the handle by which downstream systems refer
+to the entity for review, override, or recovery.
 
-- **HIPAA**: Protected health information in medical records, communications, and claims.
-- **GDPR**: Personal data of EU residents across all modalities.
-- **PCI-DSS**: Payment card data in documents, images, and structured records.
-- **CCPA**: Personal information of California residents, including the right to deletion and opt-out of sale.
+**Provenance.** Which recognizers contributed to the detection, and what evidence each
+one provided. If a phone number was detected by both a pattern recognizer and a
+named-entity recognizer, both contributions are recorded. The evidence captures
+sufficient detail to explain *why* the recognizer fired: the matched span, the
+confidence it assigned, and the rule or model identifier it was operating under.
 
-### 2.3 Policy Simulation
+**Decision.** Which policy rule matched and what action it dictated. If an override
+modified the decision, the override is recorded alongside the original rule outcome,
+together with the authority under which the override was applied. A decision is never
+recorded without its justification.
 
-Before a policy is applied to production data, the engine must support a dry-run mode that evaluates the policy against content and returns the set of redactions that would be applied, without modifying the content. This enables previewing the effect of a policy across a representative sample before committing to production use.
+**Execution.** Whether the decision was carried out, suppressed, or failed. What the
+resulting replacement was, if any. Whether the operation is reversible and, if so,
+which reversibility mechanism applies. An execution failure is itself an audit record,
+not an absence of one.
 
-### 2.4 Policy Versioning
+**Timestamp.** When the decision was made and when execution occurred. These are
+distinguished because the runtime supports decision review independent of execution,
+and the two times can diverge under human-in-the-loop workflows.
 
-Policies must be versioned, with a full history of changes. The engine must record which policy version was active for each pipeline execution so that audit trails can reference the exact rules that governed a redaction decision.
+The audit is append-oriented within a redaction pass: records are produced in order and
+not rewritten. It does not provide cryptographic tamper-evidence at the runtime layer.
+Tamper-evidence is a property of storage, not of the producer, and is addressed in the
+deployment scope below.
 
-## 3. Explainability
+## 3. Policy as Code
 
-Every redaction decision must be explainable. The engine must record:
+Compliance rules in this system are programmatic, not declarative tags. A policy is an
+ordered sequence of rules. Each rule has a set of conditions evaluated against entity
+attributes, document labels, and metadata, and an action prescribed when the conditions
+are met. The first matching rule wins; subsequent rules are not considered for that
+entity. Entities for which no rule matches receive a default action specified by the
+policy itself.
 
-- **What was redacted**: The specific content span, region, or audio segment.
-- **Why it was redacted**: The triggering rule, pattern, or model prediction.
-- **Which model version**: The exact version of any ML model involved in the decision.
-- **Confidence level**: The detection confidence associated with the decision.
-- **Review disposition**: If review decisions were provided as input, the reviewer identity and action (accept, reject, modify).
-- **When it was processed**: Timestamps for each stage of the pipeline.
+This design is deliberately audit-friendly. Every decision the system makes can be
+reduced to a single sentence: "rule N fired against entity E because of conditions C,
+prescribing action A." The rule is the citation. The conditions are the evidence. The
+action is the disposition. An auditor reconstructing a decision does not need to
+understand the engine's evaluation strategy, only the rule that won.
 
-## 4. Audit Trails
+The order of rules is significant and visible. A policy author who places a broad
+allow-listing rule before a narrow redaction rule has expressed an intentional ordering
+that an auditor can read directly from the policy text. There is no hidden priority
+system, no implicit weighting, no opaque conflict resolution.
 
-### 4.1 Immutability
+Policies are versioned. Each redaction pass records the policy version under which it
+ran. A decision made under an old policy can be reproduced exactly by replaying it
+against the same detection artifact under the same policy version, even after the
+policy has evolved.
 
-Audit logs must be append-only and tamper-evident. Once a record is written, it cannot be modified or deleted.
+## 4. The Runtime, Deployment, and Product Scope Split
 
-### 4.2 Chain of Custody
+Compliance work spans many layers. A clear statement of which layer is responsible for
+which control is the most useful artifact a runtime component can provide to its
+operators. The following split is the position this runtime takes:
 
-The audit system must maintain a complete chain of custody for every piece of content: from ingestion, through detection and redaction, to export. The content metadata captured at ingestion (MIME type, filename, source path, and any custom key-value pairs) is preserved alongside the audit trail, providing full context for each processing decision without relying on the continued availability of the original content.
+| Concern                                | Runtime | Deployment | Product |
+|----------------------------------------|---------|------------|---------|
+| Per-entity audit records               | Yes     |            |         |
+| Persistent retention of artifacts      | Yes     |            |         |
+| Programmatic query of past decisions   | Yes     |            |         |
+| Reversibility primitives               | Yes     |            |         |
+| Authentication and authorization       |         | Yes        |         |
+| Encryption at rest                     |         | Yes        |         |
+| Network isolation                      |         | Yes        |         |
+| Log forwarding to SIEM                 |         | Yes        |         |
+| Key management and rotation            |         | Yes        |         |
+| Multi-tenant separation                |         | Yes        |         |
+| Append-only audit storage              |         | Yes        |         |
+| Reviewer workflows and UI              |         |            | Yes     |
+| Regulatory policy templates            |         |            | Yes     |
+| Legal-hold integration                 |         |            | Yes     |
+| Certification documentation            |         |            | Yes     |
+| Subject-access request workflows       |         |            | Yes     |
 
-### 4.3 Reporting
+The runtime layer provides the primitives. The deployment layer provides the
+operational security envelope. The product layer provides the regulatory framing and
+human workflows. A specific organization's compliance posture is the composition of all
+three. No single layer is sufficient, and no single layer can substitute for another.
+A runtime that claims to provide tamper-evident logging without an append-only storage
+layer underneath it is misrepresenting itself, and the same misrepresentation applies
+to any product that claims regulatory compliance without operational controls behind
+it.
 
-The engine must expose audit data in a structured format suitable for compliance reporting. Reports should cover:
+## 5. Reversibility and the Right to Deletion
 
-- Redaction statistics by entity type, document category, and time period
-- Policy adherence metrics
-- Exceptions and overrides
+Redaction operators differ in whether they preserve the possibility of recovery. Some
+operators are reversible by design: encryption with a deployment-held key produces a
+ciphertext from which the original can be recovered, given the key. Others are
+deliberately irreversible: one-way hashing, span removal, and generic placeholder
+substitution discard the original and cannot reconstruct it from the redacted output.
 
-### 4.4 SOC 2 Readiness
+This distinction is consequential under regulatory regimes that grant data subjects a
+right to deletion. If a subject requests deletion of their data and that data was
+redacted using a reversible operator, the cipher key material is itself a copy of the
+subject's data, and the request cannot be honored merely by deleting the redacted
+output. If the same data was redacted using an irreversible operator, the redacted
+output contains no recoverable copy and is, for the purpose of the deletion request,
+already deleted.
 
-Logging infrastructure must meet the requirements of SOC 2 Type II certification, including continuous monitoring, access controls, and retention policies.
+The runtime exposes this distinction in the audit record. Every execution entry states
+whether the operator used was reversible, and if so, the identity of the key or recovery
+artifact under which reversal is possible. A deployment can therefore answer, for a
+given subject, the question "which records pertaining to this subject are reversibly
+redacted, and where do the keys live?" The answer to that question is the
+deletion-completion checklist.
 
-## 5. Data Retention Policies
+The runtime does not itself enforce deletion. Key destruction, cascading deletes, and
+revocation are deployment-side controls. The runtime provides the inventory.
 
-### 5.1 Original Content
+## 6. Explainability
 
-The engine must enforce configurable retention policies for original (pre-redaction) content. Organizations must be able to specify maximum retention periods after which originals are permanently deleted. Zero-retention mode, in which originals are discarded immediately after processing, must be available for environments where persistent storage of sensitive content is prohibited.
+For each redaction, the system can answer five questions:
 
-### 5.2 Redacted Output
+1. *Which entity was detected.* The identifier, type, and location of the entity in the
+   input.
+2. *Why it was detected.* The recognizers that contributed and the evidence each
+   provided.
+3. *Why it was redacted.* The policy rule that matched and the conditions under which
+   it fired.
+4. *What was done.* The operator that was applied and the replacement that was emitted.
+5. *How to reverse it, where applicable.* The reversibility mechanism and the location
+   of the recovery material.
 
-Redacted artifacts may be retained independently of originals, subject to their own retention schedule. The engine must track the lifecycle of each artifact and enforce automated deletion at expiry.
+These five answers are the minimum standard for audit-defensible automation in
+regulated contexts. A system that can answer some but not all of them places the
+unanswered questions on the human operator, who must then maintain external records to
+fill the gap. A system that answers all five places the explanation entirely within the
+artifact the auditor is already reviewing.
 
-### 5.3 Audit Logs
+## 7. Retention Semantics
 
-Audit log retention must be configurable separately from content retention. Regulatory frameworks often require audit records to be retained for longer periods than the underlying data (e.g., seven years for HIPAA, six years for SOX). Audit logs must never be deleted before their configured retention period expires, regardless of content deletion status.
+The runtime persists detection and redaction artifacts indefinitely by default. There
+is no built-in expiration, no time-to-live, no automatic purge. This is intentional:
+retention policy is a regulatory and contractual question that varies by jurisdiction,
+industry, data category, and data subject. A runtime that imposes retention defaults
+imposes opinions that may conflict with the operator's obligations.
+
+What the runtime does provide is a clear separation between retention scopes. Raw
+content has a separate retention scope from redacted content, which has a separate
+retention scope from audit records. A deployment that wishes to delete raw content
+after seven days while retaining audit records for seven years can do so without
+sacrificing the audit trail's integrity, because the audit record refers to the raw
+content by identifier rather than by inclusion. Deleting the raw content does not
+invalidate the audit; it simply means the original input is no longer available for
+re-examination, while the record of what was decided about it remains.
+
+Retention enforcement, including legal-hold overrides that prevent deletion of
+otherwise expired records, is a deployment-side concern. The runtime exposes the
+boundaries; the deployment enforces the policy.
+
+## 8. What Is Intentionally Not in Scope
+
+The runtime deliberately does not include the following:
+
+**Regulatory templates.** No preconfigured policy for HIPAA, GDPR, PCI, or any other
+regime is shipped with the runtime. Users author their own policies. The reason is
+that a regulatory template is a legal interpretation, and legal interpretations
+require legal authorship. A runtime that ships a "HIPAA policy" invites operators to
+treat it as a legal opinion, which it cannot be.
+
+**Cryptographic audit-log tamper-evidence.** Hash-chained, signed, or
+write-once-read-many storage of audit records is achievable, but it is a property of
+the storage layer, not the producer. The runtime emits records; the deployment chooses
+where to put them. A deployment that requires tamper-evidence pairs the runtime with
+append-only storage and a hash-chain or signing layer.
+
+**Reviewer workflows.** Human-in-the-loop review, queue management, reviewer
+assignment, escalation, and adjudication are user-interface concerns belonging to a
+downstream product. The runtime exposes the decision points; the product builds the
+workflow around them.
+
+**Forward-secret retention.** Key rotation, cryptographic erasure, and forward
+secrecy for reversible operators depend on key management practices that vary by
+deployment. The runtime does not assume a key lifecycle.
+
+The runtime takes the position that bolting these capabilities in would make the
+boundary between general-purpose primitives and product-specific assumptions
+disappear, leaving a component that is neither a clean primitive nor a complete
+product. The boundary as drawn is intentional.
+
+## 9. Architectural Commitments
+
+To support the guarantees above, the runtime makes four architectural commitments that
+an auditor can rely on without inspecting the implementation:
+
+**Decisions are deterministic.** Given the same detection artifact, the same policy,
+and the same set of overrides, the same decisions are produced. Replay is exact.
+Non-determinism, where it exists, is confined to the detection stage and is exposed in
+the audit record so that a re-detection producing different evidence is visible as
+such.
+
+**Audit records reference the immutable detection artifact.** The question "what was
+the input to this decision" always has a definite answer, because the decision is
+expressed against an artifact that is not rewritten after the fact. Detection happens,
+the artifact is sealed, and decisions reference the sealed artifact.
+
+**Reversibility is a first-class operator property.** Every operator declares whether
+it is reversible. A policy author selecting an operator selects a reversibility
+posture as part of that choice, and the auditor sees the posture in the record.
+Reversibility is not an afterthought attached to operators that happen to support it.
+
+**Suppressed redactions are still recorded.** A rule that matches an entity but
+prescribes no rewrite still produces an audit record. The absence of a rewrite is
+itself a decision, and the runtime records it as such. An auditor reading the trail
+sees not only the entities that were redacted but also the entities that were
+deliberately allowed through, with the rule that permitted them.
+
+These commitments together describe what the runtime guarantees to any layer above it.
+They are the surface against which an audit is conducted.

--- a/docs/DETECTION.md
+++ b/docs/DETECTION.md
@@ -1,89 +1,297 @@
-# Sensitive Data Detection
+# Detection: A Conceptual Model
 
-## 1. Overview
+## Abstract
 
-The detection engine is the core intellectual property of the platform. It is responsible for identifying sensitive content across all supported modalities with high precision and recall. Detection must operate through multiple complementary strategies: deterministic pattern matching, learned models, and computer vision, to achieve robust coverage across diverse content types and regulatory categories.
+This paper describes the conceptual architecture of a system for identifying
+sensitive data spans inside heterogeneous documents. The system is designed
+around the observation that no single recognition technique is adequate across
+all categories of personally identifiable information (PII), all content
+encodings, and all confidence regimes. Multiple recognizer families run in
+parallel against decomposed document fragments; their findings are lifted into
+a shared coordinate system and reconciled through a deterministic
+deduplication pipeline; annotations and policy rules then shape the surviving
+candidates into the final detection artifact consumed by redaction.
+Implementation details are out of scope.
 
-## 2. Language Coverage
+## 1. The Detection Problem
 
-The platform must support detection across multiple languages and writing systems. Real-world data frequently contains non-English text, multilingual documents, and code-switched content (multiple languages within a single document or conversation). Detection models must handle at minimum the major European languages, CJK (Chinese, Japanese, Korean), and Arabic script. Deterministic patterns must be parameterized by locale: national identifier formats, date conventions, and address structures vary by jurisdiction.
+Sensitive data detection is the task of locating spans of content that
+constitute personally identifiable information within a document of arbitrary
+structure. The problem is harder than it first appears because three axes vary
+independently:
 
-For audio, speech-to-text and subsequent NER must support the same language set, including language identification and mid-utterance language switching.
+- **Category heterogeneity.** PII is not a single class. Email addresses,
+  telephone numbers, government identifiers, financial account numbers,
+  biometric references, medical history, geolocation traces, and free-form
+  references to private third parties all qualify. Each category has its own
+  surface form, its own jurisdictional variants, and its own contextual cues.
 
-## 3. Deterministic Detection
+- **Encoding heterogeneity.** The same logical document can present its
+  contents as plain prose, as cells in a spreadsheet, as text regions inside a
+  raster image, as transcribed segments of an audio recording, as metadata
+  attached to a binary asset, or as fragments embedded in a structured
+  archive. A telephone number in a CSV cell is the same datum as a telephone
+  number spoken in an interview, but the detection paths leading to them are
+  not.
 
-Deterministic methods provide high-precision, low-latency detection for well-defined patterns:
+- **Confidence heterogeneity.** Different recognition techniques produce
+  fundamentally different confidence semantics. A regular expression with a
+  checksum is either correct or incorrect; the probability mass concentrates
+  at the extremes. A neural sequence tagger emits a smooth distribution
+  centered on a soft decision boundary. A generative model produces an answer
+  whose calibration is opaque. Treating these signals as commensurable
+  requires care.
 
-- **Regular expressions**: Pattern matching for structured identifiers such as Social Security numbers, credit card numbers, passport numbers, and other nationally defined formats.
-- **Checksum validation**: Algorithmic verification (e.g., Luhn algorithm for credit card numbers) to reduce false positives from pattern matching alone.
-- **Custom pattern libraries**: User-defined pattern sets that extend detection to organization-specific sensitive categories such as internal project identifiers, proprietary terms, or custom reference numbers.
+A detection system that ignores any of these axes will fail in production.
 
-## 4. Machine Learning and NLP-Based Detection
+## 2. Pluralistic Recognition
 
-Learned models address the detection of sensitive content that cannot be captured by fixed patterns:
+The central design commitment is pluralism: the system runs a population of
+recognizers concurrently and treats each as a hypothesis-generator rather than
+an authority. Three families dominate the population.
 
-- **Named entity recognition (NER)**: Identification of person names, locations, organizations, and other entity types in unstructured text.
-- **Domain-specific entity models**: Specialized models trained on financial data, medical records (HIPAA-relevant entities), legal identifiers, and biometric references.
-- **Contextual detection**: Inference of sensitivity from surrounding context rather than explicit entity presence. Phrases such as "the patient" or "my lawyer" may indicate sensitive content even in the absence of a named entity. This capability requires models that reason over discourse context rather than isolated tokens.
+### 2.1 Rule-Based Recognition
 
-## 5. Computer Vision Detection
+Rule-based recognizers combine pattern matching with deterministic validators
+and curated dictionaries. A regular expression establishes a candidate span; a
+validator (checksum verification, structural conformance, range checking)
+filters out coincidental matches; a dictionary lookup confirms membership in a
+known set (country codes, common first names, area codes). Rule-based
+recognition has high precision when the rule is well-formed, near-zero
+latency, and very low recall outside the patterns it codifies. It cannot find
+what it has not been told to look for.
 
-Visual content requires detection methods that operate on pixel-level and spatial features:
+### 2.2 Statistical Recognition
 
-- **Face detection and recognition**: Identification of human faces in images for subsequent obfuscation.
-- **Document and identifier detection**: Recognition of identity documents, license plates, and other visual identifiers.
-- **Handwritten text detection**: Extraction and analysis of handwritten content in scanned documents and images.
-- **Screen capture analysis**: Detection of sensitive text rendered in screenshots, application windows, and other digital captures.
+Statistical recognizers are sequence-labeling models trained on annotated
+corpora. They consume extracted text and emit entity spans with associated
+class probabilities. They generalize beyond a closed set of patterns and
+capture entities whose surface form is irregular (person names, organization
+names, free-form addresses) but their behavior is bounded by the distribution
+of their training data. They are noisy near class boundaries and at the
+edges of supported languages, and they are sensitive to domain shift.
 
-## 6. Audio Detection
+### 2.3 Generative Recognition
 
-Audio content introduces temporal and speaker-level dimensions to detection:
+Generative recognizers prompt a large language model to enumerate entities
+within a fragment. They are valuable for categories that resist both rule
+authorship and supervised training: open-class identifiers, paraphrased
+references to sensitive attributes, contextual mentions ("the patient," "my
+attorney"). They are the most expensive recognition path and the least
+calibrated. Their utility is highest where the other families are weakest.
 
-- **Transcript-based NER**: Application of named entity recognition to speech-to-text output, with alignment back to audio timestamps.
-- **Direct waveform redaction**: Replacement of sensitive audio segments with silence, tones, or noise at the waveform level.
-- **Speaker-specific redaction**: Selective redaction of content from identified speakers while preserving contributions from others, enabled by speaker diarization.
+### 2.4 No Dominant Strategy
 
-## 7. Policies
+None of these families subsumes the others. Each has a precision-recall
+profile shaped by its operating principle. The system does not elect a winner:
+it runs the families in parallel and defers the question of which finding to
+keep to a later stage that has access to all the evidence at once.
 
-Detection is governed by policies: declarative rule sets that define what to detect and how to handle it. A policy is the primary configuration surface through which administrators, compliance officers, and integrators express redaction intent without modifying detection code.
+```
+                          document
+                              |
+                  +-----------+-----------+
+                  |           |           |
+              rule-based  statistical  generative
+              recognizer  recognizer   recognizer
+                  |           |           |
+                  +-----------+-----------+
+                              |
+                       candidate set
+```
 
-### 7.1 Policy Structure
+## 3. Chunking and Lifting
 
-A policy is a named, versioned collection of rules. Each rule specifies:
+Documents are not scanned end-to-end. They are first decomposed into chunks:
+paragraphs in prose, cells in tabular content, regions in images, segments in
+audio. Chunking bounds the working set for any single recognizer invocation,
+preserves locality so recognizer outputs remain interpretable, and exposes
+structural context to the recognition layer (a tabular header can inform
+interpretation of the cells beneath it).
 
-- **What to detect**: An entity type, pattern, or semantic category (e.g., "SSN", "face", "medical diagnosis").
-- **Detection parameters**: Confidence thresholds, locale constraints, and any modality-specific settings.
-- **Redaction action**: The redaction method to apply when the rule matches (mask, blur, replace, or suppress).
-- **Additional context**: Free-form or structured metadata attached to a rule that provides guidance to downstream stages: a justification string, a regulatory citation, or instructions for human reviewers.
+Each recognizer reports its findings in coordinates local to the chunk it
+inspected: a character offset within a paragraph, a pixel offset within an
+image region, a millisecond offset within an audio segment. The system lifts
+these local coordinates back into the source document's coordinate system.
+Lifting is mechanical but essential: redaction acts on the original document
+and must locate every finding inside it, irrespective of which chunk produced
+the evidence.
 
-### 7.2 Annotations
+## 4. Modality Boundaries
 
-Files submitted for processing may carry annotations: either provided by the user at submission time or attached as part of a broader context (e.g., a case management system that tags documents with classification labels). Annotations can include:
+Recognition is organized by the *nature of the payload* presented to a
+recognizer, not by the modality of the source document. Text recognizers
+operate on textual payloads, regardless of whether the text came from a prose
+paragraph, a spreadsheet cell, an OCR pass over an image region, or a
+transcription pass over an audio segment. This factoring prevents
+combinatorial duplication of recognizer logic across modalities and ensures
+that improvements to a text recognizer benefit every upstream extraction
+path.
 
-- **Pre-identified regions**: Bounding boxes, text spans, or time ranges that the submitter has already marked as sensitive, bypassing or supplementing automated detection.
-- **Classification labels**: Document-level or region-level labels (e.g., "contains PHI", "attorney-client privileged") that influence which policy rules apply.
-- **Exclusion markers**: Regions or entities explicitly marked as non-sensitive, instructing the detection engine to skip them.
+The recognizer population is also open across modalities. Adding a native
+image recognizer that emits bounding-box findings, or a native audio
+recognizer that emits time-interval findings, does not perturb the existing
+text recognizers; the new recognizer is registered alongside the existing
+ones and contributes evidence on the same terms. The registry is a fan-out
+point, not a closed taxonomy.
 
-The detection engine must consume annotations as first-class inputs alongside its own detection results, merging user-provided and machine-generated findings into a unified annotation set before redaction.
+## 5. Deduplication and Conflict Resolution
 
-## 8. Pipeline State and Metadata
+The parallel evaluation of many recognizers against the same content produces
+a redundant candidate set. The same entity is often discovered by multiple
+recognizers; spans frequently overlap rather than coincide; class labels
+sometimes disagree. A layered reconciliation pipeline reduces this to a
+disjoint, deduplicated set of findings.
 
-Each document entering the detection pipeline is wrapped in an envelope that carries both the decoded document content and the original content metadata (MIME type, filename, source path, and arbitrary key-value pairs). This metadata is preserved from ingestion through every detection and redaction stage.
+### 5.1 Threshold Filtering
 
-Metadata availability during detection enables format-aware and context-aware decisions. For example, a detection rule might apply different confidence thresholds to `.csv` files than to freeform text, or a custom metadata tag attached at upload (e.g., `"department": "legal"`) might activate additional detection policies. Detection operations access this metadata directly from the pipeline envelope without re-reading the original content from storage.
+The first layer applies a confidence floor. Candidates below a category- and
+recognizer-specific threshold are discarded. This is not noise rejection in
+the signal-processing sense; it is a policy decision about the precision-
+recall tradeoff appropriate for the deployment. Thresholds are tunable and
+auditable.
 
-## 9. Detection Orchestration
+### 5.2 Overlap Resolution
 
-Individual detection strategies: deterministic, ML-based, vision, and audio, must be composed into a coherent pipeline rather than operating in isolation.
+The second layer resolves spatial conflicts. When two findings cover
+overlapping spans (in text: overlapping character ranges; in images:
+intersecting bounding boxes; in audio: overlapping time intervals), the
+higher-confidence finding is preserved and the lower-confidence finding is
+suppressed. Class agreement is not required: a generic name detection that
+overlaps a more specific identifier detection yields to the latter.
 
-### 9.1 Tiered Execution
+### 5.3 Fusion
 
-Detection should proceed in tiers ordered by cost and specificity. Deterministic patterns (regex, checksums) execute first, providing high-precision results at minimal computational cost. ML and vision models execute subsequently, targeting content that deterministic methods cannot address. This tiered architecture avoids unnecessary GPU inference for content that can be resolved through pattern matching alone.
+The third layer fuses *concurring* evidence. When multiple recognizers report
+the same span and the same category, the system merges them into a single
+finding whose confidence reflects the agreement of independent sources and
+whose provenance records every contributing recognizer. Fusion is not a
+simple maximum or average; it acknowledges that a rule-based hit and a
+statistical hit on the same span are stronger evidence than either alone.
 
-### 9.2 Result Merging
+```
+       raw candidate set
+              |
+              v
+     +------------------+
+     | threshold filter |  drop confidence < tau
+     +------------------+
+              |
+              v
+     +------------------+
+     | overlap resolve  |  keep highest-confidence span
+     +------------------+
+              |
+              v
+     +------------------+
+     |     fusion       |  merge concurring evidence
+     +------------------+
+              |
+              v
+       surviving entities
+```
 
-When multiple detection strategies identify overlapping or adjacent sensitive regions within the same content, the platform must merge results into a unified set of detection annotations. Overlapping detections should be consolidated rather than duplicated. Each merged annotation must retain provenance: which strategies contributed to the detection and at what confidence level.
+Order matters. Threshold filtering before overlap resolution prevents
+low-confidence findings from displacing high-confidence ones. Overlap
+resolution before fusion prevents fusing across categories. The pipeline is
+deterministic given the same inputs.
 
-### 9.3 Conflict Resolution
+## 6. Annotations: Ground Truth and Overrides
 
-When detection strategies disagree (for example, a regex match identifies a number as a credit card while an NER model classifies the surrounding context as non-sensitive), the platform must apply configurable conflict resolution rules. Default behavior should favor the higher-confidence or higher-sensitivity classification, but administrators must be able to override this through policy.
+User-supplied annotations are first-class participants in detection, not a
+separate workflow. They enter at two levels of authority.
+
+A **hint** marks a span as likely sensitive, biasing detection toward
+confirming the annotation but allowing recognizers to overrule it. Hints
+amplify noisy upstream beliefs about sensitivity without dictating outcomes.
+
+An **assertion** marks a span as known to contain a specific entity. It
+materializes directly as a finding with maximum confidence, bypassing
+recognizer evaluation for that span. Assertions are how authoritative
+knowledge (a human reviewer's verdict, an audited upstream tag) enters
+detection.
+
+Symmetrically, **exclusions** mark spans that must not appear as findings.
+Exclusions are applied as a final filter, removing any recognizer output
+that falls within an excluded region. Exclusions are how users correct false
+positives without retraining models or rewriting rules.
+
+## 7. Policy Filtering
+
+Detection identifies what is *present*. Policy decides what is *actionable*.
+The separation is intentional. The set of entities in a document is a
+property of the document; the set of entities subject to redaction in a
+given workflow is a property of the workflow.
+
+Policy is expressed as an ordered sequence of rules. Each rule conditions on
+attributes of the candidate finding (category, recognizer confidence,
+language, surrounding labels) and on attributes of the document (source,
+classification labels attached by upstream systems, jurisdiction). The first
+rule whose conditions are satisfied determines the disposition of the
+candidate: retain, suppress, or annotate. Subsequent rules do not fire for
+the same candidate.
+
+This formulation has two consequences worth naming. First, the same
+detection artifact can be filtered by different policies to produce
+different actionable sets, supporting per-tenant or per-context redaction
+without re-running detection. Second, policy authorship is auditable in
+isolation: a reviewer can read the rule set and understand which entities
+will be acted on without understanding how detection found them.
+
+## 8. The Detection Artifact
+
+The output of detection is an immutable record of every entity that survived
+the pipeline. Each entry carries:
+
+- a typed category;
+- a position expressed in source-document coordinates;
+- a confidence value derived from the contributing recognizers;
+- a provenance trail naming every recognizer that contributed evidence and
+  what evidence it contributed;
+- any annotations attached by upstream systems or by the policy layer.
+
+The artifact is the contract between detection and redaction. It is
+serializable, inspectable, and replayable. A redaction pass consumes the
+artifact and acts on the source document; it does not re-run detection. A
+later audit can reconstruct exactly which recognizers fired on which spans
+with which confidence, without access to the model weights or the rule
+internals at the time of the original run.
+
+The immutability of the artifact is what makes detection an *evidentiary*
+operation rather than an opaque transformation. Every decision can be
+attributed; every absence can be questioned.
+
+## 9. Limitations and Honest Gaps
+
+Detection accuracy is bounded by the accuracy of its constituent recognizers.
+Rule-based recall is bounded by the rule set: an identifier format the rules
+do not encode will not be found by rule. Statistical recall is bounded by
+training data: an entity class underrepresented in the corpus will be
+underdetected, and domain shift between training and deployment degrades
+performance silently. Generative recall is bounded by the model: hallucinated
+entities and missed entities are both possible, and the confidence the model
+assigns to its own output is not necessarily informative.
+
+The system does not promise zero leakage. It promises that detection is
+pluralistic, that evidence is reconciled deterministically, that annotations
+participate as first-class signals, that policy is separable from
+recognition, and that the resulting artifact is auditable. These are
+engineering invariants, not statistical guarantees. A deployment that
+requires statistical guarantees must measure them on its own data and tune
+its recognizer population, thresholds, and policy accordingly.
+
+The architecture is open at every layer where recall can fail: recognizers
+can be added, rules extended, models replaced, policies rewritten. The closed
+surfaces are the ones that must be stable: the chunking and lifting model,
+the deduplication pipeline, the artifact format. Stability in the contracts
+is what allows pluralism in the recognizers.
+
+## 10. Summary
+
+Detection is the parallel evaluation of many fallible recognizers against a
+chunked decomposition of a document, followed by deterministic reconciliation
+of their findings, followed by a policy projection onto the actionable
+subset. Annotations participate throughout. The product is an immutable,
+attributable record of every entity the system believes is present. The model
+is conservative about what it guarantees and generous about what it allows to
+be extended.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,71 +1,200 @@
-# Developer Experience
+# Extensibility: A Conceptual White Paper
 
-## 1. Overview
+## 1. Extensibility as a Design Axis
 
-Platform adoption scales with developer experience. Organizations evaluate redaction platforms not only on detection accuracy but on how quickly they can integrate the platform into existing systems, automate workflows, and extend capabilities to meet domain-specific requirements.
+The system is not a monolith with optional knobs. It is a composition of three pluggable subsystems, each addressing a distinct concern in the privacy pipeline:
 
-## 2. Core Interfaces
+- **Codecs** determine which formats the system understands.
+- **Recognizers** determine which categories of sensitive entities it detects.
+- **Operators** determine how those entities are transformed once detected.
 
-### 2.1 REST API
+These three surfaces are orthogonal. Adding a recognizer does not require changes to any codec. Adding an operator does not require changes to any recognizer. Adding a codec does not change the contract that recognizers and operators see. The independence is structural, not aspirational: each surface is a registry of contracts, and the pipeline composes contracts at runtime rather than embedding a fixed set of capabilities at compile time.
 
-The runtime exposes a REST API through the server layer for content submission, pipeline execution, run management, and result retrieval. The API is the primary integration surface.
+This paper describes the three extension surfaces as conceptual contracts. It is not an API reference. The reader will leave with a model of what an extension is, what it must provide, what the system provides in return, and where the boundaries of the model lie. Build mechanics, repository layout, and the contribution workflow live in the project's contribution guide; they are deliberately omitted here.
 
-API versioning must follow a clear strategy (URI-based or header-based) with documented deprecation timelines. Breaking changes must not be introduced without a major version increment and a migration period.
+The intended audience is twofold. The first reader is an engineer evaluating whether the system can be extended to a particular use case — a new document format, a regulatory category not yet covered by the default recognizers, an in-house redaction policy. The second reader is a designer interested in the extension surfaces themselves, perhaps to compare against alternative architectures. The paper is written so that neither reader requires familiarity with the codebase; the architectural argument is meant to stand on its own.
 
-### 2.2 SDKs
+```
+                     +---------------+
+                     |   Pipeline    |
+                     +-------+-------+
+                             |
+        +--------------------+--------------------+
+        |                    |                    |
+   +----v-----+        +-----v-----+        +-----v-----+
+   |  Codec   |        | Recognizer|        |  Operator |
+   | (format) |        |  (detect) |        | (transform)|
+   +----------+        +-----------+        +-----------+
+        ^                    ^                    ^
+        |                    |                    |
+   "what bytes         "what entities       "what happens
+    we can read"        we can find"         to them"
+```
 
-Official client libraries for Python and JavaScript (at minimum) should wrap the REST API with idiomatic interfaces, type safety, and built-in error handling. SDKs are maintained as separate packages outside the runtime repository.
+Each surface answers one question. The questions do not overlap, and that is the property the architecture exists to preserve.
 
-### 2.3 Authentication and Rate Limiting
+A useful frame: the pipeline is a producer–consumer chain in which a codec produces handles for recognizers and operators to consume, recognizers produce detections for operators to consume, and operators produce mutations for the codec to consume on the way back out. The three surfaces are arranged around this chain, each at a distinct seam. An extension joins the system by attaching at one seam and only at that seam; it does not reach across the chain to influence the others.
 
-Authentication and rate limiting are provided by the surrounding infrastructure (see [INFRASTRUCTURE.md](INFRASTRUCTURE.md) Section 4.2). The runtime accepts an authenticated actor identity with each request. Rate limiting should be enforced per client and per tenant by the API gateway or reverse proxy layer.
+The implication for someone evaluating the system is direct. The cost of an extension is bounded by the surface it inhabits. A new entity category is cheap because the surface is narrow. A new format is expensive because the surface is wide. The architecture does not equalize these costs — it names them, and it ensures that the wide cost of one surface never silently leaks into the narrow cost of another.
 
-### 2.4 Webhooks and Events
+## 2. The Format Extension Surface
 
-An event-driven notification system should allow consumers to subscribe to processing lifecycle events (content ingested, detection complete, redaction applied) without polling. Webhook delivery is the responsibility of the surrounding infrastructure; the runtime emits lifecycle events that an external service can relay.
+A format extension teaches the system how to read and write a new content type. It is the most invasive of the three surfaces because it touches the deepest contract: the representation of content as a typed handle that the rest of the pipeline operates on.
 
-## 3. Tooling
+A new format is defined by two complementary contracts:
 
-### 3.1 CLI
+- A **decoder** consumes a raw byte stream and produces a typed handle suitable for downstream operations.
+- An **encoder** consumes a (possibly mutated) handle and produces a byte stream that can be persisted or returned.
 
-The `nvisy-cli` crate provides a command-line interface for common operations: starting the server, submitting content, querying run status, and downloading results. The CLI wraps the REST API and is suitable for scripting, automation, and developer workflows.
+The handle is not a passive container. It must support four behaviors that the pipeline relies on:
 
-### 3.2 Sample Policies and Synthetic Data
+1. **Streaming chunking.** The handle yields its content as a sequence of chunks. Large inputs are never required to fit in memory in full.
+2. **Random-access reads.** A chunk can be revisited; recognizers that need to look backward or forward are not forced to buffer.
+3. **In-place mutation.** When an operator decides to replace a region, the handle accepts the replacement without requiring the caller to reconstruct the document.
+4. **Coordinate lifting.** A region detected inside a chunk carries chunk-local coordinates. The handle must translate these into source-level coordinates that survive across reads, mutations, and re-encoding.
 
-A library of sample redaction policies (see [REDACTION.md](REDACTION.md) Section 3) and a synthetic data generator should be available to accelerate development and testing. Developers should be able to exercise the full pipeline against realistic but non-sensitive data without access to production content.
+The format extension registers itself under a stable identifier and a set of lookup keys: file extensions, media types, and any other discriminator the deployment uses to route content. Resolution at decode time is registry-driven.
 
-## 4. Configuration
+The contract acknowledges a trade-off. For formats with byte-level structure — plain text, delimited tabular data, line-oriented logs — the contract is straightforward: source coordinates and byte coordinates align, and mutations replay through encode without surprises. For deeply-parsed formats — structured markup, office documents, container formats — source-byte fidelity is unavoidably lost. The handle is the source of truth; the original bytes are not reconstructable after encode. The system documents this rather than pretending otherwise.
 
-### 4.1 Runtime Configuration
+A format extension is the only surface that must engage with all four handle behaviors. The remaining surfaces consume the handle and never construct it.
 
-The engine accepts a TOML-based runtime configuration that controls subsystem behavior: LLM provider selection, OCR settings, speech-to-text parameters, and engine-level tuning (channel buffer sizes, parallelism limits). Configuration is structured into discrete sections for each subsystem, with clear separation between engine-level settings and provider-specific settings.
+A second consequence follows from this asymmetry. Because the handle abstraction is the contract every downstream component sees, a format extension is the only place where misimplementation can corrupt every other component's view of the world. A recognizer that reports the wrong offset misredacts one detection. A handle that lifts coordinates incorrectly misredacts every detection that flows through it. The system mitigates this with a coordinate-lifting contract that is small in surface but precise in semantics; the burden on the format author is to honor that contract under all chunking strategies the author chooses to implement.
 
-### 4.2 Configuration Validation
+```
+   raw bytes  --decoder-->  handle  --encoder-->  raw bytes'
+                              |
+                              +-- streaming chunking
+                              +-- random-access reads
+                              +-- in-place mutation
+                              +-- coordinate lifting
+```
 
-Before a pipeline executes, the runtime configuration is validated to catch structural errors early: empty API keys, invalid buffer sizes, and other constraint violations. Validation errors are surfaced as structured error messages identifying the specific field and constraint that was violated.
+The diagram is not incidental. The handle is the durable artifact across the pipeline's lifetime; the bytes on either side are transient.
 
-### 4.3 Environment Variable Resolution
+## 3. The Recognizer Extension Surface
 
-API keys and other secrets can be injected from environment variables rather than stored in configuration files. When a configuration field is empty, the engine checks a corresponding environment variable before rejecting the configuration. This supports deployment patterns where secrets are managed through infrastructure (Kubernetes secrets, CI/CD variables) rather than config files.
+A recognizer answers a single question: given a region of content, what entities does it contain? It is, in conceptual terms, a function from a payload to a set of detections, where each detection carries:
 
-### 4.4 Per-Request Overrides
+- a **kind** (the category of entity discovered, drawn from an open vocabulary),
+- a **provenance** (where it came from in the source coordinates),
+- a **confidence** (how strongly the recognizer asserts the finding).
 
-Each pipeline execution can include configuration overrides that are merged with the base runtime configuration. Overrides replace entire sections: they do not partially merge individual fields within a section. This allows callers to adjust provider selection, model parameters, or feature flags on a per-request basis without modifying the persistent configuration.
+Recognizers are typed by modality — a text recognizer cannot be applied to tabular content and vice versa — but new recognizers can be added without modifying the registry's definition. The registry is an open type-map keyed by the modality's identity. The system does not need to know in advance how many recognizers will eventually be registered, nor what they detect; at pipeline time it fans detection out across every registered recognizer that applies and unions the results.
 
-## 5. Advanced Capabilities
+This surface is the least invasive of the three. A pattern-driven recognizer for a new entity category — a regional identifier number, a domain-specific token — is implementable in isolation. The author writes the detection logic, declares the entity kinds it produces, and registers it. There is one system-level obligation: the recognizer must honor the chunk-relative coordinate contract. A detection reported at the wrong offset will be redacted in the wrong place; the system cannot detect this for the author.
 
-### 5.1 Risk Scoring
+Recognizers that depend on external inference — named-entity recognition models, language models, classifiers backed by remote services — are subject to the same contract. The recognizer is the abstraction; how it produces its answers is opaque to the registry.
 
-Documents and datasets should be scored by aggregate privacy exposure level, enabling organizations to prioritize review effort and allocate resources toward the highest-risk content.
+Because the registry is open and the fan-out is parallel, the cost model for adding a recognizer is additive rather than multiplicative. Two recognizers detecting overlapping kinds do not interfere: the union of their detections is reconciled by the pipeline, not by the recognizers. This is the basis on which a deployment can stack a high-precision pattern-driven recognizer alongside a high-recall model-driven recognizer for the same category, without either author needing to be aware of the other.
 
-### 5.2 Smart Redaction Suggestion
+The contract leaves one judgment to the recognizer: confidence calibration. The system uses confidence to reconcile competing detections; a recognizer that reports an over-confident answer will dominate, and a recognizer that under-reports will be ignored. The architecture does not normalize confidence across recognizers, and it makes no claim to. The judgment is a deployment concern, expressed in the recognizers the deployment chooses to register.
 
-Rather than applying maximal redaction, the engine should be capable of suggesting the minimal set of redactions required to satisfy a given regulatory standard. This preserves data utility while meeting compliance obligations.
+The cost model for this surface is the architectural payoff of the paper. A new recognizer is conceptually a single function, registered against the entity kinds it asserts. There is no protocol negotiation, no compatibility table, no lifecycle hook beyond registration. This is the surface to reach for first when a deployment asks how the system can be tailored.
 
-### 5.3 Semantic Redaction
+## 4. The Operator Extension Surface
 
-Beyond named entity redaction, the engine should support redaction of semantic categories: references to rare diseases, specific legal proceedings, or proprietary methodologies, that carry sensitivity not through the presence of a specific identifier but through their meaning in context.
+An operator takes a detection and returns a replacement. It is the surface that determines what redaction actually looks like.
 
-### 5.4 Synthetic Data Replacement
+Operators, like recognizers, are typed by modality. They are registered against the entity kinds they handle. A new operator — a tokenizer that produces stable pseudonyms for a particular entity category, a hash-based blinder for a class of identifiers, a generator that produces realistic synthetic substitutes — implements the per-modality replacement contract and declares which kinds it serves.
 
-Rather than replacing sensitive content with black bars or placeholder tokens, the engine should support replacement with realistic synthetic alternatives: generated names, addresses, dates, and other values that preserve the statistical and structural properties of the original data while eliminating re-identification risk.
+Two operator dispositions are first-class:
+
+- **Irreversible.** The replacement discards information; the original cannot be recovered. Masking, deletion, and one-way hashing fall in this category.
+- **Reversible.** The operator participates in a paired protocol, registering both as the forward transform and as its inverse. Shared state — a vault, a deterministic key, a mapping table — is the operator's responsibility, not the pipeline's. The pipeline guarantees that the inverse, when invoked, sees the same registry and the same content shape as the forward pass.
+
+The pipeline does not adjudicate between dispositions. An operator declares what it is, and the deployment configures which operators apply to which kinds. The registry composes; the pipeline executes.
+
+An additional property is worth naming: operators are pure with respect to the handle. They observe a detection, they emit a replacement, and the handle applies the replacement. They do not mutate the handle directly. This separation is what makes operators substitutable. A deployment can swap a masking operator for a tokenizing operator for a given entity kind, and the pipeline composes the change without any downstream coordination. The handle is the single mutator; operators describe mutations rather than performing them.
+
+A consequence for reversible operators is worth surfacing. Because forward and inverse share state but not control flow — they are independent registrations — the operator author owns the state's lifecycle. The pipeline does not provide a vault, a key store, or a mapping table; it provides the seams at which such things attach. This is a deliberate refusal: state management for reversible redaction is a security-sensitive concern, and the system does not presume a one-size policy for it.
+
+## 5. The Modality Boundary
+
+The three extension surfaces are open. The set of modalities they range over is not.
+
+Modalities — text, tabular, image, audio — form a closed set in the current architecture. Each modality has its own coordinate space, its own notion of what a chunk is, its own definition of what a redactable region looks like. The modality identity participates in the type system: registries are keyed by it, contracts are parameterized by it, and the compiler enforces that a recognizer or operator written for one modality cannot be misapplied to another.
+
+This is a deliberate trade-off. Adding a fifth modality is not a plug-in operation. It is a workspace-wide change: a new coordinate type, a new chunk contract, new operator contracts, new format handlers, and updates to every component that pattern-matches on the modality set. The system buys type-safety invariants — the impossibility of routing image bytes through a text operator — at the cost of extensibility along this axis.
+
+The cost is real and is named here rather than glossed over. Deployments that need a modality outside the closed set will not find a quick path. The judgment underlying the closed set is that the type-system guarantees pay for themselves across the rest of the surface area, where extension is plentiful and safe.
+
+```
+   open extension axes          closed axis
+   ------------------          --------------
+   codecs:        many         modalities:
+   recognizers:   many             text
+   operators:     many             tabular
+   backends:     several           image
+                                   audio
+```
+
+The contrast is the central architectural fact of the system. The open axes are where day-to-day extensibility lives. The closed axis is where the type system enforces global coherence. A reader weighing whether the system fits their use case should map the use case onto this contrast: extensions that align with the open axes are routine; extensions that cross the closed axis are projects.
+
+## 6. Pluggable Inference Backends
+
+Recognizers that depend on machine inference — entity-recognition models, language models, speech-to-text, optical recognition — abstract over the source of inference behind a backend interface. The recognizer asks; the backend answers; the recognizer interprets.
+
+The consequence is that a deployment can change the inference substrate without changing detection logic. A site that migrates from one language-model provider to another, or replaces a hosted model with an on-premise inference server, or substitutes one entity-recognition model for another, updates configuration and not code. The system ships with backends for common deployments. These are defaults, not requirements; a deployment is free to supply its own.
+
+The backend interface is itself an extension surface, narrower than the three principal surfaces but governed by the same principle: the system commits to a contract, the deployment supplies an implementation, and the registry mediates.
+
+The narrowness is intentional. A backend is a leaf: it does not see the pipeline, it does not see the registry, it does not see other backends. It sees only the requests its recognizer sends and the answers it returns. This isolation is what makes a backend swap safe. The site of substitution is small enough to reason about; the contract is small enough to verify. A deployment that needs to comply with data-residency constraints can choose backends accordingly without auditing the rest of the system.
+
+## 7. What the Architecture Does Not Promise
+
+Honest description requires naming what extensibility does not mean here.
+
+- **There is no no-code extension surface.** Adding a format, a recognizer, or an operator requires writing code in the host language. The system does not offer a configuration-driven path for any of the three surfaces, and there is no plan to introduce one.
+- **There is no runtime loading of extensions.** All extensions are compiled into the binary. A deployment that needs a new extension produces a new binary. This is the cost of the type-system guarantees that the rest of the architecture is built on.
+- **There is no backwards-compatibility guarantee across major contract revisions.** The system reserves the right to evolve the extension contracts. Extensions written against an earlier major version are expected to update. Deprecation cycles for minor changes exist; soft-deprecation paths across major boundaries do not.
+
+These are trade-offs, not oversights. Each is a deliberate exchange of one form of flexibility for one form of predictability.
+
+The honest framing is that the architecture optimizes for deployments that own their build pipeline and can produce binaries. A deployment that must consume third-party plug-ins drawn from an open ecosystem at runtime is not the deployment the system is designed for. A deployment that builds, tests, and ships a curated set of extensions as part of its operational practice is exactly the deployment the system is designed for. Prospective adopters should locate themselves on this spectrum before judging the trade-off.
+
+## 8. The Extension Lifecycle
+
+An extension proceeds through four stages, regardless of which surface it inhabits.
+
+```
+   identify  -->  contract  -->  register  -->  verify
+   "what is      "implement     "tell the      "pass the
+    this in      the required    registry       four gates"
+    the          interface"      it exists"
+    system's
+    vocabulary?"
+```
+
+1. **Conceptual identification.** The author names what the extension is in the system's vocabulary. Is it a new format — a new way of representing content? A new recognizer family — a new class of entity to detect? A new operator category — a new transformation to apply? The answer determines the surface.
+
+2. **Contract implementation.** The author implements the contracts the chosen surface requires. The contracts are not negotiable. The pipeline depends on them being honored; failures here propagate.
+
+3. **Registration.** The extension is registered with the appropriate registry during startup. Registration is explicit. The system does not discover extensions implicitly; what is not registered does not exist as far as the pipeline is concerned.
+
+4. **Verification.** The system runs a four-gate verification across every change: build, lint, the unit and integration test suite, and documentation. An extension is not optional with respect to these gates. They apply equally to first-party and third-party code, and they apply equally to the pipeline's core and to any extension added to it.
+
+The lifecycle establishes that extensions are first-class members of the system. They are not afterthoughts attached to a frozen core; they are how the system grows.
+
+Two properties of the lifecycle are worth emphasizing for a prospective extension author. First, the four gates are symmetric: the same gates that the system applies to its own internals apply to extensions, with no second-class status for either. There is no internal-only test suite that an extension is exempt from, and there is no relaxed lint posture for newly added code. Second, the gates are pre-merge, not post-merge. The system does not accept code that fails a gate on the promise of a follow-up fix. The intent is that the main line of the codebase is, at every commit, in a shippable state — extensions included.
+
+## 9. The Contributor Compact
+
+The system carries conventions that govern how it evolves. They are not specific to extension authors, but extension authors inherit them.
+
+- **Conditional compilation is minimized.** Code paths branch on configuration, not on compile-time switches, except in narrow cases where the alternative is worse.
+- **There are no soft-deprecation paths inside the codebase.** An extension is present and supported, or it is removed. Half-removed code is not a stable state.
+- **Suppressed warnings are not tolerated.** The build is clean. Warnings are addressed; they are not silenced. An extension that requires suppression has, in the project's judgment, not yet been written correctly.
+- **Documentation moves with code.** A contract change without a corresponding documentation change fails verification. Documentation is part of the build, not adjacent to it.
+
+These conventions are stylistic. They are not gates intended to discourage contribution. They are the form discipline takes here, and the form the codebase will continue to take. An extension that respects them inherits the system's stability guarantees; one that does not will be reshaped until it does.
+
+There is a deeper reason for the compact. The system runs in environments where privacy guarantees are operationally consequential — a redaction that silently fails has real cost. The conventions are not aesthetic preferences imported from elsewhere; they are the codebase's defense against the class of bug that a redaction system is least equipped to tolerate. An extension that lowers the standard locally raises the operational risk globally. The conventions distribute the defense across every line of code, including code that has not been written yet.
+
+## 10. Closing Note
+
+Extensibility in this system is local where it can be — codecs, recognizers, operators — and global where the type system insists — modalities. The architecture trades freedom along one axis for safety along three others. The contracts are sharp on purpose; the registries are open on purpose; the modality boundary is closed on purpose.
+
+The reader evaluating the system should take away three claims. First, that the surfaces are independent, and that this independence is structural rather than nominal. Second, that the modality boundary is the one place the independence breaks down, and that the system is candid about the cost. Third, that the verification and convention apparatus around extensions is uniform: extensions are not second-class. Together, these claims define the system the prospective contributor will be working with.
+
+A reader who has reached this point should have a working model of where the system invites extension, where it does not, and what the cost of each invitation is. The detail of any particular contract is a matter for the corresponding interface documentation; the conceptual map is the contribution of this paper.

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -1,93 +1,246 @@
-# Infrastructure
+# Deployment Architecture
 
-## 1. Overview
+## Abstract
 
-The regulated industries that require multimodal redaction: healthcare, legal, government, and financial services, impose stringent requirements on where and how data is processed. This document describes the surrounding infrastructure and services that should accompany the runtime in production deployments.
+This paper describes the deployment shape of the runtime and the boundary
+between concerns the runtime owns and concerns the surrounding deployment must
+provide. It is intended for platform engineers evaluating the system for
+production use. The treatment is conceptual: it addresses the structure of the
+artifact, the persistence model, the external dependencies the runtime may
+acquire, and the operational primitives it exposes. Specifics of any particular
+hosting environment are out of scope.
 
-## 2. Deployment Models
+## 1. Deployment Philosophy
 
-The runtime is deployment-agnostic. The surrounding infrastructure determines which model applies:
+The runtime ships as a single self-contained binary with embedded storage. It
+does not require a separate database, message broker, or coordination service.
+A working installation is a process and a data directory.
 
-- **Cloud-hosted**: Managed deployment in the vendor's infrastructure.
-- **VPC deployment**: Installation within the customer's own virtual private cloud, ensuring data never leaves their network boundary.
-- **On-premises**: Full deployment on customer-owned hardware for organizations with strict data sovereignty requirements.
-- **Air-gapped**: Operation without network connectivity, required by certain government and defense use cases. The runtime supports local-only provider configurations for this model.
-- **Edge processing**: Lightweight deployment at the point of data capture.
+This is a deliberate choice rather than an incidental one. Privacy-sensitive
+systems benefit from minimizing the number of components that handle, observe,
+or could be compelled to surrender sensitive material. Every additional
+dependency is a potential side channel: a log line in a database server, a
+message queue that retains payloads briefly, a coordination service that
+participates in routing decisions. Each of these expands the trust surface that
+must be reasoned about, audited, and defended.
 
-### 2.1 Architecture
+The runtime accepts a corresponding constraint: it trades horizontal scale-out
+inside the runtime itself for trust-surface simplicity. A deployment that needs
+to spread load across multiple machines does so by running multiple independent
+runtime instances, each owning its own state, and sharding work at the
+application layer. The runtime does not coordinate among instances.
 
-The runtime is API-first, supporting both batch and streaming processing modes. All capabilities are accessible programmatically through the server layer, enabling integration into existing enterprise workflows without dependence on a dedicated user interface.
+This trade-off is suitable for the class of workloads the runtime is designed
+for. It is not suitable for workloads that require shared mutable state across
+machines.
 
-## 3. Performance and Scale
+## 2. Process Model
 
-### 3.1 Workload Requirements
+A deployment unit is one process. The process exposes a network interface for
+programmatic access and reads from and writes to a local data directory for
+persistent state. There is no separate worker tier, no auxiliary daemon, and no
+sidecar requirement.
 
-The runtime must handle workloads that span orders of magnitude in volume and latency sensitivity:
+Concurrency within the runtime is asynchronous: many requests are in flight
+inside a single process, scheduled cooperatively. Concurrency across processes
+is not provided by the runtime. A deployment that requires multiple instances
+must arrange for inputs to be partitioned externally, and each instance owns its
+partition exclusively.
 
-- Large document sets (thousands to millions of PDFs)
-- Long-form audio files
-- Real-time stream redaction with sub-second latency targets
-- Concurrent processing across multiple tenants or projects
+The process is restartable without ceremony. State that must survive a restart
+lives in the data directory; everything else is reconstructed at startup.
 
-### 3.2 Scaling
+## 3. State and Persistence
 
-The surrounding infrastructure handles horizontal scaling: multiple runtime instances can process independent workloads concurrently without coordination beyond shared storage. GPU acceleration should be provisioned for ML inference workloads where throughput or latency requirements exceed CPU capacity.
+The runtime persists three categories of state.
 
-### 3.3 Cost Optimization
+**Content.** The raw bytes of ingested material, retrievable by a stable
+identifier. Content is the largest category by volume and the most sensitive by
+nature.
 
-The runtime optimizes processing cost by routing content through the appropriate detection tier. Simple deterministic pattern matches do not incur the computational cost of ML inference. The tiered processing architecture (regex first, ML models only when deterministic methods are insufficient) reduces cost without sacrificing detection coverage.
+**Decisions.** The detection and redaction artifacts produced by the processing
+pipeline: what was found, where, with what confidence, and what transformation
+was applied. Decisions are the audit substrate of the system.
 
-### 3.4 Content Storage
+**Operational metadata.** Policies, annotations, retention configurations, and
+similar control-plane state. This category is small in volume but
+high-consequence: it governs how content and decisions are produced and how
+long they are kept.
 
-The runtime stores content in a registry backed by an embedded key-value store. Raw content bytes and descriptive metadata are persisted in separate storage keyspaces, enabling independent access patterns: metadata lookups do not require reading the full content payload, and content retrieval includes metadata reconstruction automatically.
+All persistent state lives in an embedded ordered key-value store colocated
+with the process. The three categories occupy separate logical keyspaces. This
+separation is load-bearing: retention policies, encryption choices, and access
+patterns differ between categories, and a shared keyspace would entangle them.
 
-When content is registered, the registry eagerly detects the MIME type from magic-byte signatures and persists it as part of the metadata. This ensures that format detection signals survive the storage round-trip, even for content where magic bytes are the only available detection method.
+The store assumes exclusive ownership of its data directory. Running two
+processes against the same data directory is unsupported and will produce
+undefined behavior. Backup procedures must respect this invariant: a consistent
+backup is one taken against a quiesced process or via a snapshot mechanism that
+the store explicitly supports.
 
-Content is addressed by a composite key of actor identity and content source identifier, providing natural tenant isolation at the storage layer.
+## 4. External Dependencies
 
-## 4. Security
+Most of the runtime is self-contained. Two recognition modes optionally extend
+the system with capabilities that exceed what a single process can reasonably
+host, and these are treated as deployment-side dependencies rather than runtime
+internals.
 
-### 4.1 Data Protection
+**Named-entity recognition.** An offline model served by an external inference
+server. The server is a separate process, typically on a separate machine with
+hardware suited to model inference. The runtime communicates with it over the
+network and tolerates its absence.
 
-Given that the runtime processes the most sensitive data an organization holds, security must be foundational rather than additive:
+**Generative recognition.** A large language model accessed over an API. This
+may be a hosted service or a self-operated endpoint. The runtime treats the
+endpoint as opaque: it sends prompts and consumes responses.
 
-- **Encryption at rest**: Content stored in the registry supports AES-256-GCM encryption via a pluggable key provider interface. The runtime integrates with external key management systems (AWS KMS, Azure Key Vault, HashiCorp Vault) through the key provider abstraction.
-- **Encryption in transit**: The surrounding infrastructure must terminate TLS for all external API communication (reverse proxy, load balancer). The runtime does not terminate TLS itself.
-- **Zero-retention processing**: The runtime supports a zero-retention mode in which content is discarded from the registry immediately after pipeline execution completes.
-- **Ephemeral compute**: The surrounding infrastructure may provision ephemeral environments (containers, serverless) where the processing environment is destroyed after each job. The runtime is designed to operate in this model.
+Neither dependency is required for the runtime to function. Pattern-based
+recognition operates without either. Deployments that require named-entity or
+generative recognition provision the corresponding services and configure the
+runtime to use them. The runtime adapts to whatever is available; the absence
+of an optional dependency disables the corresponding capability but does not
+prevent startup.
 
-### 4.2 Access Control
+This pattern preserves the single-binary philosophy: the runtime itself does
+not embed model weights or inference engines, and the operational complexity
+of running such services remains where it belongs, with the platform team.
 
-The surrounding infrastructure must provide access control services:
+## 5. Observability
 
-- **Role-based access control (RBAC)**: Fine-grained permissions governing who can configure policies, submit content, and access audit logs.
-- **Single sign-on (SSO) and SCIM**: Integration with enterprise identity providers for authentication and automated user provisioning.
-- **Data residency controls**: Configuration to ensure that content is processed and stored only within specified geographic regions.
+The runtime emits structured tracing throughout its execution. Trace targets
+follow a uniform hierarchical convention that mirrors the system's internal
+structure, so deployments can filter traces at any level of granularity: an
+entire subsystem, a specific stage of the pipeline, or a single operation.
 
-The runtime accepts an authenticated actor identity with each request and enforces tenant isolation at the storage and pipeline level based on that identity. It does not implement authentication or authorization logic itself.
+The runtime also exposes a health endpoint that aggregates the status of each
+subsystem the deployment should care about: the embedded store, the network
+interface, and any configured inference dependencies. The endpoint reports
+which subsystems are healthy, which are degraded, and which are unreachable. A
+deployment's orchestration layer consumes this endpoint to drive readiness and
+liveness checks.
 
-## 5. Multi-Tenancy
+Beyond these primitives, observability is a deployment concern. Log
+aggregation, metric collection, dashboarding, alerting, and incident routing
+are provided by the surrounding platform. The runtime makes no assumptions
+about which tools are used and emits its tracing in a form that standard
+collectors can consume.
 
-### 5.1 Tenant Isolation
+## 6. At-Rest Encryption
 
-The runtime enforces tenant isolation at the data layer: content, metadata, and audit records are keyed by actor identity, ensuring that no actor can access another actor's data. The surrounding infrastructure is responsible for compute isolation (dedicated or partitioned processing resources per tenant) and API-layer tenant scoping.
+Encryption of stored content is optional and entirely deployment-driven. The
+runtime exposes a contract for an opaque key provider; a deployment that
+requires at-rest encryption implements that contract using whatever key
+management system, hardware security module, or rotation policy is appropriate.
+The runtime itself does not manufacture, store, or rotate keys.
 
-### 5.2 Tenant-Specific Configuration
+The runtime does not retain long-lived keys in process memory. A key is held
+only for the duration of a single request, then released. This limits the
+blast radius of a process compromise and aligns the runtime's behavior with
+the principle that secret material lives in the deployment's key custody
+infrastructure, not in the application that consumes it.
 
-Each pipeline execution accepts its own configuration (provider selection, model parameters, policies). The runtime does not maintain persistent per-tenant configuration; this is managed by the calling service and passed per-request.
+Deployments that do not require at-rest encryption omit the key provider
+entirely; content is stored in cleartext within the data directory, and the
+deployment relies on filesystem-level protections instead.
 
-## 6. Observability
+## 7. Compression
 
-### 6.1 Metrics
+Compression of stored content is similarly optional. When enabled, content is
+compressed before persistence and decompressed transparently when the pipeline
+reads it back. The choice of algorithm is deployment-configurable; the runtime
+treats the codec as a pluggable component.
 
-The runtime must expose operational metrics covering ingestion throughput, detection latency, redaction processing time, queue depth, error rates, and resource utilization. Metrics must be available in a format compatible with standard monitoring systems (Prometheus, OpenTelemetry, or equivalent).
+Compression is a cost optimization, not a security feature. It interacts with
+at-rest encryption in the usual order: compress first, then encrypt.
 
-### 6.2 Distributed Tracing
+## 8. The Runtime / Deployment Boundary
 
-Each piece of content carries a trace identifier through every stage of the pipeline: ingestion, detection, redaction, and export. Distributed tracing enables operators to diagnose latency bottlenecks, identify failed processing stages, and correlate events across services.
+This section is the conceptual core of the paper. Privacy systems fail in
+production most often not because of defects in the runtime but because the
+boundary between runtime and deployment was implicit, and concerns landed on
+the wrong side of an unspoken line. The boundary is therefore stated
+explicitly.
 
-All tracing events use explicit, hierarchical target names following the convention `<crate>::<module>::<submodule>` (e.g. `nvisy_engine::op::import_file`, `nvisy_codec::transform::text`). This enables precise per-module log filtering in production without relying on log levels alone.
+| Concern | Owned by Runtime | Owned by Deployment |
+|---|---|---|
+| Detection, redaction, audit | yes | |
+| Format decoding, encoding, lifting | yes | |
+| Registries of recognizers, operators, policies | yes | |
+| Embedded persistence layer | yes | |
+| Network interface for programmatic access | yes | |
+| Structured tracing and health reporting | yes | |
+| Authentication of callers | | yes |
+| Authorization of operations | | yes |
+| Transport encryption (TLS termination) | | yes |
+| Backup and disaster recovery | | yes |
+| Multi-tenant isolation enforcement | | yes |
+| Log shipping and metrics aggregation | | yes |
+| Provisioning of inference services | | yes |
+| Key management and rotation | | yes |
+| Quota enforcement and rate limiting | | yes |
+| Capacity planning and horizontal sharding | | yes |
 
-### 6.3 Alerting
+The runtime exposes actor-scoped namespaces in its persistence and processing
+layers, so the deployment can pass an identity through and have the runtime
+keep state separated accordingly. The runtime does not verify the identity; it
+trusts the network edge to have done so. A deployment that fails to
+authenticate at the edge effectively grants every caller every identity.
 
-The surrounding monitoring infrastructure should consume the runtime's metrics and tracing data to trigger alerts on operational anomalies: elevated error rates, processing latency exceeding thresholds, queue backpressure, model inference failures, and storage capacity warnings. Alerts should be deliverable through standard channels (email, webhook, PagerDuty, or equivalent).
+This division is the load-bearing assumption of the architecture. Mixing the
+two sides — for instance, expecting the runtime to enforce identity, or
+expecting the deployment to manage detection policies — produces systems that
+are neither secure nor maintainable.
+
+## 9. Scaling
+
+The runtime scales vertically. Additional cores and memory allow more
+concurrent requests within a single process. The asynchronous execution model
+makes this effective up to the limits of the host.
+
+The runtime does not scale horizontally in the conventional sense. The
+embedded store assumes single-writer semantics: exactly one process owns a
+given data directory at a time. A deployment that exceeds the capacity of a
+single instance runs multiple instances, each with its own data directory, and
+partitions inputs at the application layer such that any given identity is
+served by a single instance.
+
+This is a deliberate trade-off. A single-writer architecture eliminates entire
+classes of concurrency bugs — distributed deadlocks, partial-failure
+reconciliation, split-brain conditions — that would otherwise be present in
+the data path of a privacy system. The cost is that scale-out requires
+deployment-level sharding logic. The benefit is predictability: the runtime
+behaves the same way under load as it does in isolation, and there is no
+hidden coordination protocol that can degrade in ways the deployment cannot
+observe.
+
+For workloads where this trade-off is unacceptable, the runtime is the wrong
+choice and a different system should be selected.
+
+## 10. What the Architecture Does Not Provide
+
+In the interest of accuracy, the following capabilities are explicitly out of
+scope. A deployment that needs them must build them around the runtime.
+
+- Cluster coordination among multiple runtime instances.
+- Multi-region failover or active-active replication.
+- Replicated storage at the persistence layer.
+- Service mesh integration beyond what a standard network client provides.
+- Pre-built container images, orchestrator manifests, or installation
+  automation tailored to specific platforms.
+- A user interface; all interaction is programmatic.
+- Identity provisioning, directory integration, or federated authentication.
+
+These omissions are not oversights. Each represents a category of
+functionality that varies substantially across deployments and that, if
+embedded in the runtime, would force a particular operational model on
+adopters that may not suit their environment. They belong in the layer that
+already encodes the deployment's choices about networking, identity, and
+orchestration.
+
+## 11. Closing
+
+The runtime is a process with a data directory and a network interface. The
+deployment is everything else. Drawing that line cleanly is the precondition
+for operating the system with confidence. The runtime is built on the
+assumption that the deployment will draw it; this paper exists so that
+assumption is shared.

--- a/docs/INGESTION.md
+++ b/docs/INGESTION.md
@@ -1,115 +1,299 @@
-# Ingestion & Transformation
+# Document Ingestion in a Multimodal PII System
 
-## 1. Overview
+## Abstract
 
-The ingestion layer is responsible for accepting content from heterogeneous sources and normalizing it into a unified internal representation suitable for downstream detection and redaction. The transformation layer handles the inverse concern: producing redacted output in the appropriate format while preserving the structural integrity of the original document.
+A privacy system is, before anything else, a decoder. Detection models and
+redaction policies operate on structured representations of content; the world
+delivers content as opaque byte streams in dozens of incompatible formats.
+Ingestion is the layer that bridges the two: it accepts heterogeneous bytes,
+resolves them to a typed representation that detection can address, mediates
+the mutation that redaction performs, and re-emits bytes in the original format
+without losing fidelity. This paper describes the conceptual model that governs
+ingestion in our runtime. We treat formats not as a catalogue but as instances
+of a single abstraction — the typed handle — and we describe the coordinate
+systems, mutation contract, and round-trip guarantees that hold across the
+abstraction.
 
-The quality of the ingestion layer is a critical success factor. Redaction platforms that cannot reliably parse and extract content from real-world documents — scanned forms, embedded tables, multi-speaker audio — will produce incomplete redaction results regardless of the sophistication of their detection models.
+## 1. The Ingestion Problem
 
-## 2. Supported Input Formats
+Every input to a privacy system arrives as a sequence of bytes paired with a
+claim about what those bytes mean. The system must produce, from that pair, a
+representation against which detection can operate and into which redaction
+can write. The difficulty is that no two formats agree on what either of those
+operations means.
 
-The platform must support ingestion across multiple modalities. Formats are organized into tiers reflecting implementation priority and expected coverage at each stage of the product lifecycle.
+A plain-text file encoded in UTF-8 differs from the same text in UTF-16 not
+just at the byte level but in the unit of indexing a recognizer must use.
+A structured document hides its strings behind escape sequences, so the text a
+recognizer sees is not the text the file contains. Markup languages resolve
+entity references and decode attribute values, presenting the recognizer with
+a view that may have no direct byte correspondence to the source. Delimited
+text formats negotiate quoting rules whose details depend on a dialect. Images
+speak in pixel coordinates; audio speaks in time. Each format also disagrees on
+what counts as a redactable unit: a span of characters, a scalar value, a
+rectangle in pixel space, a half-open interval of audio samples.
 
-### Tier 1: Core (launch requirement)
+Ingestion is the discipline of generalising over these formats without erasing
+them. A naive approach would coerce everything into one common type — say, a
+string of characters — and lose the formats on the way in. The result would be
+a system that detects names in a word-processing document but cannot produce a
+word-processing document back. A correct ingestion layer keeps the format
+present from the moment bytes arrive to the moment bytes leave.
 
-These formats represent the most common inputs in regulated enterprise environments and must be supported at general availability:
+## 2. The Content Bundle
 
-- **PDF**: Native (digitally authored) and scanned, including multi-page documents with mixed content (text, images, tables, forms).
-- **Images**: JPG, PNG, and TIFF: the dominant formats for scanned documents, photographs, and screenshots.
-- **Plain text and markup**: TXT, HTML, and Markdown.
-- **Structured data**: CSV and JSON.
-- **Office documents**: DOCX, XLSX, PPTX.
-- **Audio**: WAV, MP3, and other common audio formats.
+Content does not arrive as a single object. It arrives as several orthogonal
+facets that the system keeps separate on purpose:
 
-### Tier 2: Extended (near-term)
+```
+                            content
+                               |
+        +----------+-----------+-----------+----------+
+        |          |           |           |          |
+      bytes     descriptor   digest      record    (future)
+        |          |           |           |
+      raw       caller-       system-    system-
+      data      supplied      computed   derived
+      +         metadata      metadata   metadata
+      stable    (claimed      (hashes    (storage
+      source    format,       for        time,
+      id        filename,     dedup,     derived
+                source path)  integrity) attributes)
+```
 
-These formats are frequently encountered in enterprise workflows and should be supported shortly after launch:
+The split is not cosmetic. Each facet has a different trust level and a
+different lifecycle. Raw bytes are immutable: they are what was uploaded.
+Descriptor metadata is caller-supplied and may be wrong — by accident or
+otherwise. Digest metadata is computed by the system from the bytes themselves
+and is authoritative. Record metadata captures processing facts the system
+knows but the caller could not have known — when the content entered the
+system, what derived attributes the pipeline later attached.
 
-- **Email**: EML and MSG formats, including inline content and attachments (recursively ingested).
-- **Communications**: Chat log exports from Slack, Teams, and WhatsApp.
+Merging these facets would corrupt them. A caller who misreports a format
+could overwrite a system-computed integrity hash; a system-derived attribute
+could be confused with caller intent. Keeping the facets separate keeps the
+trust boundaries legible: at any later stage, the pipeline can ask whether a
+fact came from the caller or from the system, and treat it accordingly.
 
-### Tier 3: Specialized (roadmap)
+## 3. Format Detection
 
-These formats address long-tail use cases in specific verticals or operational contexts:
+Detection is the act of choosing which decoder to apply to a stream of bytes.
+The system resolves format identity by consulting signals in priority order:
 
-- **Archival and compound formats**: ZIP, TAR, and other container formats with recursive extraction of enclosed files.
-- **Domain-specific**: DICOM (medical imaging), GeoTIFF (geospatial), and other vertical-specific formats as demand dictates.
+```
+   caller MIME hint  ->  filename extension  ->  content-type heuristics
+        (1)                    (2)                       (3)
+```
 
-## 3. Extraction Capabilities
+The caller's explicit hint takes priority. If the upload arrived through a
+request with a content-type header, or through a programmatic interface that
+named the format, that claim wins. When no hint exists, the filename
+extension is consulted. When neither is available, a small set of
+content-derived heuristics fills the gap.
 
-Each modality requires specialized extraction techniques:
+The runtime does not perform deep magic-byte sniffing. This is a deliberate
+design choice with a real cost. Deployments that need probabilistic format
+detection — accepting uploads from end users who provide no metadata, for
+instance — must add a sniffer upstream. Inside the runtime, format identity
+is treated as supplied: the system decodes according to what it was told.
+The tradeoff is precision for predictability. A runtime that re-identifies
+formats can disagree with the caller about what was uploaded, and that
+disagreement becomes a class of bug that does not exist when the caller is
+authoritative.
 
-- **Optical character recognition (OCR)**: Layout-aware OCR that preserves spatial relationships between text regions, table cells, headers, and form fields.
-- **Speech-to-text**: Transcription with speaker diarization, enabling attribution of spoken content to individual speakers.
-- **Entity identification in images**: Detection and localization of entities within images: faces, persons, objects, text regions, documents, and other identifiable elements, producing bounding boxes or segmentation masks that downstream detection and redaction stages can operate on.
-- **Document structure parsing**: Identification of semantic document elements: headings, paragraphs, tables, lists, and form fields, beyond raw text extraction.
-- **Metadata extraction**: Capture of authorship, timestamps, geolocation, and other embedded metadata that may itself constitute sensitive information.
+## 4. The Typed Handle
 
-## 4. Transformation & Output
+Once decoded, content is no longer a byte stream; it is a typed handle whose
+type encodes both the format and the modality. The handle is the central
+abstraction of the ingestion layer, and every downstream stage operates
+through it.
 
-Following redaction, the transformation layer must produce output that meets downstream requirements while maintaining fidelity to the original format.
+A handle exposes five capabilities:
 
-### 4.1 Format Preservation
+1. **Streaming chunking.** The handle yields redactable units in document
+   order. A unit may be a span of text, a value in a structured document, a
+   region of an image, a segment of audio. The chunker streams units as the
+   recognizer requests them, without materialising the entire decoded view.
+2. **Random-access retrieval.** Given a coordinate, the handle returns the
+   unit at that coordinate, supporting stages that revisit units out of
+   document order.
+3. **In-place mutation.** Redaction does not rewrite the handle from scratch;
+   it mutates the units the recognizer identified. Mutation is addressed by
+   coordinate and confined to the units the policy named.
+4. **Re-encoding.** The handle serialises itself back to bytes in the same
+   format as the input.
+5. **Coordinate lifting.** Given an offset in the decoded view a recognizer
+   saw, the handle returns the corresponding offset in the source bytes.
 
-Redacted output should preserve the structural characteristics of the source document. Tables must remain aligned, page layouts must be maintained, and non-redacted content must remain unaltered.
+The handle's type is parameterised on the modality. Downstream code that
+holds a handle does not need to ask what kind of content it carries; the
+type already encodes it, and a routine written for text handles cannot
+accept an image handle by mistake.
 
-### 4.2 Output Formats
+## 5. Modality Boundaries Within a Document
 
-The primary output of the transformation layer is a redacted file in the same format as the input — a PDF produces a redacted PDF, an image produces a redacted image, and so on. The platform must not alter the source format unless explicitly requested.
+Some formats produce a homogeneous decoded view: a plain-text file decodes to
+text, an image file decodes to an image, an audio file decodes to audio. Many
+real-world formats do not. A word-processing document combines text with
+embedded images and inline comments. A markup page mixes textual body content,
+attribute values, embedded scripts, and structural markup, each with its own
+redaction semantics.
 
-In addition to the format-preserving primary output, the platform should produce supplementary outputs that serve downstream workflows:
+The system models a mixed handle as a heterogeneous stream of redactable
+items. Each item carries with it both the kind of unit it represents and the
+knowledge of how to write a mutated value back at encode time. A text span
+knows how to substitute its replacement into the appropriate container slot;
+an image region knows how to overwrite its pixel range; an attribute value
+knows how to escape itself back into a markup attribute. The recognizer
+addresses items by kind; the encoder delegates to each item's own write-back
+logic.
 
-- **Redaction metadata (JSON)**: A structured manifest describing every redaction applied: entity type, location, triggering rule, confidence score, and reviewer disposition. This metadata enables programmatic consumption of redaction results by audit systems, analytics pipelines, and downstream integrations.
-- **Masked structured data (CSV/JSON)**: For tabular or structured inputs, a masked variant in which sensitive cell values are replaced according to the active masking strategy, suitable for analytics or data science consumption.
-- **Anonymized datasets**: Fully de-identified exports intended for secondary use (model training, statistical analysis) where no re-identification pathway should exist.
+Modality is a per-item property, not a per-document property. A single handle
+can yield a text item, then an image item, then another text item, in
+document order, and each is handled by the recognizer appropriate to its
+modality.
 
-### 4.3 Masking Strategies
+## 6. The Decode-Redact-Encode Loop
 
-Multiple masking strategies should be available, selected according to the use case:
+The lifecycle of content inside the ingestion layer is a single loop:
 
-- **Tokenization and pseudonymization**: Replacement of sensitive values with consistent tokens that preserve referential integrity across documents.
-- **Reversible masking**: Vault-based masking where original values can be recovered by authorized parties through a secure key exchange.
-- **De-identification with re-linking key**: Removal of direct identifiers with a separately stored mapping that enables re-identification under controlled conditions.
+```
+   bytes
+     |
+     v
+   decode  --->  typed handle  --->  chunker  ---+
+                       ^                          |
+                       |                       items
+                       |                          |
+                   mutations                      v
+                       |                     recognizer
+                       |                          |
+                       |                       findings
+                       |                          |
+                       |                          v
+                       |                       lift to
+                       |                       source
+                       |                       coords
+                       |                          |
+                       +--------------------------+
+                       |
+                       v
+                   re-encode
+                       |
+                       v
+                    bytes
+```
 
-## 5. Content Model
+The handle is decoded once. The chunker streams items into the recognizer,
+which identifies sensitive regions in the decoded view. The lifter translates
+those regions from decoded coordinates back to source coordinates. The policy
+stage decides what to do with each finding, and mutations are applied to the
+handle in source coordinates. The encoder serialises the mutated handle back
+to format-native bytes. There is no second decode pass and no separate write
+phase: the handle is the medium through which decoding, recognition, and
+re-encoding communicate.
 
-The internal content representation separates raw data from descriptive metadata. This separation is fundamental to reliable format detection and pipeline execution.
+## 7. The Encode Round-Trip Contract
 
-### 5.1 Content Data and Metadata
+Re-encoding has a two-clause contract.
 
-Each piece of ingested content is represented as a `Content` bundle consisting of two parts:
+First, untouched units serialise byte-for-byte where the format permits. For
+formats whose parsers preserve a verbatim view of the source — plain text and
+structured formats where unmodified regions are kept as raw slices — the
+encoder copies untouched bytes directly. The output of a document with no
+mutations is byte-identical to the input.
 
-- **Content data**: The raw bytes and a unique source identifier. Content data carries no descriptive information: it is opaque binary or text.
-- **Content metadata**: All descriptive attributes that accompany the content: the caller-supplied MIME type, the auto-detected MIME type (from magic-byte signatures), the original filename, the source path, and an extensible key-value map for arbitrary metadata.
+Second, touched units serialise their mutated value through format-aware
+write-back. A text replacement is escaped according to the format's rules. A
+redacted image region is composited into the output pixel buffer. An audio
+segment is replaced in the sample stream.
 
-This separation ensures that descriptive information is never lost during storage and retrieval. The registry persists data and metadata in separate storage keyspaces; when content is reconstructed for pipeline execution, both halves are reunited into a complete bundle.
+Some formats cannot satisfy the first clause completely. Markup languages and
+rich word-processing formats discard structural information during parsing —
+attribute ordering, whitespace between tags, default values left implicit.
+For these formats, re-encoding necessarily re-parses and re-serialises the
+source, producing output that is semantically equivalent but not byte-identical
+to the input. The system makes this tradeoff explicit per format rather than
+silently degrading round-trip fidelity across the board.
 
-### 5.2 Format Detection
+## 8. Coordinate Systems and Lifting
 
-Format detection determines the document type (text, image, audio, PDF, spreadsheet, etc.) and drives decoder selection. Detection evaluates multiple signals in priority order:
+The recognizer and the encoder do not speak the same coordinate language. A
+recognizer sees the decoded payload of a chunk: escape sequences resolved,
+percent-encoding decoded, content extracted from containers, character
+encodings normalised. Its offsets index into that decoded view. The encoder
+must address the source. A mutation expressed in decoded coordinates would
+land on the wrong bytes — sometimes by a few characters, sometimes by an
+entire escape sequence, sometimes by a chunk boundary.
 
-1. **Caller-supplied MIME type** — highest priority. Set explicitly at upload time (e.g. from an HTTP `Content-Type` header). This is the only way to identify text formats that have no magic bytes.
-2. **Magic-byte detection** — automatic detection from binary signatures in the raw content. Reliable for binary formats (PNG, JPEG, WAV, PDF) but returns nothing for plain text.
-3. **Filename extension** — lowest priority. Used as a fallback when MIME type and magic bytes are inconclusive. When the MIME type identifies a broad category (e.g. `text/plain`) and the extension provides a more specific variant (e.g. `.log`), the extension refines the result.
+The lifting contract closes this gap. Given a decoded offset, the handle
+returns the corresponding source offset. The mechanism varies by format:
 
-Format detection occurs at decode time, not at upload. Metadata is persisted at upload so that all detection signals are available when the content is later processed.
+```
+   format class                lifting mechanism
+   --------------------------+-----------------------------------------
+   verbatim text             | identity (decoded offset == source)
+   escaped textual formats   | escape map walked at lift time
+   container/parsed formats  | item-index coordinates, not byte offsets
+```
 
-### 5.3 Metadata Through the Pipeline
+For verbatim text, the lift is the identity function. For formats with escape
+sequences, the handle maintains an escape map built during decode and walks
+it at lift time. For formats whose parsers discard byte-level structure, the
+lift cannot return a meaningful source offset; the system accepts that
+source-byte fidelity is lost and addresses items by structural index instead.
 
-Once content is decoded into a document, the original metadata is preserved on the pipeline envelope and flows through every processing stage — detection, fusion, policy evaluation, redaction, and export. This enables operations to make context-aware decisions based on the original filename, MIME type, or custom metadata without re-reading the raw content.
+The lifting contract allows recognizers to be format-agnostic. A recognizer
+for personal names does not need to know about escape sequences or entity
+references; it operates on decoded text and returns decoded offsets, and the
+handle is responsible for translating those into something the encoder can
+act on.
 
-## 6. Validation and Error Handling
+## 9. Compression and Encryption Boundaries
 
-Ingestion must account for real-world content that is malformed, incomplete, or unsupported.
+Some ingestion paths receive bytes that are not in their final form. Content
+may be compressed at rest or encrypted with a symmetric scheme. The pipeline
+decompresses and decrypts before decode, performs the decode-redact-encode
+loop on the cleartext, and may re-encrypt and re-compress before storage.
 
-### 6.1 Input Validation
+The runtime does not hold long-lived keys. Keys are supplied by a
+deployment-pluggable key provider, which the runtime calls at the moment a
+cleartext is needed. The provider can be backed by a hardware security
+module, a managed key service, or a process-local secret, as the deployment
+requires. The runtime sees cleartext only for the duration of the loop.
 
-Before processing begins, the platform must validate that submitted content meets minimum requirements: supported file format, non-zero size, and absence of corruption indicators. Invalid submissions must be rejected with actionable error messages that identify the specific validation failure.
+This boundary separates two threats. Threats against the keys are addressed
+by the provider's deployment. Threats against the cleartext during processing
+are addressed by the runtime's own memory hygiene. Conflating the two — for
+instance, by caching decrypted bytes in the runtime — would weaken both.
 
-### 6.2 Partial Extraction
+## 10. Persistence and Retrieval
 
-When a document is partially parseable — a multi-page PDF with a corrupt page, an audio file with a damaged segment, or an image with an unreadable region — the platform should extract what it can and flag the remainder as incomplete. Partial extraction results must be clearly annotated so that downstream detection operates only on successfully extracted content.
+Ingested content is persisted in a registry. The registry key is the source
+identifier paired with an actor scope, which provides multi-tenant isolation:
+two tenants may upload content with the same source identifier without
+colliding.
 
-### 6.3 Error Reporting
+Persistence stores the bundle's facets separately, matching the in-memory
+split. Retrieval reconstructs the bundle by reading each facet and
+reassembling them, so downstream stages receive the same bundle they would
+have received on first ingest. A pipeline that crashes mid-processing can
+restart from the persisted bundle; a re-detection after a policy update can
+read the bundle without asking the caller to re-upload; audit replays can
+reconstruct the exact bytes the pipeline processed.
 
-Every ingestion failure must produce a structured error record that includes the content identifier, the failure type (unsupported format, corrupt data, extraction timeout, codec unavailable), and the processing stage at which the failure occurred. These records must be available through the same audit infrastructure described in [COMPLIANCE.md](COMPLIANCE.md).
+## 11. Honest Scope
+
+The runtime supports a curated set of formats today. Some are full
+implementations with bidirectional decode-encode fidelity; some are present
+as stubs whose interfaces are stable but whose internals are incomplete. The
+architecture treats new format support as a plug-in concern: adding a format
+means implementing a decoder that produces a handle and an encoder that
+serialises one. Once both exist, the format is available to detection, to
+redaction, to persistence, and to every downstream stage without further
+changes.
+
+New formats require code. They do not require pipeline changes, schema
+migrations, or coordination across stages. This is the property the
+ingestion abstraction was designed to provide, and it is the property by
+which the abstraction should be judged.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,250 +1,434 @@
-# Pipeline: detection ↔ redaction split
+# The Two-Phase Pipeline
 
-Contract for the two-subsystem pipeline implemented by
-`nvisy-engine`. Detection produces an immutable artifact;
-redaction consumes that artifact, applies overrides, and writes
-output. The two are separate `Engine` methods and separate REST
-resources.
+## Abstract
 
-## Why two subsystems
+Automated removal of sensitive content from heterogeneous documents
+is conventionally treated as a single end-to-end transformation:
+bytes in, redacted bytes out. This document describes an
+alternative architecture in which the act of *identifying*
+sensitive content and the act of *acting on* it are realised as
+two distinct phases joined by an immutable, durable artifact. The
+two phases have different cost structures, different failure
+modes, and different review requirements. Coupling them, as a
+conventional one-shot pipeline does, forces the worst
+characteristics of each onto the other. Separating them yields a
+system in which detection can be cached, redaction can be reviewed
+before any byte is mutated, and failures localise to a single side
+of the boundary.
 
-Redaction without human review is a compliance liability in the
-domains the platform targets (healthcare, legal, finance).
-Running detection and apply as one atomic operation means a
-recogniser false-positive deletes real content with no
-opportunity to intervene. Splitting the pipeline lets a reviewer
-inspect the policy chain's decisions before any bytes move.
+## 1. Problem framing
 
-The split is also useful without a human: one detection can feed
-multiple redaction passes (preview with `Mask`, commit with
-`Fake`) without re-running NER.
+A redaction system performs two qualitatively different workloads
+back to back.
 
-## Surface
+The first workload is *recognition*. For each piece of input
+content, the system must enumerate every span, region, or interval
+that is sensitive — typically by composing rule-based matchers with
+statistical and generative models, often running expensive inference
+over images, audio, or long text. Recognition is computationally
+heavy, model-dependent, non-deterministic in the small, and
+characterised by tail-latency rather than throughput. A single
+document may pass through several recognisers; some may time out;
+some may produce overlapping or contradictory findings; all of them
+have measurable error rates.
 
-Two `Engine` methods. Two REST resources. No shared mode flag.
+The second workload is *application*. Given that a span of text or
+a region of an image is sensitive, the system must execute a
+transformation against it — masking, replacing, pseudonymising,
+blurring, silencing — and re-emit the document in its original
+format. This work is light on CPU but heavy on destructive writes:
+it permanently mutates content in a way that cannot be undone
+without re-deriving the document from the original. A wrong
+recognition decision propagated into application is observable only
+as missing or corrupted content.
+
+Bundling these workloads into a single operation couples failures
+that should fail independently. A transient recogniser timeout
+aborts the redaction. A misconfigured operator destroys content
+that recognition already correctly identified. A reviewer who
+notices a probable false positive has no opportunity to intervene;
+the bytes are already gone. Re-running on the same input re-incurs
+the cost of recognition even when only the operator policy
+changed. These problems are not specific to any particular
+implementation; they follow from treating recognition and
+application as a single atomic step.
+
+## 2. The two-phase split
+
+The architecture under discussion realises recognition and
+application as two distinct phases. Each is invoked separately;
+each produces a durable, addressable artifact; each can be observed
+and managed in isolation.
 
 ```
-Engine::detect(input: DetectionInput) -> Result<Uuid, Error>
-Engine::redact(input: RedactionInput) -> Result<Uuid, Error>
+                    +-----------------------+
+   raw content ---> |   DETECTION PHASE     |
+                    |  ingest -> extract    |
+                    |  -> recognise -> dedup|
+                    +-----------+-----------+
+                                |
+                                v
+                  +----------------------------+
+                  |   DETECTION ARTIFACT       |
+                  |  (immutable, addressable)  |
+                  |  - typed entity records    |
+                  |  - per-entity provenance   |
+                  |  - per-entity decision     |
+                  |  - stable entity ids       |
+                  +----+--------------+--------+
+                       |              |
+            overrides  |              |
+            (optional) v              v  (replay, n times)
+                  +-------------------------+
+                  |   REDACTION PHASE       |
+                  | resolve -> apply ->     |
+                  |   encode -> audit       |
+                  +-----+-------------+-----+
+                        |             |
+                        v             v
+                 rewritten        audit
+                 content          trail
 ```
 
+The artifact at the centre is the load-bearing element. It is
+typed, exhaustive over the recognised entity set, and never
+mutated in place. Each entry within it carries enough provenance
+to reconstruct, after the fact, which recognition strategy
+produced the entry, what confidence was assigned to it, and which
+decision rule selected the transformation that would be applied.
+
+Three properties of this split deserve explicit attention.
+
+**Replayability.** Because detection produces a durable artifact,
+the same recognition output can drive multiple application passes
+— one for previewing, another for archival, another for analytics —
+without re-paying the cost of recognition. The artifact also
+becomes a useful object in its own right: it can be compared
+across recogniser versions, measured for precision and recall, and
+shipped to a reviewer without exposing transformed content.
+
+**Reviewability before mutation.** Because application is a
+separate phase, the artifact can be inspected, modified, or
+partially rejected before any byte of underlying content has been
+touched. This is the difference between a compliance system that
+can defend its decisions and one that has already irreversibly
+acted on them. In regulated domains the former is a precondition
+for deployment.
+
+**Failure localisation.** Recogniser failure cannot corrupt
+content; application failure cannot poison the recognition cache.
+A failure in either phase is recoverable by retrying *that phase*
+against a known-good artifact at the boundary.
+
+The trade-off is honest: this architecture requires the system to
+manage more state. The detection artifact is a first-class entity
+with its own identity, lifecycle, retention policy, and access
+controls.
+
+## 3. Inside the detection phase
+
+The detection phase is itself a small pipeline. Conceptually it
+moves through four stages.
+
 ```
-POST   /detections                returns detection_id
-GET    /detections                lists actor's detections
-GET    /detections/{id}           returns DetectionSnapshot
-DELETE /detections/{id}           removes from store
-POST   /detections/{id}/cancel    cooperative cancel
-
-POST   /redactions                body references detection_id
-GET    /redactions                lists actor's redactions
-GET    /redactions/{id}           returns RedactionSnapshot
-DELETE /redactions/{id}           removes from store
-POST   /redactions/{id}/cancel    cooperative cancel
+   raw bytes
+       |
+       v
+  +----------+    +-----------+   +-------------+   +------------+
+  | INGEST   | -> | EXTRACT   |-> | RECOGNISE   |-> | DEDUPLICATE|
+  | (decode  |    | (OCR,     |   | (rule +     |   | (threshold,|
+  |  to a    |    |  ASR,     |   |  statistic +|   |  overlap,  |
+  |  typed   |    |  structure|   |  generative,|   |  fusion)   |
+  |  handle) |    |  parsing) |   |  in parallel|   |            |
+  +----------+    +-----------+   +-------------+   +------------+
+                                                          |
+                                                          v
+                                                  detection artifact
 ```
 
-## Detection (immutable artifact)
+**Ingestion** is format-specific decode. Heterogeneous input bytes
+(documents, images, audio, structured records) become typed
+in-memory handles. The handle's type encodes the modality;
+downstream stages can rely on that typing rather than re-inspecting
+raw bytes.
 
-A `DetectionResult` is the immutable outcome of one
-`Engine::detect` call. Once produced, it is never edited. Each
-`RedactionInput` references one detection by id; the same
-detection can be referenced by many redactions.
+**Extraction** derives a scannable payload from modalities where
+sensitivity exists in non-textual content but is most reliably
+identified in textual form: optical character recognition for
+images, transcription for audio, structure parsing for layout-rich
+documents. Extraction does not erase the original modality; the
+typed handle retains the underlying pixels or samples so that
+later phases can act on them.
 
-Persistence: detection results live in the registry under a
-dedicated keyspace (`detections_ks`), serialised as JSON. The
-in-memory `DetectionState` mirror is volatile and lost on
-process restart; reads after a restart hit the registry. The
-write at end of `Engine::detect` is the consistency point — a
-crash mid-detection produces no detection record, never a
-half-written one.
+**Recognition** is pluralistic and parallel. Multiple recognition
+strategies run side by side: deterministic patterns with checksum
+validation; statistical models for named entity recognition over
+text; generative models for context-sensitive identification;
+vision models for face and document detection. Each strategy
+operates over the appropriate payload (raw text, transcript,
+extracted layout, pixels, samples). Each emits candidate entities
+with a confidence score and a record of which strategy produced
+the candidate.
 
-The result carries the original `ImportFile` references. These
-are by id (registry `ContentSource` UUIDs). When `Engine::redact`
-runs, it re-opens the same content from the registry. The
-content itself is governed by the registry's retention policy;
-if it has been deleted between detect and redact, the redaction
-fails with a clear error pointing to the missing import.
+**Deduplication** converges the candidate set into a stable entity
+set. It is a layered pipeline, not a single step:
 
-## Redaction (override-aware apply)
+1. *Threshold filtering.* Candidates whose confidence falls
+   below the configured threshold for their entity type are
+   discarded. Different categories may admit different
+   thresholds.
+2. *Overlap resolution.* Where candidates overlap in
+   modality-appropriate space (character ranges, pixel regions,
+   time intervals), the system selects a winner according to a
+   declared precedence — typically favouring higher confidence
+   or more specific categorisation.
+3. *Fusion.* Candidates from different strategies that
+   describe the same underlying entity are merged. The merged
+   entity inherits the union of its sources' provenance, so a
+   later reader can see that, for example, the same span was
+   independently flagged by a regex and by a model.
 
-`Engine::redact` takes a `RedactionInput`:
+The output of detection is the immutable artifact described
+above: a typed record of every surviving entity, with provenance,
+confidence, and decision rationale. The artifact also stores
+enough identifying information about the original content (by
+reference, not by value) for the application phase to re-acquire
+it.
 
-```rust
-struct RedactionInput {
-    actor_id: Uuid,
-    detection_id: Uuid,
-    overrides: Vec<RedactionOverride>,
-    exports: Vec<ExportFile>,
-}
+## 4. Inside the redaction phase
+
+The redaction phase consumes a detection artifact and produces two
+outputs: rewritten content in the original format, and an audit
+trail describing what happened. Like detection it decomposes into
+conceptual stages.
+
+```
+   detection artifact
+       +  optional overrides
+       |
+       v
+  +--------------+   +-----------+   +-----------+   +----------+
+  | RESOLVE      |-> | APPLY     |-> | ENCODE    |-> | AUDIT    |
+  | (artifact +  |   | (per-     |   | (handle - |   | (per-    |
+  |  overrides   |   |  entity   |   |  >        |   |  entity  |
+  |  -> decision |   |  operator |   |  original |   |  outcome |
+  |  set)        |   |  on typed |   |  format)  |   |  record) |
+  |              |   |  handle)  |   |           |   |          |
+  +--------------+   +-----------+   +-----------+   +----------+
+                                                          |
+                                                          v
+                                                   rewritten content
+                                                       +  audit
 ```
 
-The engine:
+**Override resolution** combines the detection artifact with any
+overrides supplied by a human reviewer or an external policy
+system, producing a final decision set. Overrides express intent
+at the granularity of a single entity: accept the recogniser's
+choice as-is; reject it (so that the entity will not be
+transformed); replace the chosen operator with a different one;
+or insert an entity that recognition missed. Each form of
+override is recorded in the eventual audit trail as a distinct
+provenance value, so a reader can later tell which decisions
+originated with the recognisers, which were affirmed by a
+reviewer, and which were authored by a reviewer.
 
-1. Loads the detection. Returns `NotFound` if missing or
-   actor-mismatched; `Validation` if the detection is not in a
-   terminal state.
-2. Calls `validate_overrides(&overrides)` to catch malformed
-   input (duplicate targets, modality mismatch on `Add`).
-3. Re-opens the imported content from the registry.
-4. Re-builds the per-document trees from the imports (same
-   importer as detection used).
-5. Replays the detection's audit into each tree: entities the
-   recognisers detected are placed back at their locations.
-6. Applies overrides:
-   - `Accept` marks the audit entry as `OverrideAccept` —
-     provenance only; behaviour identical to no override.
-   - `Reject` sets `Execution = Suppressed` and marks the audit
-     entry as `OverrideReject`.
-   - `Replace` substitutes the operator and marks
-     `OverrideReplace`. The original chain pick is retained on
-     the audit entry alongside the substituted operator.
-   - `Add` synthesises an `Entity<M>` with a fresh UUID, places
-     it into the tree at the override's `location`, runs the
-     policy chain for it (unless `operator` is pinned), and
-     marks `OverrideAdd`.
-7. Runs the redaction phase + validation phase against the
-   prepared tree.
-8. Runs export.
-9. Persists the `RedactionResult` to the registry under
-   `redactions_ks`.
+**Application** executes the chosen transformation for each
+surviving entity against the typed handle that was re-derived
+from the original content. Each operator is paired with its
+modality: text spans are replaced in text handles, pixel regions
+are mutated in image handles, sample intervals in audio handles,
+cells in tabular handles. Operators are byte-level primitives
+within their modality, but the dispatch is not byte-level: it is
+done once, on modality, at the entry to this stage. (Section 5
+treats this point in its own right.)
 
-The audit trail records every override's provenance via the
-`RedactionDecision` enum. A reviewer reading the final audit can
-distinguish:
+**Encoding** re-serialises the mutated handle back into the
+document's original format. A redacted document remains the same
+kind of artifact it was: a PDF stays a PDF, an image stays an
+image, a tabular file stays tabular. Encoding is the inverse of
+ingestion and is the point at which mutation becomes visible to
+the outside world.
 
-- `PolicyChain` — recogniser detected, policy chose, no human
-  touched it.
-- `OverrideAccept` — recogniser detected, policy chose, human
-  reviewed and approved.
-- `OverrideReject` — recogniser detected, human rejected.
-- `OverrideReplace` — recogniser detected, policy chose, human
-  swapped the operator.
-- `OverrideAdd` — recogniser missed, human added.
+**Audit** records, per entity, what happened: whether the entity
+was applied, suppressed by override, or failed to apply. The
+audit is not a side effect; it is one of the two first-class
+outputs of the phase. Section 6 develops its semantics.
 
-These provenance values are non-negotiable for compliance: the
-audit must defend every redaction in court if needed.
+## 5. Per-modality dispatch
 
-## Override target identity
+Once the ingestion stage has produced a typed handle, the rest of
+the pipeline avoids repeatedly asking "what kind of content is
+this?". Dispatch on modality happens once, at the boundary into
+each downstream stage, after which each branch operates
+monomorphically — text operators see only text handles, image
+operators see only image handles, and so on. The byte-level
+mutation primitives at the leaves of the system are not modality-
+agnostic; they are specific to their modality and statically
+paired with it.
 
-Overrides reference an entity by its `Entity::id` (the
-per-mention UUID), **not** its `entity_id` (the coreference
-group identifier). Coreferent mentions are independent. To
-reject every mention of a coreferent entity, submit one
-`Reject` per mention.
+This is more than stylistic. Errors in modality pairing surface
+early: an operator intended for one modality cannot be issued
+against another; the mismatch is rejected before any byte is
+touched, not silently absorbed into an unreachable code path.
+Reasoning about each branch is local: a change to image redaction
+does not require revisiting the text path. And the hot path
+inside a branch is straight-line work on bytes of known shape,
+without per-entity type interrogation.
 
-The choice is deliberate: a reviewer must be able to reject one
-mention while accepting another. The recogniser's coreference
-linkage is a model output, not ground truth.
+The dispatch boundary is therefore a load-bearing architectural
+element, not an incidental implementation detail. Adding a new
+modality requires a new ingestion path, a new branch of the
+dispatch, and a new family of operators — but no modification to
+existing branches.
 
-## Cancellation
+## 6. Audit trail semantics
 
-Both `Engine::detect` and `Engine::redact` accept cooperative
-cancellation through a per-task `CancellationToken` checked at:
+Every entity that survives to the application phase produces an
+audit entry. The entry records two things distinctly.
 
-- Every phase boundary (between extraction → detection →
-  deduplication for detect; between override-application →
-  redaction → validation → export for redact).
-- Inside long-running recogniser / extractor / export loops, at
-  every yielded await point.
+The first is the *decision*: which recogniser or rule produced
+the entity, what confidence was attached, which operator the
+recognition phase selected, and whether an override modified that
+selection. The five decision provenances are *recogniser-only*,
+*recogniser plus reviewer acceptance*, *recogniser plus reviewer
+rejection*, *recogniser plus reviewer replacement*, and
+*reviewer-authored insertion*. Each is recorded explicitly. A
+reader of the audit trail can therefore distinguish, for any
+redaction, whether it originated with a machine, was affirmed by a
+human, was modified by a human, or was authored by a human.
 
-Cancellation observed during detection produces a `Cancelled`
-status and discards any in-progress audit. The persisted state
-is absent.
+The second is the *execution*: whether the chosen transformation
+was actually applied, was suppressed (because an override said so),
+or failed (because the operator itself errored). The decision and
+the execution are independent: a decision can be made and not
+executed; an execution can succeed or fail without changing the
+decision that selected it.
 
-Cancellation observed during redaction is the harder case. If
-cancellation lands after the redaction phase has written bytes
-to some documents but not others, the result is `PartialFailure`
-with the audit recording which documents completed and which
-were aborted. Bytes already written are not rolled back —
-exports are append-only or codec-replacing, and once a codec has
-emitted output the operation is durable. Reviewers reading the
-audit see exactly which documents were redacted before the
-cancel landed.
+The audit is the runtime's authoritative log of what happened. It
+is append-only and tamper-evident; it accompanies the rewritten
+content as a co-equal output of the phase.
 
-## Error taxonomy
+## 7. Override target identity
 
-| Situation                                            | `ErrorKind`     |
-|------------------------------------------------------|-----------------|
-| Detection / redaction does not exist                 | `NotFound`      |
-| Detection / redaction belongs to a different actor   | `NotFound`*     |
-| Detection exists but not yet terminal                | `Validation`    |
-| Detection terminal but cancelled (no result)         | `Validation`    |
-| Override duplicate target                            | `Validation`    |
-| Override `Add` operator modality mismatches location | `Validation`    |
-| Override `Replace`/`Add` operator missing for kind   | `Validation`    |
-| Override targets `entity_id` not in detection's audit| `Validation`    |
-| Cancellation observed                                | `Cancellation`  |
-| Recogniser / extractor / codec error                 | `Runtime`       |
-| Registry / fjall I/O error                           | `Internal`      |
+A subtle problem appears as soon as detection and application are
+separated: how does an override say which entity it refers to?
 
-\* Actor-scoping returns `NotFound` (not `Forbidden`) on
-mismatch to avoid leaking existence to unauthorised callers.
+A reviewer cannot reference an entity by its content — two entities
+may have the same surface text but represent different referents,
+and entity sets are not stable across recognition runs. A reviewer
+cannot reference an entity by its position alone, because
+applying earlier overrides may shift the positions of later
+entities. A reviewer cannot reference an entity by a recogniser-
+internal model identifier, because the recogniser set may change.
 
-## Test obligations
+The system's answer is that each surviving entity is assigned a
+stable identifier at the moment it is written into the detection
+artifact. The identifier is a per-mention value: distinct
+occurrences of the same underlying entity receive distinct
+identifiers. Overrides reference that identifier and only that
+identifier.
 
-The integration tests in `crates/nvisy-engine/tests/` exercise
-the engine + registry + (mocked) recogniser end-to-end.
+Two consequences are worth naming.
 
-**Detection:**
+- *Per-mention granularity is preserved.* A reviewer can reject one
+  occurrence of an entity while accepting another. The
+  recogniser's view of which mentions are coreferent is treated as
+  a model output, not as a constraint on review.
+- *Overrides become diffable.* A set of overrides against a fixed
+  detection artifact is fully determined: it can be stored,
+  versioned, replayed, and compared. There is no implicit
+  dependency on the recognition run that produced the entities,
+  beyond the artifact's own identity.
 
-- Happy path: text/image/audio/tabular import, every recogniser
-  fires, terminal `Succeeded` with audit on disk.
-- Partial failure: one of N imports fails to parse;
-  `PartialFailure` with audits for the successful imports.
-- Cancellation mid-detection: token fires during extraction,
-  during detection, during deduplication. Each produces
-  `Cancelled` and no on-disk artifact.
-- Actor isolation: actor A cannot read actor B's detection.
-- Restart durability: persist a detection, restart engine, read
-  it back via `get_detection`.
+If a reviewer wishes to operate at the coreference-group level,
+the system permits expressing that intent as a batch of per-
+mention overrides — but it does not allow the system itself to
+quietly fan a single override out to multiple mentions. The
+explicit form is recoverable; the implicit form is not.
 
-**Redaction:**
+## 8. Cancellation and failure
 
-- Happy path with empty overrides: applies policy chain to
-  every entity; audit shows `PolicyChain` decisions.
-- `Accept` overrides round-trip: audit shows `OverrideAccept`,
-  output bytes identical to the no-override case.
-- `Reject` override suppresses one entity; audit shows
-  `OverrideReject` and `Execution::Suppressed`; output bytes
-  reflect the suppression (entity not redacted).
-- `Replace` override substitutes operator; audit shows
-  `OverrideReplace`; output bytes show the new operator's
-  result.
-- `Add` override injects an entity; audit shows `OverrideAdd`
-  with fresh UUID; output bytes show the new entity redacted.
-- `Add` with pinned operator bypasses policy chain.
-- `Add` without pinned operator runs policy chain (matches
-  recogniser-detected behaviour).
-- Modality validation: `Replace` for a text entity with an
-  image operator rejected pre-engine via `validate_overrides`.
-- Coreference: two mentions of one coreferent entity get
-  independent overrides; rejecting one does not reject the
-  other.
-- Missing detection: `RedactionInput.detection_id` not found
-  returns `NotFound`.
-- Missing import: detection references a content_id since
-  deleted; redaction fails clearly pointing at the missing
-  import.
-- Cancellation mid-redaction across N documents: documents
-  completed before cancel keep their redactions; documents
-  not yet processed are aborted; `PartialFailure` status.
+Both phases are long-running and both must be cancellable.
+Cancellation is cooperative: each phase checks at well-defined
+boundaries whether it has been asked to stop, and additionally at
+each yielded await point inside long-running inner loops.
 
-**Cross-cutting:**
+For *detection*, the boundaries are the transitions between its
+stages — between extraction and recognition, between recognition
+and deduplication — together with the cancellation checks inside
+extractor and recogniser loops. Cancellation observed during
+detection produces no persisted artifact. The phase either
+completes and writes a complete artifact, or it does not. Partial
+artifacts are not durable, by construction; this is the
+consistency point that makes detection cacheable and replayable.
 
-- Override referencing `entity_id` not present in the
-  detection: `Validation` error, no partial redaction.
-- Two concurrent redactions against the same detection succeed
-  independently.
-- Concurrent override application within one redaction is
-  ordered: overrides are applied serially per document so the
-  audit is deterministic.
+For *redaction*, the boundaries are the transitions between
+override resolution, application, encoding, and audit emission.
+Cancellation observed inside application across multiple documents
+is the harder case. Some documents may already have been encoded
+and emitted before the cancellation lands; those bytes are not
+rolled back, because the encoding step is the moment at which the
+operation becomes externally visible and durable. The audit
+records, per document, whether the document completed or was
+aborted. A reviewer reading the audit after a cancellation sees
+exactly which documents were redacted before the cancellation
+landed and which were not. The system therefore prefers honest
+partial visibility over the illusion of atomicity it cannot
+provide.
 
-## Out of scope
+Failure modes are handled analogously. A recogniser that errors on
+one input does not abort detection on the others; the artifact
+records which inputs succeeded. An operator that errors on one
+entity does not abort application of the others; the audit records
+which entities applied and which failed. Where the artifact
+references content that has since been deleted (because retention
+policy expired it between phases), the application phase fails
+loudly rather than silently producing degraded output.
 
-- Multi-detection redaction (one redaction targeting two
-  detections at once). Not a real use case yet.
-- Override-only redaction without re-importing (skip extraction
-  + detection on restart). Optimisation; correctness first.
-- Streaming detection results to the caller as documents
-  complete. Today: caller polls `get_detection`.
-- Detection retention separate from audit retention. Detection
-  results inherit the audit's retention policy today.
+## 9. What this architecture buys
+
+It is worth stating plainly what the two-phase split delivers and
+what it costs, by contrast with two alternative architectures.
+
+*Against a single-pipeline system* — one in which ingestion,
+recognition, and application are fused into a single end-to-end
+transformation — the two-phase split delivers:
+
+- the ability to review recognition output before any byte is
+  mutated;
+- the ability to derive multiple application outputs from one
+  recognition run, at the cost of one recognition and several
+  cheap applications;
+- explicit, independent failure semantics for the recognition and
+  application halves;
+- a recognition output that can be cached, replayed, evaluated,
+  and compared as a first-class object.
+
+*Against an unstructured detect-then-redact system* — one in which
+recognition writes loose findings into some shared store and
+application reads them back — the two-phase split delivers:
+
+- a typed, addressable artifact that is the only contract between
+  the phases, eliminating the ambient-state coupling that such
+  systems typically develop;
+- a stable per-entity identifier scheme that makes overrides
+  diffable;
+- a clear locus for retention and access control (the artifact
+  itself), rather than a sprawl of intermediate state to be
+  governed individually.
+
+The price the system pays for these properties is the artifact
+itself. Recognition output is now a durable, retained object with
+its own identity and its own lifecycle. The system must manage
+it: store it, retrieve it, expire it, access-control it, and
+reason about its relationship to the originating content. That is
+real engineering cost, not negligible, and not free in storage.
+
+In the domains the system targets — where a single incorrect
+redaction is a compliance event, where regulators may demand to
+see the basis of a decision years after it was made, and where
+the alternative is irreversible destruction of content based on
+unreviewed model output — the cost is the right one to pay. The
+two-phase split is not an optimisation. It is a design decision
+about which failures the system is permitted to have.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,54 +1,85 @@
-# Multimodal Redaction & Privacy Platform
+# A System for Multimodal PII Detection and Redaction
 
 ## Abstract
 
-As organizations contend with an ever-growing volume of unstructured and multimodal data, the challenge of identifying and redacting sensitive information has become a critical concern. Regulatory frameworks such as GDPR, HIPAA, CCPA, and PCI-DSS impose strict obligations on how personally identifiable information (PII), protected health information (PHI), and other sensitive content must be handled across documents, images, and audio.
+This document series describes the conceptual architecture of a system
+for detecting and redacting personally identifiable information across
+heterogeneous data: free text, tabular records, still images, and
+recorded audio. The system addresses three problems that a
+single-modality redactor cannot. First, sensitive content surfaces
+through different carriers in each modality (a span of characters, a
+cell value, a region of pixels, an interval of waveform), and any
+unified treatment must respect those carriers rather than reduce them
+to a common substrate. Second, no single detection technique is
+sufficient: deterministic patterns recover structured identifiers with
+high precision, statistical models recover unstructured entities with
+useful recall, and generative models recover context-dependent
+mentions that neither of the prior two can frame; the system therefore
+admits a pluralistic detection layer in which multiple recognisers
+contribute to a single annotation set. Third, the regulated settings
+this system targets demand that redaction be auditable and, in
+specific cases, reversible by an authorised party, so the system
+treats the rewrite operation itself as a first-class object with a
+declared kind (suppression, anonymization, pseudonymization) and a
+recorded provenance. The overall pipeline separates detection from
+redaction into two distinct phases: detection produces an immutable
+record of what was found and why; redaction consumes that record,
+admits human overrides, and writes format-preserving output together
+with the audit trail that justifies every change.
 
-This document series presents the architectural and functional requirements for a multimodal redaction platform capable of extracting content from heterogeneous sources, detecting sensitive data through deterministic and learned methods, applying context-aware redaction, and producing auditable evidence of compliance.
+## Reader's guide
 
-The guiding principle is: **extract everything, understand context, redact precisely, prove compliance.**
+The remaining documents in this series each take one slice of the
+system and develop it in isolation. They are independent and may be
+read in any order, though the order below reflects the flow of a
+document through the system.
 
-## Documents
-
-| Document | Scope |
+| Document | Subject |
 | --- | --- |
-| [Ingestion & Transformation](INGESTION.md) | Content model, format detection, multimodal extraction, and post-redaction output |
-| [Detection](DETECTION.md) | Sensitive data detection across modalities and pipeline state |
-| [Redaction & Review](REDACTION.md) | Context-aware redaction and human-in-the-loop workflows |
-| [Pipeline](PIPELINE.md) | Implementation contract for the detection ↔ redaction code split |
-| [Compliance & Audit](COMPLIANCE.md) | Policy engine, explainability, and audit trails |
-| [Infrastructure](INFRASTRUCTURE.md) | Deployment, storage, performance, and security |
-| [Developer Experience](DEVELOPER.md) | APIs, SDKs, configuration, and advanced capabilities |
-
-## Strategic Positioning
-
-Three viable product directions exist for platforms in this space:
-
-1. **Compliance-first platform**: targets enterprise procurement cycles driven by regulatory mandates.
-2. **Developer-first redaction API**: prioritizes integration speed, SDK quality, and self-serve adoption.
-3. **AI-native multimodal privacy engine**: leads with model sophistication, context understanding, and semantic redaction.
-
-The strongest long-term defensibility lies in context-aware, explainable, policy-driven multimodal redaction — a convergence of all three directions.
-
-## Target Verticals
-
-The platform is designed to serve regulated industries where sensitive data handling is a legal and operational requirement:
-
-- **Healthcare**: HIPAA-governed medical records, clinical communications, insurance claims, and patient intake forms.
-- **Legal**: Court filings, discovery documents, attorney-client communications, and case management systems.
-- **Government and defense**: Law enforcement records, intelligence reports, FOIA responses, and classified material processing.
-- **Financial services**: Transaction records, customer onboarding documents, fraud investigation files, and PCI-scoped payment data.
-- **Education**: Student records, admissions documents, and FERPA-governed institutional data.
+| Pipeline | The two-phase decomposition of the system into a detection phase that produces an immutable artifact and a redaction phase that consumes it, together with the contract between them and the role of human review at the seam. |
+| Ingestion | The process by which a raw uploaded file becomes a typed, addressable handle on which the rest of the pipeline operates, including format identification, structural extraction across modalities, and the preservation of descriptive metadata. |
+| Detection | The composition of rule-based, statistical, and generative recognisers into a single layer that produces a unified set of entity annotations, including the treatment of overlap, disagreement, and confidence between recognisers. |
+| Redaction | The translation of detected entities into concrete rewrites or removals on the original document, the catalogue of operator kinds, the role of policy in selecting an operator per entity, and the conditions under which a redaction is reversible. |
+| Compliance | The semantics of the audit trail, the distinction between what the runtime itself guarantees and what the surrounding deployment must provide, retention policy, and the explainability requirements that govern every recorded decision. |
+| Infrastructure | The deployment shape of the system, the external services it depends on for storage, key management and access control, and the boundaries between concerns the runtime owns and concerns the surrounding environment owns. |
+| Developer | The extension surfaces through which a practitioner adds support for a new input format, a new recogniser, or a new redaction operator, and the configuration model that governs per-deployment behaviour. |
 
 ## Glossary
 
-| Term | Definition |
-| --- | --- |
-| **PII** | Personally identifiable information: any data that can identify a specific individual |
-| **PHI** | Protected health information: health data covered under HIPAA |
-| **NER** | Named entity recognition: ML technique for identifying entities (names, locations, organizations) in text |
-| **OCR** | Optical character recognition: extraction of text from images and scanned documents |
-| **RBAC** | Role-based access control: permissions model based on user roles |
-| **SSO** | Single sign-on: authentication mechanism allowing one set of credentials across multiple systems |
-| **SCIM** | System for Cross-domain Identity Management: protocol for automating user provisioning |
-| **KMS** | Key management service: system for managing cryptographic keys |
+The terms below are used throughout the series with the meanings given
+here. They are intended as conceptual definitions, not as references
+to any particular interface.
+
+- **Modality** — a class of data carrier with its own internal
+  structure and its own notion of location: text, tabular records,
+  still images, and recorded audio are the four modalities treated by
+  this system.
+- **Entity** — a single occurrence of sensitive information within a
+  document, located in one modality, of one declared kind (person
+  name, identifier, face region, spoken interval, and so on).
+- **Location** — the modality-specific coordinate that identifies
+  where an entity lives in its host document: a character span, a row
+  and column, a pixel region, or a time interval.
+- **Redaction** — the act of replacing, removing, or otherwise
+  altering an entity in the host document so that it no longer
+  conveys the sensitive information it originally carried.
+- **Anonymization** — a redaction that severs the link between the
+  redacted document and the original entity in a way that the system
+  itself cannot reverse.
+- **Pseudonymization** — a redaction that substitutes the entity for
+  a token or surrogate value, where the substitution can be reversed
+  by a party in possession of the appropriate key or mapping.
+- **Deanonymization** — the inverse operation to a pseudonymizing
+  redaction, available only where the original redaction was declared
+  reversible and the reverser holds the requisite authority.
+- **Audit trail** — the record kept by the system of every entity
+  detected, every operator selected, every override applied, and
+  every byte changed, structured so that any single redaction can be
+  explained after the fact.
+- **Override** — a human decision, supplied at the seam between
+  detection and redaction, that accepts, rejects, replaces, or adds
+  to the automated finding before it is committed to output.
+- **Policy** — a declarative specification that maps an entity (by
+  kind, by confidence, by document context) to the operator that
+  should redact it, allowing the system's behaviour to be tuned
+  without modification to its detection or redaction layers.

--- a/docs/REDACTION.md
+++ b/docs/REDACTION.md
@@ -1,64 +1,304 @@
 # Redaction
 
-## 1. Overview
+A conceptual white paper on the redaction subsystem. The audience is a
+privacy engineer evaluating the architecture; the goal is to describe the
+model, not the implementation.
 
-Detection identifies what is sensitive; redaction determines what to do about it. The distinction between a basic redaction tool and a production-grade platform lies in the ability to apply redaction with contextual awareness: understanding not just that a name appears in a document, but whose name it is, why it matters, and whether the surrounding regulatory and organizational policy requires its removal.
+## 1. The Redaction Problem
 
-## 2. Context-Aware Redaction
+Detection answers *where is the sensitive information*. Redaction answers
+the harder question: *what should happen to it*. The two are routinely
+conflated, and the conflation hides a design problem. Once a span has been
+identified as personal data, the system must transform it, and every
+possible transformation costs something.
 
-### 2.1 Instance-Level Precision
+Naive removal -- deleting the span outright -- destroys downstream utility.
+Analytics that counted records, machine-learning workflows trained on
+context windows, and human reviewers that relied on document structure all
+degrade when arbitrary bytes vanish. Naive replacement -- substituting a
+fixed token like `[REDACTED]` -- preserves shape but leaks structure. If
+every occurrence of one individual becomes the same token across a
+corpus, the redaction itself is a join key: the identifier the operator
+was supposed to eliminate.
 
-The platform must distinguish between occurrences of the same entity across different contexts. Redacting "John Smith" in one document should not require redacting every occurrence of the name across an entire corpus. Redaction decisions must be scoped to the relevant instance, document, or case.
+Different deployments demand different trade-offs. A public data release
+wants strong anonymization, biased toward irreversibility. An internal
+audit pipeline wants reversible pseudonymization so authorized
+investigators can later recover the original value. A financial dataset
+wants format-preserving masking so downstream validators continue to pass.
+A machine-learning corpus wants synthetic but plausible replacements so
+token distributions remain useful. A single redaction operation cannot
+serve all four. The runtime therefore treats redaction as a *family of
+operators* parameterized by policy. Each operator is a small contract:
+given a span and its modality, produce a transformed span and an audit
+record describing what happened.
 
-### 2.2 Conditional Redaction
+## 2. Operator Taxonomy
 
-Redaction rules must support conditional logic:
+Operators divide into two top-level categories based on whether the
+original can be recovered from the audit trail.
 
-- **Document-type conditions**: Apply medical redaction policies only when the document type is classified as a health record. The pipeline envelope carries the original content metadata (MIME type, filename, custom key-value pairs) through every stage, making these signals available to redaction rules without re-reading the original content.
-- **Temporal conditions**: Redact specific time segments in audio content.
-- **Metadata conditions**: Activate or suppress rules based on custom metadata attached at upload (e.g., department, classification level, jurisdiction).
+```
+                          Operator
+                             |
+              +--------------+---------------+
+              |                              |
+         Anonymizer                     Deanonymizer
+              |                              |
+   +---+------+------+-----+               (key-held
+   |   |      |      |     |                recovery)
+ keep mask  hash  replace remove              |
+                                          decrypt
+```
 
-### 2.3 Relationship-Aware Redaction
+### 2.1 Anonymizers
 
-Advanced redaction scenarios require reasoning over relationships between entities: redacting all names associated with a specific case identifier, or redacting all communications involving a particular individual across a document set.
+Anonymizers transform a span in a way intended to be irreversible from the
+redacted artifact alone.
 
-### 2.4 Confidence-Driven Redaction
+- **Keep** records that an entity was inspected and consciously preserved.
+  Not a no-op; absence from the audit trail is semantically different
+  from the explicit decision to keep.
+- **Replace** substitutes a token (literal string, synthetic value,
+  category reference) for the span. The simplest anonymizer; also the
+  most prone to leakage when substitution is naive.
+- **Mask** transforms the span character by character (or sample by
+  sample), preserving format. A masked card number stays the same length
+  and still parses as a card number, but its information content is gone.
+- **Hash** produces a one-way fingerprint. The original is absent from the
+  artifact, but identical inputs produce identical outputs, preserving
+  equality joins at the cost of dictionary-attack exposure.
+- **Remove** deletes the span entirely; surrounding bytes close around the
+  hole. The most lossy and format-disruptive operator; some codecs cannot
+  honour it without producing invalid output.
 
-Each detection carries a confidence score from the underlying model or pattern matcher. Redaction rules should be able to set confidence thresholds: entities above the threshold are redacted automatically, while entities below it are flagged for review or skipped. This enables a tunable precision/recall tradeoff per entity type.
+### 2.2 Deanonymizers
 
-## 3. Regulatory Policy Templates
+Deanonymizers reverse an earlier transformation when the holder presents
+sufficient authority, typically a cryptographic key. The canonical case is
+**decryption**: a span encrypted by an anonymizer is recoverable later by
+the key holder. The ciphertext sits in the artifact in place of the
+original; the audit record carries the metadata needed to reverse it.
 
-Predefined policy templates aligned to common regulatory frameworks provide a starting point for organizations deploying the platform. Each template is a JSON definition of entity types, pattern identifiers, and redaction actions that collectively satisfy the requirements of a specific regulation.
+Reversibility is a first-class operator category, not a feature flag on
+individual anonymizers. Reversible operators require key management,
+rotation, and access controls; they carry liability anonymizers do not (a
+stolen key is a stolen dataset); they are appropriate for internal
+pipelines and inappropriate for public releases. Conflating them under a
+single "redact" verb hides exactly the property the privacy engineer most
+needs to reason about.
 
-Templates included in the repository:
+## 3. Per-Modality Replacement Semantics
 
-- **HIPAA**: Protected health information in medical records, communications, and claims.
-- **GDPR**: Personal data of EU residents across all modalities.
-- **PCI-DSS**: Payment card data in documents, images, and structured records.
-- **CCPA**: Personal information of California residents.
+The operator catalogue is uniform, but the concrete meaning of "replace
+this span" depends on the modality. Each modality has its own notion of a
+span at the byte level and of what replacement looks like.
 
-Templates are not enforced by default. Organizations select and extend templates through the policy configuration, adding organization-specific rules or narrowing thresholds as needed.
+```
+Modality     Span               Replacement primitive
+--------     ----               ---------------------
+Text         byte range         substitute string (length may change)
+Tabular      cell coordinate    rewrite cell, or drop column schema-wide
+Image        bounding box       blur | block | mosaic | pixel substitute
+Audio        time interval      silence | remove | substitute samples
+```
 
-## 4. Review Integration
+**Text.** A span is a half-open byte range. Replacement substitutes a
+string for the matched bytes; surrounding bytes are unchanged. Replacement
+length may differ from the original, which is why text redaction batches
+require coordinate care (Section 7).
 
-The runtime does not provide a review interface, but it accepts review decisions as an optional input to the pipeline. A review decision is a list of actions (accept, reject, or modify) applied to individual redaction entries before export.
+**Tabular.** A span is a cell coordinate or a column identifier for
+schema-wide operations. Replacement either rewrites the cell or drops the
+column from the output schema.
 
-When review input is provided:
+**Image.** A span is a bounding box. Replacement has several flavors that
+are not interchangeable: Gaussian blur preserves rough silhouette,
+solid-block redaction preserves nothing, mosaic pixelation preserves
+coarse color statistics, and in-place pixel substitution preserves
+geometry while destroying identifiable detail. The choice is policy-driven.
 
-- **Accepted** redactions proceed to export unchanged.
-- **Rejected** redactions are removed: the original content is restored for those regions.
-- **Modified** redactions replace the automated output with a reviewer-specified alternative (different mask text, adjusted bounding box, narrower time range).
+**Audio.** A span is a time interval. Replacement can silence the interval
+(amplitude zeroed), remove it (the buffer shrinks and downstream
+timestamps shift), or substitute alternate samples (pink noise, a tone, a
+synthetic utterance).
 
-When no review input is provided, all automated redaction decisions are applied as-is. This keeps the engine stateless with respect to review workflow: the external review service is responsible for presenting decisions to reviewers, collecting responses, and passing the result back to the runtime for a final export pass.
+The operator framework abstracts over these primitives. A policy that says
+"mask this entity" produces the correct per-modality output without each
+operator carrying modality-specific code. This is why the operator
+catalogue is small: every operator must have a meaningful definition in
+every modality the system handles. Operators that cannot meet that bar are
+pushed into the modality-specific layer.
 
-Each review action should carry the reviewer identity and a timestamp so that the audit trail records who approved or modified each decision.
+## 4. Format-Preserving Output
 
-## 5. Redaction Versioning and Rollback
+After redaction, the modified artifact re-serializes to its original
+container format. A redacted CSV is still a valid CSV; a redacted PDF is
+still a valid PDF; a redacted WAV is still a valid WAV. Two properties
+follow. First, **non-redacted bytes are preserved**: when the codec
+supports it, every byte outside a redaction span is byte-for-byte
+identical to the input. Re-encoding the entire artifact would be simpler,
+but would subtly alter content the policy never intended to touch --
+floating-point columns re-rounded, image compression artifacts shifted,
+audio samples re-quantized. The runtime treats avoidable re-encoding as a
+bug. Second, **the format contract is preserved**: downstream consumers
+that expect a specific column ordering or a PDF whose embedded fonts
+match an external reference continue to work.
 
-### 5.1 Versioned Redaction State
+The cost is that the redaction layer threads its operations through
+codec-specific writers that understand how to splice modifications into
+the original stream. The benefit is that the runtime can be inserted into
+a deployment without forcing every consumer to tolerate a re-serialized
+variant of its input.
 
-The platform must maintain versioned snapshots of redaction state for each piece of content. Each modification, whether automated or manual, produces a new version. Prior versions must remain accessible for comparison, audit, and rollback.
+## 5. Reversibility as a Design Choice
 
-### 5.2 Rollback
+The audit trail records different information depending on whether the
+operator was reversible. For an irreversible operator -- masking, hashing,
+removal, plain replacement -- the audit stores the *replacement*: what was
+written into the artifact, where, and which policy rule selected the
+operator. The original value is intentionally absent. If the audit log
+contains the original, it becomes a new copy of the personal data, and
+the redaction has not reduced exposure, only relocated it.
 
-Before export, any redaction decision must be reversible. The engine must support rolling back individual redactions or restoring an entire document to a previous redaction state. After export, rollback is no longer available: the exported artifact is final, and any corrections require re-processing from the original content.
+For a reversible operator, the audit stores enough information to recover
+the original when the key is available -- an opaque token or ciphertext
+reference, but never the plaintext. This is the difference between a
+redacted dataset that can be re-identified by authorized parties and one
+that genuinely cannot. The runtime exposes the distinction at the
+operator boundary so the choice is deliberate at policy-authoring time,
+not an emergent property of how the log was configured.
+
+## 6. Override Flow
+
+The detection artifact is immutable: once detection produces a set of
+entities, that set is the canonical record of what was found. Redaction
+accepts an override layer that lets a reviewer adjust the decisions
+before the destructive write step.
+
+```
+   Detection Artifact (immutable)
+              |
+              v
+   +---------------------+
+   | Override Resolution |  <-- reviewer / upstream system
+   +---------------------+
+              |
+              v
+   Effective Entity Set
+              |
+              v
+   Redaction Batch -> Codec Write -> Audited Artifact
+```
+
+The override surface supports four operations:
+
+- **Accept.** Take the detected entity as-is. Default for any entity not
+  mentioned by an override.
+- **Reject.** Suppress redaction for a specific entity. The detection
+  record persists in the audit, marked as suppressed; the artifact bytes
+  are left untouched.
+- **Replace.** Use a different operator than the one policy selected. A
+  policy that defaulted to masking might be overridden to use encryption
+  where reversibility is required.
+- **Add.** Insert a new entity at a location detection missed. It carries
+  an explicit operator and span coordinate; it does not back-fill the
+  detection artifact but is recorded as an override-added entity in the
+  audit.
+
+Overrides reference entities by their stable identifier from the
+detection artifact, not by position or content. This makes overrides
+robust to re-runs of detection that might shift coordinates and keeps the
+override file meaningful as a standalone record. The override layer is
+intentionally narrow: it does not allow editing the content of a detected
+entity, changing its type, or rewriting its confidence; those are
+modifications to the detection artifact, which is immutable by design.
+
+## 7. The Redaction Batch
+
+A document typically produces many entities. The runtime collects them
+into a batch and lets the codec layer decide ordering. For codecs whose
+write step *shifts byte offsets* -- text, audio, any stream where a
+replacement can change buffer length -- the batch is sorted right-to-left
+before application. A redaction near the end is applied first, so an
+earlier insertion or deletion cannot invalidate the coordinates of later
+redactions.
+
+```
+   buffer: [....a.....b.......c....]
+                |     |       |
+            entity1 entity2 entity3
+
+   apply order: entity3, entity2, entity1
+```
+
+For codecs whose write step does *not* shift offsets -- image (bounding
+boxes are independent), tabular (cell coordinates are stable) -- the
+batch can be applied in any order, and the runtime may parallelize.
+Right-to-left ordering is opt-in per modality, not a global invariant.
+Each codec declares its own ordering contract. This avoids the failure
+mode where a text-derived assumption silently mis-orders an image batch.
+
+## 8. Audit Trail
+
+Every entity reaching redaction produces an audit entry, regardless of
+whether the redaction was applied. The audit is the authoritative log of
+what happened to each piece of personal data; it is not a debug aid. Each
+entry records two things:
+
+- **The decision.** Which policy rule fired, whether an override applied
+  (and which reviewer it came from, when available), what operator was
+  selected, and which alternatives were considered. Answers *why* this
+  entity was treated this way.
+- **The execution.** Whether the redaction was applied, suppressed, or
+  failed; for reversible operators, the metadata required to reverse it;
+  for failures, the error and span coordinates. Answers *what happened*
+  in the artifact.
+
+The split matters because the sections have different lifetimes and
+access controls. Decisions may need to be visible to compliance reviewers
+without access to the artifact; executions, especially for reversible
+operators, may need to be tightly held by key custodians. The audit is
+append-only. A re-run produces a new audit, not an in-place update;
+comparison between audits is how the runtime supports the question "what
+changed between these two redactions of the same document".
+
+## 9. Out of Scope
+
+The runtime provides primitives. Several adjacent concerns belong to
+deployments and are explicitly out of scope.
+
+- **Differential privacy.** The catalogue does not include noise-addition
+  operators tuned for differential-privacy guarantees. The supporting
+  accounting -- privacy budgets, composition tracking, query auditing --
+  is deployment-level.
+- **k-anonymity / l-diversity guarantees.** The runtime does not analyze
+  the corpus for re-identification risk after redaction. A k-anonymous
+  output is the result of policy-authoring discipline, not a runtime
+  guarantee.
+- **External key management.** Reversible operators consume a key; they
+  do not source it. Vault integration, HSM-backed signing, key rotation,
+  and access policy are deployment integrations.
+- **Reviewer UIs.** The runtime exposes an override surface, not a review
+  interface. Presenting decisions to a human and collecting input is the
+  responsibility of an external service.
+
+## 10. Roadmap Limitations
+
+Three areas are not yet at the conceptual completeness this paper
+describes, noted so the model is not mistaken for the implementation.
+
+- **Tabular redaction** is not yet a full phase with its own coordinate
+  model. Tabular content is handled by the text pipeline over a serialized
+  representation -- adequate for small structured payloads and inadequate
+  for arbitrary tabular workloads.
+- **Audio sample substitution** is partial. Silencing and removal are
+  production-ready; substituting synthesized speech or alternate samples
+  is supported only for a narrow set of inputs.
+- **Operator policy composition** -- fallbacks such as "encrypt if a key
+  is available, otherwise mask" -- is expressible but not first-class;
+  deployments encode it as multiple rules.
+
+These are roadmap items, not architectural limits. The operator and audit
+boundaries are stable; what is missing is breadth of coverage inside the
+existing categories.


### PR DESCRIPTION
## Summary

All eight files under \`docs/\` rewritten as conceptual white
papers describing the system's design without referencing
implementation details. The previous prose carried marketing
language, stale type names, deleted concepts, and aspirational
features.

The first round of this PR rewrote them as code-anchored API
reference (history of PR). That was the wrong genre — the
implementer audience already has rustdoc + per-crate READMEs.
This commit moves \`docs/\` to its proper role: the conceptual
layer.

Net change: +2032 / -730 across 8 files.

## What landed

- **README.md** (85 lines) — index page. Abstract framing the
  three-problem decomposition (modality-specific carriers,
  pluralistic detection, auditable/reversible redaction).
  Reader's guide table for the seven siblings. 10-entry glossary.

- **PIPELINE.md** (434 lines) — the two-phase detect/redact
  split. Why the split matters. Phase decomposition for both
  passes. Per-modality dispatch. Audit semantics. Override
  target identity. Cancellation. Contrast with alternative
  architectures.

- **DETECTION.md** (297 lines) — pluralistic recognition (rule
  / statistical / generative). Chunking and coordinate lifting.
  Deduplication funnel (threshold → overlap → fusion).
  Annotations as ground truth and overrides. Policy filtering.

- **REDACTION.md** (304 lines) — anonymizer/deanonymizer
  taxonomy. Per-modality replacement semantics. Format-preserving
  output contract. Reversibility as a first-class operator
  property. Override flow. Audit trail.

- **INGESTION.md** (299 lines) — the content bundle decomposition
  (data / descriptor / digest / record). Typed handle
  abstraction. Modality boundaries within mixed-content
  documents. Encode round-trip contract. Coordinate lifting
  mechanisms.

- **COMPLIANCE.md** (250 lines) — the sociotechnical scope split.
  Audit trail dimensions. Policy as code with first-match-wins
  citation semantics. Runtime / deployment / product scope
  table. Reversibility and the right to deletion.

- **INFRASTRUCTURE.md** (246 lines) — single-binary deployment
  philosophy. Embedded persistent state. External inference
  dependencies as deployment-side. Observability primitives.
  The runtime/deployment boundary.

- **DEVELOPER.md** (200 lines) — three extension surfaces
  (codecs, recognizers, operators) as orthogonal seams. The
  closed-modality trade-off named openly. Pluggable inference
  backends. Extension lifecycle.

## Constraints honored

- No Rust type names.
- No crate paths.
- No method signatures.
- No file paths.
- No build commands.
- No marketing prose.
- No comparisons to specific competitors by name.

Cross-references between papers use doc titles only. Diagrams
(ASCII / Mermaid) used where they earn their keep — the
two-phase split, the recognizer fan-out, the operator taxonomy
tree, the override flow.

## Verification

\`grep\` sweep across all 8 docs for code references
(\`crates/\`, \`.rs\`, \`::detect\`, \`::redact\`, \`Engine::\`,
\`Handler<\`, \`Loader<\`, \`cargo\`, \`nvisy_*\`) returns zero
matches.

## Test plan

- [x] All 8 files render correctly on GitHub.
- [x] Zero code reference leakage.
- [ ] Spot-check a couple of papers for conceptual accuracy
      against the actual system behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)