### PR TITLE
Feature-gate modalities; per-format codec toggles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1018,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1052,7 +1052,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#39e3acc451fa1d3ab30ac4401de3b87e130dab8f"
+source = "git+https://github.com/nvisycom/elide?branch=main#4e56ae5fc8683c3c23cb36f9b713adda99c5c03e"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -19,12 +19,42 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 
 [features]
-default = ["tabular", "image", "audio", "document"]
+default = ["tabular", "image", "audio", "codec-docx"]
 
-tabular = ["elide/codec-tabular"]
-image = ["elide/codec-image"]
-audio = ["elide/codec-audio"]
-document = ["elide/codec-document"]
+## Tabular modality (analyzer + anonymizer + redaction operators)
+## plus every tabular codec elide ships (CSV, XLSX).
+tabular = ["internal_tabular", "codec-csv", "codec-xlsx"]
+## Image modality (analyzer + anonymizer + redaction operators)
+## plus every image codec elide ships (PNG, JPEG, TIFF).
+image = ["internal_image", "codec-png", "codec-jpeg", "codec-tiff"]
+## Audio modality (analyzer + anonymizer + redaction operators)
+## plus the WAV codec. MP3 is opt-in via `codec-mp3` because of
+## patent licensing.
+audio = ["internal_audio", "codec-wav"]
+
+## Individual codec toggles. Each pulls in its modality's shared
+## code (`internal_*`), so `codec-png` alone works without also
+## enabling `image`.
+codec-csv = ["internal_tabular", "elide/codec-csv"]
+codec-xlsx = ["internal_tabular", "elide/codec-xlsx"]
+codec-png = ["internal_image", "elide/codec-png"]
+codec-jpeg = ["internal_image", "elide/codec-jpeg"]
+codec-tiff = ["internal_image", "elide/codec-tiff"]
+codec-wav = ["internal_audio", "elide/codec-wav"]
+## MP3 is opt-in: MP3 patent licensing may not be satisfiable
+## downstream. Off by default even when `audio` is enabled.
+codec-mp3 = ["internal_audio", "elide/codec-mp3"]
+## DOCX documents (a zip archive with an XML body plus embedded
+## image parts). Standalone: not implied by `image` or `tabular`.
+codec-docx = ["elide/codec-docx"]
+
+# Internal shared-code gates. Not part of the public feature
+# surface: enabled transitively by every user-facing feature that
+# needs the corresponding modality's analyzer, anonymizer, and
+# redaction operators. Never set directly by consumers.
+internal_tabular = []
+internal_image = []
+internal_audio = []
 
 ## Turn on the test-only mock variants
 ## (`{Ner,Ocr,Stt,Llm}BackendConfig::Mock`) and the elide mock

--- a/crates/nvisy-engine/src/engine/analyzer/mod.rs
+++ b/crates/nvisy-engine/src/engine/analyzer/mod.rs
@@ -23,17 +23,23 @@
 //! [`Orchestrator`]: elide::Orchestrator
 //! [`Orchestrator::with_scope`]: elide::Orchestrator::with_scope
 
+#[cfg(feature = "internal_audio")]
 mod audio;
 mod catalog;
 mod common;
+#[cfg(feature = "internal_image")]
 mod image;
+#[cfg(feature = "internal_tabular")]
 mod tabular;
 mod text;
 
 use elide::detection::Analyzer;
 use elide_core::Error;
+#[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
+#[cfg(feature = "internal_image")]
 use elide_core::modality::image::Image;
+#[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_core::llm::LlmConfig;
@@ -51,14 +57,19 @@ pub(crate) use self::catalog::LabelCatalogCompile;
 /// compile fn consults the deployment [`NerConfig`] when the
 /// request toggles `recognizers.ner = true`; text and image
 /// also consult [`LlmConfig`] when `recognizers.llm = true`.
+///
+/// Non-text methods are gated on their modality's feature.
 pub(crate) trait AnalyzerCompile {
     /// Build the text-modality analyzer.
     fn compile_text(&self, ner: &NerConfig, llm: &LlmConfig) -> Result<Analyzer<Text>, Error>;
     /// Build the tabular-modality analyzer.
+    #[cfg(feature = "internal_tabular")]
     fn compile_tabular(&self, ner: &NerConfig) -> Result<Analyzer<Tabular>, Error>;
     /// Build the image-modality analyzer.
+    #[cfg(feature = "internal_image")]
     fn compile_image(&self, ner: &NerConfig, llm: &LlmConfig) -> Result<Analyzer<Image>, Error>;
     /// Build the audio-modality analyzer.
+    #[cfg(feature = "internal_audio")]
     fn compile_audio(&self, ner: &NerConfig) -> Result<Analyzer<Audio>, Error>;
 }
 
@@ -67,14 +78,17 @@ impl AnalyzerCompile for AnalyzerParams {
         self::text::compile(self, ner, llm)
     }
 
+    #[cfg(feature = "internal_tabular")]
     fn compile_tabular(&self, ner: &NerConfig) -> Result<Analyzer<Tabular>, Error> {
         self::tabular::compile(self, ner)
     }
 
+    #[cfg(feature = "internal_image")]
     fn compile_image(&self, ner: &NerConfig, llm: &LlmConfig) -> Result<Analyzer<Image>, Error> {
         self::image::compile(self, ner, llm)
     }
 
+    #[cfg(feature = "internal_audio")]
     fn compile_audio(&self, ner: &NerConfig) -> Result<Analyzer<Audio>, Error> {
         self::audio::compile(self, ner)
     }

--- a/crates/nvisy-engine/src/engine/anonymizer/mod.rs
+++ b/crates/nvisy-engine/src/engine/anonymizer/mod.rs
@@ -34,15 +34,21 @@
 //!
 //! [`Anonymizer`]: elide::redaction::Anonymizer
 
+#[cfg(feature = "internal_audio")]
 mod audio;
 mod dispatch;
+#[cfg(feature = "internal_image")]
 mod image;
 mod selector;
+#[cfg(feature = "internal_tabular")]
 mod tabular;
 mod text;
 mod text_op;
 
+#[cfg(feature = "internal_audio")]
 pub(crate) use self::audio::{attach_override_audio, attach_policies_audio};
+#[cfg(feature = "internal_image")]
 pub(crate) use self::image::{attach_override_image, attach_policies_image};
+#[cfg(feature = "internal_tabular")]
 pub(crate) use self::tabular::{attach_override_tabular, attach_policies_tabular};
 pub(crate) use self::text::{attach_override_text, attach_policies_text};

--- a/crates/nvisy-engine/src/engine/document.rs
+++ b/crates/nvisy-engine/src/engine/document.rs
@@ -18,8 +18,11 @@ use std::collections::HashMap;
 
 use elide_core::entity::Entity;
 use elide_core::modality::Modality;
+#[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
+#[cfg(feature = "internal_image")]
 use elide_core::modality::image::Image;
+#[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_schema::policy::RuleAction;
@@ -59,16 +62,22 @@ pub enum RecognizedGroup {
         entities: Vec<EntityRecord<Text>>,
     },
     /// Tabular entities.
+    #[cfg(feature = "internal_tabular")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tabular")))]
     Tabular {
         /// Recognized entities, in source-coordinate order.
         entities: Vec<EntityRecord<Tabular>>,
     },
     /// Image entities.
+    #[cfg(feature = "internal_image")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
     Image {
         /// Recognized entities, in source-coordinate order.
         entities: Vec<EntityRecord<Image>>,
     },
     /// Audio entities.
+    #[cfg(feature = "internal_audio")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "audio")))]
     Audio {
         /// Recognized entities, in source-coordinate order.
         entities: Vec<EntityRecord<Audio>>,

--- a/crates/nvisy-engine/src/engine/mod.rs
+++ b/crates/nvisy-engine/src/engine/mod.rs
@@ -66,8 +66,11 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use elide::codec::{FormatRegistry, PartId, UntypedDocumentHandle};
+#[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
+#[cfg(feature = "internal_image")]
 use elide_core::modality::image::Image;
+#[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_core::{Error, Result};
@@ -167,21 +170,26 @@ impl Engine {
 
         // Walk the body modality slots in order; the first that
         // returns Some is the body modality the orchestrator's
-        // codec resolved. `body` ends up None only if no pipeline
-        // accepted the body — defensive, since all four are wired.
-        let body_group = take_body::<Text>(&mut report)
-            .or_else(|| take_body::<Tabular>(&mut report))
-            .or_else(|| take_body::<Image>(&mut report))
-            .or_else(|| take_body::<Audio>(&mut report))
-            .ok_or_else(|| {
-                Error::validation(
-                    format!(
-                        "codec resolved {extension:?} to a modality the orchestrator \
-                         has no pipeline for"
-                    ),
-                    COMPONENT,
-                )
-            })?;
+        // codec resolved. Only the modalities compiled in are
+        // considered; a document decoded to a disabled modality
+        // ends up in the `None` arm and surfaces as Validation.
+        let body_group = take_body::<Text>(&mut report);
+        #[cfg(feature = "internal_tabular")]
+        let body_group = body_group.or_else(|| take_body::<Tabular>(&mut report));
+        #[cfg(feature = "internal_image")]
+        let body_group = body_group.or_else(|| take_body::<Image>(&mut report));
+        #[cfg(feature = "internal_audio")]
+        let body_group = body_group.or_else(|| take_body::<Audio>(&mut report));
+
+        let body_group = body_group.ok_or_else(|| {
+            Error::validation(
+                format!(
+                    "codec resolved {extension:?} to a modality the orchestrator \
+                     has no pipeline for"
+                ),
+                COMPONENT,
+            )
+        })?;
 
         // Walk the parts in the same way: collect (id, modality)
         // pairs first (read-borrow), then drain each part with the
@@ -192,18 +200,7 @@ impl Engine {
             .collect();
         let mut parts = HashMap::with_capacity(part_ids.len());
         for (id, type_id) in part_ids {
-            let group = if type_id == TypeId::of::<Text>() {
-                take_part::<Text>(&mut report, &id)
-            } else if type_id == TypeId::of::<Tabular>() {
-                take_part::<Tabular>(&mut report, &id)
-            } else if type_id == TypeId::of::<Image>() {
-                take_part::<Image>(&mut report, &id)
-            } else if type_id == TypeId::of::<Audio>() {
-                take_part::<Audio>(&mut report, &id)
-            } else {
-                // Pipeline modality the engine doesn't model. Skip.
-                continue;
-            };
+            let group = take_part_dispatch(&mut report, &id, type_id);
             if let Some(group) = group {
                 parts.insert(id.as_str().to_owned(), group);
             }
@@ -286,4 +283,31 @@ impl Engine {
                 .with_source(err)
             })
     }
+}
+
+/// Dispatch a part to the take-part helper matching its modality
+/// `TypeId`. Feature-gated per modality; a part whose modality is
+/// disabled in this build falls through to `None`, and the caller
+/// treats it the same as a part the engine doesn't model.
+fn take_part_dispatch(
+    report: &mut elide::Report,
+    id: &PartId,
+    type_id: TypeId,
+) -> Option<self::document::RecognizedGroup> {
+    if type_id == TypeId::of::<Text>() {
+        return take_part::<Text>(report, id);
+    }
+    #[cfg(feature = "internal_tabular")]
+    if type_id == TypeId::of::<Tabular>() {
+        return take_part::<Tabular>(report, id);
+    }
+    #[cfg(feature = "internal_image")]
+    if type_id == TypeId::of::<Image>() {
+        return take_part::<Image>(report, id);
+    }
+    #[cfg(feature = "internal_audio")]
+    if type_id == TypeId::of::<Audio>() {
+        return take_part::<Audio>(report, id);
+    }
+    None
 }

--- a/crates/nvisy-engine/src/engine/orchestrator.rs
+++ b/crates/nvisy-engine/src/engine/orchestrator.rs
@@ -14,8 +14,11 @@ use elide::Orchestrator;
 use elide::redaction::Anonymizer;
 use elide_core::entity::LabelCatalog;
 use elide_core::modality::Modality;
+#[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
+#[cfg(feature = "internal_image")]
 use elide_core::modality::image::Image;
+#[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_core::{Error, Result};
@@ -25,10 +28,13 @@ use uuid::Uuid;
 
 use super::Engine;
 use super::analyzer::{AnalyzerCompile, LabelCatalogCompile};
-use super::anonymizer::{
-    attach_override_audio, attach_override_image, attach_override_tabular, attach_override_text,
-    attach_policies_audio, attach_policies_image, attach_policies_tabular, attach_policies_text,
-};
+use super::anonymizer::{attach_override_text, attach_policies_text};
+#[cfg(feature = "internal_audio")]
+use super::anonymizer::{attach_override_audio, attach_policies_audio};
+#[cfg(feature = "internal_image")]
+use super::anonymizer::{attach_override_image, attach_policies_image};
+#[cfg(feature = "internal_tabular")]
+use super::anonymizer::{attach_override_tabular, attach_policies_tabular};
 
 const COMPONENT: &str = "engine::orchestrator";
 
@@ -78,43 +84,57 @@ impl Engine {
             attach_override_text,
             attach_policies_text,
         )?;
-        let tabular = assemble::<Tabular, _, _>(
-            &catalog,
-            overrides,
-            policies,
-            attach_override_tabular,
-            attach_policies_tabular,
-        )?;
-        let image = assemble::<Image, _, _>(
-            &catalog,
-            overrides,
-            policies,
-            attach_override_image,
-            attach_policies_image,
-        )?;
-        let audio = assemble::<Audio, _, _>(
-            &catalog,
-            overrides,
-            policies,
-            attach_override_audio,
-            attach_policies_audio,
-        )?;
-
         let text_analyzer = spec
             .compile_text(&self.ner, &self.llm)
             .map_err(compile_err)?;
-        let tabular_analyzer = spec.compile_tabular(&self.ner).map_err(compile_err)?;
-        let image_analyzer = spec
-            .compile_image(&self.ner, &self.llm)
-            .map_err(compile_err)?;
-        let audio_analyzer = spec.compile_audio(&self.ner).map_err(compile_err)?;
 
-        Ok(Orchestrator::new(&self.formats)
+        #[allow(unused_mut)]
+        let mut orchestrator = Orchestrator::new(&self.formats)
             .with_scope(scope)
-            .with_modality::<Text>(text_analyzer, text)
-            .with_modality::<Tabular>(tabular_analyzer, tabular)
-            .with_modality::<Image>(image_analyzer, image)
-            .with_modality::<Audio>(audio_analyzer, audio))
+            .with_modality::<Text>(text_analyzer, text);
+
+        #[cfg(feature = "internal_tabular")]
+        {
+            let tabular = assemble::<Tabular, _, _>(
+                &catalog,
+                overrides,
+                policies,
+                attach_override_tabular,
+                attach_policies_tabular,
+            )?;
+            let tabular_analyzer = spec.compile_tabular(&self.ner).map_err(compile_err)?;
+            orchestrator = orchestrator.with_modality::<Tabular>(tabular_analyzer, tabular);
+        }
+
+        #[cfg(feature = "internal_image")]
+        {
+            let image = assemble::<Image, _, _>(
+                &catalog,
+                overrides,
+                policies,
+                attach_override_image,
+                attach_policies_image,
+            )?;
+            let image_analyzer = spec
+                .compile_image(&self.ner, &self.llm)
+                .map_err(compile_err)?;
+            orchestrator = orchestrator.with_modality::<Image>(image_analyzer, image);
+        }
+
+        #[cfg(feature = "internal_audio")]
+        {
+            let audio = assemble::<Audio, _, _>(
+                &catalog,
+                overrides,
+                policies,
+                attach_override_audio,
+                attach_policies_audio,
+            )?;
+            let audio_analyzer = spec.compile_audio(&self.ner).map_err(compile_err)?;
+            orchestrator = orchestrator.with_modality::<Audio>(audio_analyzer, audio);
+        }
+
+        Ok(orchestrator)
     }
 }
 

--- a/crates/nvisy-engine/src/engine/report.rs
+++ b/crates/nvisy-engine/src/engine/report.rs
@@ -34,8 +34,11 @@ use std::mem;
 use elide::codec::{PartId, UntypedDocumentHandle};
 use elide_core::entity::Entity;
 use elide_core::modality::Modality;
+#[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
+#[cfg(feature = "internal_image")]
 use elide_core::modality::image::Image;
+#[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_core::{Error, Result};
@@ -69,8 +72,11 @@ macro_rules! impl_group_carrier {
 }
 
 impl_group_carrier!(Text, Text);
+#[cfg(feature = "internal_tabular")]
 impl_group_carrier!(Tabular, Tabular);
+#[cfg(feature = "internal_image")]
 impl_group_carrier!(Image, Image);
+#[cfg(feature = "internal_audio")]
 impl_group_carrier!(Audio, Audio);
 
 /// Drain the body's entities from `report` into a
@@ -95,12 +101,15 @@ pub(super) fn take_part<M: GroupCarrier>(
 pub(super) fn insert_body(report: elide::Report, group: &RecognizedGroup) -> elide::Report {
     match group {
         RecognizedGroup::Text { entities } => report.insert_body::<Text>(clone_entities(entities)),
+        #[cfg(feature = "internal_tabular")]
         RecognizedGroup::Tabular { entities } => {
             report.insert_body::<Tabular>(clone_entities(entities))
         }
+        #[cfg(feature = "internal_image")]
         RecognizedGroup::Image { entities } => {
             report.insert_body::<Image>(clone_entities(entities))
         }
+        #[cfg(feature = "internal_audio")]
         RecognizedGroup::Audio { entities } => {
             report.insert_body::<Audio>(clone_entities(entities))
         }
@@ -118,12 +127,15 @@ pub(super) fn insert_part(
         RecognizedGroup::Text { entities } => {
             report.insert_part::<Text>(part_id, clone_entities(entities))
         }
+        #[cfg(feature = "internal_tabular")]
         RecognizedGroup::Tabular { entities } => {
             report.insert_part::<Tabular>(part_id, clone_entities(entities))
         }
+        #[cfg(feature = "internal_image")]
         RecognizedGroup::Image { entities } => {
             report.insert_part::<Image>(part_id, clone_entities(entities))
         }
+        #[cfg(feature = "internal_audio")]
         RecognizedGroup::Audio { entities } => {
             report.insert_part::<Audio>(part_id, clone_entities(entities))
         }
@@ -143,8 +155,11 @@ where
 pub(super) fn collect_overrides_into(out: &mut Vec<(Uuid, RuleAction)>, group: &RecognizedGroup) {
     match group {
         RecognizedGroup::Text { entities } => extend_overrides(out, entities),
+        #[cfg(feature = "internal_tabular")]
         RecognizedGroup::Tabular { entities } => extend_overrides(out, entities),
+        #[cfg(feature = "internal_image")]
         RecognizedGroup::Image { entities } => extend_overrides(out, entities),
+        #[cfg(feature = "internal_audio")]
         RecognizedGroup::Audio { entities } => extend_overrides(out, entities),
     }
 }
@@ -168,8 +183,11 @@ pub(super) fn encode_redacted(
 ) -> Result<ApplyOutcome> {
     match body {
         RecognizedGroup::Text { .. } => encode_typed::<Text>(handle, "Text"),
+        #[cfg(feature = "internal_tabular")]
         RecognizedGroup::Tabular { .. } => encode_typed::<Tabular>(handle, "Tabular"),
+        #[cfg(feature = "internal_image")]
         RecognizedGroup::Image { .. } => encode_typed::<Image>(handle, "Image"),
+        #[cfg(feature = "internal_audio")]
         RecognizedGroup::Audio { .. } => encode_typed::<Audio>(handle, "Audio"),
     }
 }


### PR DESCRIPTION
## Summary

Two coupled changes:

1. **Modality features actually gate the code now.** Before this PR, `nvisy-engine`'s `tabular` / `image` / `audio` / `document` features looked like modality toggles but the engine's code referenced all four modalities unconditionally. Turning any feature off broke the build with 9 compile errors. The features were only forwarding elide's `codec-*` side, not the redaction-operator side, and no `#[cfg]` gated the modality-specific code paths. Latent bug — nobody hit it because `default = ["tabular", "image", "audio", "document"]` always enabled them all.
2. **Per-format codec control.** New individual `codec-*` toggles let consumers disable specific formats (e.g. `codec-mp3` is opt-in only, so downstreams with MP3 patent-license concerns are covered).

## Feature layout

Mirrors elide's `internal_*` convention: user-facing features forward to hidden `internal_tabular` / `internal_image` / `internal_audio` gates, which are the actual `#[cfg]` sites in the code.

**User-facing:**
- `tabular`: shared code + CSV + XLSX
- `image`: shared code + PNG + JPEG + TIFF
- `audio`: shared code + WAV **(mp3 explicitly excluded — licensing)**
- `codec-csv`, `codec-xlsx`, `codec-png`, `codec-jpeg`, `codec-tiff`, `codec-wav`, `codec-mp3`, `codec-docx`: individual format toggles. Each transitively enables its modality's shared code.

**Default:** `["tabular", "image", "audio", "codec-docx"]` — everything except MP3.

**Removed:** the old `document` alias; it was just `codec-docx` in disguise.

## Where `#[cfg]` was added

- `engine::analyzer::{audio,image,tabular}` modules + their re-exports + `AnalyzerCompile` trait methods.
- `engine::anonymizer::{audio,image,tabular}` modules + their re-exports.
- `engine::orchestrator::build_orchestrator`: text is unconditional; each other modality's `with_modality::<M>` sits in `#[cfg]` blocks.
- `engine::mod::analyze_document`: `take_body::<M>` fallback chain + per-part modality dispatch (via new `take_part_dispatch` helper).
- `engine::report`: match arms in `insert_body` / `insert_part` / `collect_overrides_into` / `encode_redacted`.
- `engine::document::RecognizedGroup`: variants gated per modality with `#[cfg_attr(docsrs, doc(cfg(…)))]` so docs.rs renders the modality attribution.

## Verified locally

`cargo check` across the whole feature matrix:

| Features | Compiles |
|---|---|
| defaults | ✅ |
| `--no-default-features` | ✅ |
| `audio` only | ✅ |
| `image` only | ✅ |
| `tabular` only | ✅ |
| `codec-png` | ✅ |
| `codec-jpeg` | ✅ |
| `codec-mp3` | ✅ |
| `codec-wav` | ✅ |
| `audio,codec-mp3` | ✅ |
| `audio image` | ✅ |
| `image tabular` | ✅ |

`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (3 multimodal tests pass), `RUSTDOCFLAGS='--cfg docsrs -D warnings' cargo +nightly doc --workspace --no-deps`, and `cargo deny check` all green.

Includes an elide bump `39e3acc4 → 4e56ae5f` (no downstream API changes).

## Test plan

- [ ] CI green on all matrix jobs (defaults)
- [ ] Downstream MP3-license-blocked consumers can now build with `default-features = false, features = ["tabular", "image", "audio", "codec-docx"]`
- [ ] Text-only build works: `default-features = false, features = []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)