### PR TITLE
Engine walkthrough cleanups + Cargo.toml heading harmonization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,7 @@ version = "0.1.0"
 dependencies = [
  "derive_builder",
  "derive_more",
+ "elide-core",
  "elide-llm",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,18 +32,17 @@ documentation = "https://docs.rs/nvisy-runtime"
 #
 # See for more details: https://github.com/rust-lang/cargo/issues/11329
 
-# Elide toolkit (upstream)
+# Elide crates
 elide = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-core = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-detection = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-redaction = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-# Pulled directly only by `elide-bento`, which implements the per-backend traits these crates export.
 elide-llm = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-ner = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-ocr = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-stt = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 
-# Runtime-owned elide extensions
+# Elide extensions
 elide-bento = { path = "./crates/elide-bento", version = "0.1.0" }
 
 # Internal crates

--- a/crates/elide-bento/Cargo.toml
+++ b/crates/elide-bento/Cargo.toml
@@ -32,7 +32,7 @@ ner = ["dep:elide-ner"]
 ocr = ["dep:elide-ocr", "dep:base64", "elide-core/image"]
 
 [dependencies]
-# Elide toolkit (upstream)
+# Elide crates
 elide-core = { workspace = true, features = [] }
 elide-ner = { workspace = true, features = [], optional = true }
 elide-ocr = { workspace = true, features = [], optional = true }
@@ -40,20 +40,21 @@ elide-ocr = { workspace = true, features = [], optional = true }
 # Serialization
 serde = { workspace = true, features = ["derive"] }
 
+# Derive macros and error handling
+thiserror = { workspace = true, features = [] }
+
 # Primitive datatypes
 hipstr = { workspace = true, features = [] }
 
-# Async runtime
-async-trait = { workspace = true, features = [] }
-
-# Error handling
-thiserror = { workspace = true, features = [] }
-
-# Image bytes → base64 (OCR only)
+# Encoding and hashing
 base64 = { workspace = true, features = [], optional = true }
 
-# BentoML client
+# Async runtime and parallelism
+async-trait = { workspace = true, features = [] }
+
+# AI / LLM frameworks
 bentoml = { workspace = true, default-features = false, features = ["rustls-tls", "tracing"] }
 
 [dev-dependencies]
+# Async runtime and parallelism
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/nvisy-context/Cargo.toml
+++ b/crates/nvisy-context/Cargo.toml
@@ -23,16 +23,14 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-# Elide's stable wire vocabulary: primitive types (LanguageTag,
-# BoundingBox, TimeSpan) plus modality types. No codec, no LLM, no
-# runtime plumbing — elide-core is the SDK-safe subset.
+# Elide crates
 elide-core = { workspace = true, features = ["serde", "schema"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }
 schemars = { workspace = true, features = ["uuid1", "semver1"] }
 
-# Derive macros
+# Derive macros and error handling
 derive_builder = { workspace = true, features = [] }
 derive_more = { workspace = true, features = ["from"] }
 
@@ -42,5 +40,5 @@ jiff = { workspace = true, features = ["serde"] }
 semver = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-# Round-trip tests serialize + deserialize schema values.
+# Serialization
 serde_json = { workspace = true, features = [] }

--- a/crates/nvisy-core/Cargo.toml
+++ b/crates/nvisy-core/Cargo.toml
@@ -31,21 +31,17 @@ default = []
 test-utils = []
 
 [dependencies]
-# LLM types (`Provider`, `AuthenticatedProvider`, `UnauthenticatedProvider`).
-# The provider features gate their enum variants — turning them on is what
-# makes `Provider::OpenAi` etc. exist. Rig comes along for the ride.
+# Elide crates
+elide-core = { workspace = true, features = [] }
 elide-llm = { workspace = true, features = ["rig", "openai-gpt", "anthropic-claude", "google-gemini"] }
 
-# Serialization — needed for the LLM config's derive-serde types.
+# Serialization
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = [] }
 schemars = { workspace = true, features = [] }
 
-# Error type deps: `Error::From<serde_json::Error>` +
-# `Error::From<derive_builder::UninitializedFieldError>` map upstream
-# errors into the shared vocabulary.
+# Derive macros and error handling
 thiserror = { workspace = true, features = [] }
-strum = { workspace = true, features = ["derive"] }
 derive_more = { workspace = true, features = ["display"] }
 derive_builder = { workspace = true, features = [] }
-
+strum = { workspace = true, features = ["derive"] }

--- a/crates/nvisy-core/src/error.rs
+++ b/crates/nvisy-core/src/error.rs
@@ -273,5 +273,26 @@ impl From<derive_builder::UninitializedFieldError> for Error {
     }
 }
 
+impl From<elide_core::Error> for Error {
+    /// Map elide's per-operation error into the runtime's shared
+    /// vocabulary. The elide `ErrorKind` is preserved semantically
+    /// via a mapping onto the nearest [`ErrorKind`] variant; the
+    /// original elide error travels along as the source cause.
+    ///
+    /// Called at every `nvisy-engine` seam where an `elide::Error`
+    /// crosses into engine-land — pattern compile, recognizer
+    /// build, anonymizer attach, orchestrator analyze/anonymize.
+    fn from(err: elide_core::Error) -> Self {
+        let kind = match err.kind() {
+            elide_core::ErrorKind::OutOfRange | elide_core::ErrorKind::Validation => {
+                ErrorKind::Validation
+            }
+            elide_core::ErrorKind::Transport => ErrorKind::Connection,
+            _ => ErrorKind::Runtime,
+        };
+        Self::new(kind, err.to_string()).with_source(err)
+    }
+}
+
 /// Convenience type alias for results using the Nvisy error type.
 pub type Result<T, E = Error> = result::Result<T, E>;

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -74,56 +74,45 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+# Elide crates
+elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "llm", "llm-rig", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "serde", "schema", "sha2"] }
+elide-core = { workspace = true, features = ["serde", "schema", "image", "audio", "tabular"] }
+elide-llm = { workspace = true, features = ["jinja2"] }
+elide-ocr = { workspace = true, features = [] }
+elide-stt = { workspace = true, features = [] }
+
+# Elide extensions
+elide-bento = { workspace = true, features = ["ner", "ocr"] }
+
 # Internal crates
 nvisy-core = { workspace = true, features = [] }
 nvisy-schema = { workspace = true, features = [] }
 
-# Elide toolkit (upstream). `mock` pulls the no-op NER stub; the LLM
-# features pull the rig backend (`llm-rig`, needed for Ollama) plus
-# the three authenticated providers.
-elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "llm", "llm-rig", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "serde", "schema", "sha2"] }
-
-# `Jinja2Prompt` loader for deployment-configured per-recognizer
-# prompt templates. Not re-exported from the elide umbrella, so
-# we depend directly.
-elide-llm = { workspace = true, features = ["jinja2"] }
-elide-core = { workspace = true, features = ["serde", "schema", "image", "audio", "tabular"] }
-
-# Recognition-side elide crates not re-exported through the elide
-# umbrella the way the recognizer crates are (`elide::recognition::*`
-# is the natural reach for those). `elide-ocr` is the OCR enricher
-# layer engine wires from the image-modality compile path.
-elide-ocr = { workspace = true, features = [] }
-elide-stt = { workspace = true, features = [] }
-
-# Runtime-owned elide extensions
-elide-bento = { workspace = true, features = ["ner", "ocr"] }
+# Serialization
+serde = { workspace = true, features = ["derive"] }
+schemars = { workspace = true, features = [] }
 
 # Primitive datatypes
 uuid = { workspace = true, features = [] }
 bytes = { workspace = true, features = [] }
-serde = { workspace = true, features = ["derive"] }
-schemars = { workspace = true, features = [] }
 
-# Structured logging — surface non-fatal anomalies (unknown
-# builtin label name in a catalog request, etc.).
+# Observability
 tracing = { workspace = true, features = [] }
 
 [dev-dependencies]
-# Turn on the test-only mock variants
-# (`{Ner,Ocr,Stt,Llm}BackendConfig::Mock`) so integration tests
-# can construct a working analyzer without hitting a real Bento
-# backend or LLM provider.
+# Internal crates
 nvisy-engine = { path = ".", features = ["test-utils"] }
 
-# Async runtime and parallelism
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+# Serialization
+serde_json = { workspace = true, features = [] }
 
-# Primitives referenced from test fixtures.
-hipstr = { workspace = true, features = [] }
+# Primitive datatypes
 uuid = { workspace = true, features = ["v7"] }
 bytes = { workspace = true, features = [] }
+hipstr = { workspace = true, features = [] }
 
 # Test utilities
 zip = { workspace = true }
-serde_json = { workspace = true, features = [] }
+
+# Async runtime and parallelism
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/nvisy-engine/src/analyzer/audio.rs
+++ b/crates/nvisy-engine/src/analyzer/audio.rs
@@ -41,9 +41,7 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    if spec.recognizers.ner {
-        analyzer = attach_ner_lineup(analyzer, ner)?;
-    }
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/analyzer/image.rs
+++ b/crates/nvisy-engine/src/analyzer/image.rs
@@ -46,12 +46,13 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    if spec.recognizers.ner {
-        analyzer = attach_ner_lineup(analyzer, ner)?;
-    }
-    if spec.recognizers.llm {
-        analyzer = attach_llm_lineup(analyzer, llm, LlmRecognizerModality::Image)?;
-    }
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
+    analyzer = attach_llm_lineup(
+        analyzer,
+        llm,
+        LlmRecognizerModality::Image,
+        spec.recognizers.llm,
+    )?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
@@ -40,7 +40,7 @@ use nvisy_core::llm::{
 /// - `DefaultPrompt: Prompt<M>` — elide ships text + image
 ///   default prompts.
 /// - `Jinja2Prompt<M>: Prompt<M>` — same coverage.
-pub(crate) fn attach_llm_lineup<M>(
+pub(in crate::analyzer) fn attach_llm_lineup<M>(
     mut analyzer: Analyzer<M>,
     llm: &LlmConfig,
     modality: LlmRecognizerModality,

--- a/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
@@ -18,14 +18,20 @@ use nvisy_core::llm::{
 };
 
 /// Attach every LLM recognizer in `llm.recognizers` whose
-/// modality list includes `modality` to `analyzer`. Errors when:
+/// modality list includes `modality` to `analyzer`, dispatched on
+/// the request's three-state toggle.
 ///
-/// - The lineup has no recognizer for this modality (compile is
-///   only invoked when the request toggled `llm = true`, so
-///   "nothing configured for this modality" is user-visible).
-/// - A recognizer's `modalities` list is empty.
-/// - A Jinja2 prompt file / template fails to load or compile.
-/// - A provider-client construction (rig) fails.
+/// - `Some(true)`: explicit opt-in. Attaches every configured
+///   recognizer whose declared modalities include `modality`;
+///   errors when zero match.
+/// - `Some(false)`: explicit opt-out. Returns the analyzer
+///   unchanged.
+/// - `None`: softly-on default. Attaches every matching
+///   recognizer if any match; skips silently otherwise.
+///
+/// Errors on: any recognizer whose `modalities` list is empty
+/// (bad config), Jinja2 prompt load/compile failure, provider
+/// client construction failure.
 ///
 /// Bound explanation:
 ///
@@ -38,6 +44,7 @@ pub(crate) fn attach_llm_lineup<M>(
     mut analyzer: Analyzer<M>,
     llm: &LlmConfig,
     modality: LlmRecognizerModality,
+    toggle: Option<bool>,
 ) -> Result<Analyzer<M>, Error>
 where
     M: LlmModality,
@@ -45,6 +52,9 @@ where
     DefaultPrompt: Prompt<M>,
     Jinja2Prompt<M>: Prompt<M>,
 {
+    if toggle == Some(false) {
+        return Ok(analyzer);
+    }
     let mut matched = 0usize;
     for recognizer in &llm.recognizers {
         if recognizer.modalities.is_empty() {
@@ -63,13 +73,13 @@ where
         matched += 1;
         analyzer = attach_one(analyzer, recognizer)?;
     }
-    if matched == 0 {
+    if matched == 0 && toggle == Some(true) {
         return Err(Error::new(
             ErrorKind::Validation,
             format!(
                 "AnalyzerParams.recognizers.llm = true but the deployment has no LLM \
                  recognizer configured for the {modality:?} modality; add one to \
-                 `[[llm.recognizers]]` in the deployment config or leave `llm = false`",
+                 `[[llm.recognizers]]` in the deployment config or leave `llm` unset / false",
             ),
         ));
     }

--- a/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
@@ -4,7 +4,8 @@
 //! backend (or `MockBackend` under the `test-utils` feature).
 //!
 //! Symmetric with [`super::llm`]; called by every per-modality
-//! compile function when `AnalyzerParams.recognizers.ner == true`.
+//! compile function with the request's
+//! `AnalyzerParams.recognizers.ner` three-state toggle.
 //!
 //! [`Analyzer`]: elide::detection::Analyzer
 //! [`NerConfig::recognizers`]: nvisy_core::ner::NerConfig::recognizers
@@ -17,26 +18,37 @@ use elide_core::modality::TextRecognizable;
 use elide_core::recognition::Recognizer;
 use nvisy_core::ner::{NerBackendConfig, NerConfig, NerRecognizer as ConfigNerRecognizer};
 
-/// Attach every recognizer from the deployment's NER lineup.
-/// Errors when the lineup is empty (compile is only invoked when
-/// the request toggled `ner = true`, so "no recognizers
-/// configured" is user-visible). Modality-generic for any
-/// `M: TextRecognizable`.
+/// Attach every recognizer from the deployment's NER lineup,
+/// dispatched on the request's three-state toggle.
+///
+/// - `Some(true)`: explicit opt-in. Attaches every configured
+///   recognizer; errors if the lineup is empty.
+/// - `Some(false)`: explicit opt-out. Returns the analyzer
+///   unchanged.
+/// - `None`: softly-on default. Attaches every configured
+///   recognizer if the lineup is non-empty; skips silently
+///   otherwise.
 pub(in crate::analyzer) fn attach_ner_lineup<M>(
     mut analyzer: Analyzer<M>,
     ner: &NerConfig,
+    toggle: Option<bool>,
 ) -> Result<Analyzer<M>, Error>
 where
     M: TextRecognizable,
     NerRecognizer: Recognizer<M> + 'static,
 {
-    if ner.recognizers.is_empty() {
-        return Err(Error::new(
-            elide_core::ErrorKind::Validation,
-            "AnalyzerParams.recognizers.ner = true but the deployment has no NER \
-             recognizer configured; add one to `[[ner.recognizers]]` in the \
-             deployment config or leave `ner = false`",
-        ));
+    match toggle {
+        Some(false) => return Ok(analyzer),
+        None if ner.recognizers.is_empty() => return Ok(analyzer),
+        Some(true) if ner.recognizers.is_empty() => {
+            return Err(Error::new(
+                elide_core::ErrorKind::Validation,
+                "AnalyzerParams.recognizers.ner = true but the deployment has no NER \
+                 recognizer configured; add one to `[[ner.recognizers]]` in the \
+                 deployment config or leave `ner` unset / false",
+            ));
+        }
+        _ => {}
     }
     for recognizer in &ner.recognizers {
         analyzer = attach_ner_one(analyzer, recognizer)?;

--- a/crates/nvisy-engine/src/analyzer/tabular.rs
+++ b/crates/nvisy-engine/src/analyzer/tabular.rs
@@ -35,9 +35,7 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    if spec.recognizers.ner {
-        analyzer = attach_ner_lineup(analyzer, ner)?;
-    }
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/analyzer/text.rs
+++ b/crates/nvisy-engine/src/analyzer/text.rs
@@ -2,9 +2,11 @@
 //! [`elide::detection::Analyzer<Text>`].
 //!
 //! Text supports the full recognizer set: Pattern, NER, and LLM.
-//! NER and LLM are opt-in via `spec.recognizers.ner = true` /
-//! `spec.recognizers.llm = true`; the deployment's [`NerConfig`]
-//! and [`LlmConfig`] provide the actual recognizer lineups.
+//! NER and LLM are three-state toggles on
+//! `spec.recognizers.{ner,llm}` (see
+//! [`nvisy_schema::plan::RecognizerParams`]); the deployment's
+//! [`NerConfig`] and [`LlmConfig`] provide the actual recognizer
+//! lineups.
 //!
 //! Modality-foreign enrichers (`ocr`, `stt`) on `spec` are
 //! silently ignored; those flow through the modalities they
@@ -44,12 +46,13 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    if spec.recognizers.ner {
-        analyzer = attach_ner_lineup(analyzer, ner)?;
-    }
-    if spec.recognizers.llm {
-        analyzer = attach_llm_lineup(analyzer, llm, LlmRecognizerModality::Text)?;
-    }
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
+    analyzer = attach_llm_lineup(
+        analyzer,
+        llm,
+        LlmRecognizerModality::Text,
+        spec.recognizers.llm,
+    )?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/anonymizer/compile/selector.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/selector.rs
@@ -52,7 +52,7 @@ pub(super) fn fallback_attribution(policy: &Policy) -> Attribution {
 /// sentinel `policy_id = "override"` so audits can distinguish
 /// override-driven redactions from policy-driven ones; `reason`
 /// carries the overridden entity's id.
-pub(crate) fn override_attribution(entity_id: Uuid) -> Attribution {
+pub(super) fn override_attribution(entity_id: Uuid) -> Attribution {
     Attribution {
         policy_id: "override".into(),
         reason: Some(entity_id.to_string().into()),
@@ -63,7 +63,7 @@ pub(crate) fn override_attribution(entity_id: Uuid) -> Attribution {
 /// identified by `entity_id`. Used by the apply pipeline to give
 /// reviewer overrides higher precedence than any policy-driven
 /// rule.
-pub(crate) fn attach_override<M, O>(
+pub(super) fn attach_override<M, O>(
     anonymizer: Anonymizer<M>,
     entity_id: Uuid,
     operator: O,

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -99,9 +99,7 @@ use nvisy_schema::policy::{Policy, PolicyAction};
 use uuid::Uuid;
 
 pub use self::analyzed::{AnalyzedDocument, EntityRecord, RecognizedGroup};
-use self::report::{
-    collect_overrides_into, encode_redacted, insert_body, insert_part, take_body, take_part,
-};
+use self::report::{take_body, take_part};
 
 const COMPONENT: &str = "pipeline";
 
@@ -312,12 +310,12 @@ impl Engine {
         })?;
         let correlation_id = document.correlation_id;
         let mut handle = self.decode(document).await?;
-        let mut report = insert_body(Report::new(), body_group);
+        let mut report = body_group.insert_into_body(Report::new());
         let mut overrides: Vec<(Uuid, PolicyAction)> = Vec::new();
-        collect_overrides_into(&mut overrides, body_group);
+        body_group.collect_overrides_into(&mut overrides);
         for (id, group) in &analyzed.parts {
-            report = insert_part(report, id.as_str(), group);
-            collect_overrides_into(&mut overrides, group);
+            report = group.insert_as_part(report, id.as_str());
+            group.collect_overrides_into(&mut overrides);
         }
 
         let orchestrator = self.build_anonymize_orchestrator(
@@ -333,7 +331,7 @@ impl Engine {
                 Error::internal("orchestrator anonymize_with failed", COMPONENT).with_source(err)
             })?;
 
-        encode_redacted(handle, body_group)
+        body_group.encode_redacted_from(handle)
     }
 
     async fn decode(&self, document: Document) -> Result<UntypedDocumentHandle> {

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -218,9 +218,7 @@ impl Engine {
         let extension = document.extension.clone();
         let mut handle = self.decode(document).await?;
         let (orchestrator, scope) = self.build_analyze_orchestrator(spec, correlation_id)?;
-        let mut report = orchestrator.analyze(&mut handle).await.map_err(|err| {
-            Error::internal("orchestrator analyze failed", COMPONENT).with_source(err)
-        })?;
+        let mut report = orchestrator.analyze(&mut handle).await?;
 
         // Walk the body modality slots in order; the first that
         // returns Some is the body modality the orchestrator's
@@ -324,12 +322,7 @@ impl Engine {
             &overrides,
             correlation_id,
         )?;
-        orchestrator
-            .anonymize_with(&mut handle, report)
-            .await
-            .map_err(|err| {
-                Error::internal("orchestrator anonymize_with failed", COMPONENT).with_source(err)
-            })?;
+        orchestrator.anonymize_with(&mut handle, report).await?;
 
         body_group.encode_redacted_from(handle)
     }

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -40,7 +40,7 @@ use elide_core::modality::image::Image;
 #[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
-use nvisy_core::{Error, Result};
+use nvisy_core::Result;
 use nvisy_schema::plan::AnalyzerParams;
 use nvisy_schema::policy::{Policy, PolicyAction};
 use uuid::Uuid;
@@ -54,8 +54,6 @@ use crate::anonymizer::{attach_override_image, attach_policies_image};
 #[cfg(feature = "internal_tabular")]
 use crate::anonymizer::{attach_override_tabular, attach_policies_tabular};
 use crate::anonymizer::{attach_override_text, attach_policies_text};
-
-const COMPONENT: &str = "pipeline::orchestrator";
 
 impl Engine {
     /// Build an [`Orchestrator`] for the analyze path: compile
@@ -89,41 +87,32 @@ impl Engine {
         };
 
         let text_anon = assemble_empty::<Text>(&catalog);
-        let text_analyzer = spec
-            .compile_text(&self.ner, &self.llm, &self.pattern_guardrails)
-            .map_err(compile_err)?;
+        let text_analyzer = spec.compile_text(&self.ner, &self.llm, &self.pattern_guardrails)?;
 
-        #[allow(unused_mut)]
-        let mut orchestrator = Orchestrator::new(&self.formats)
+        let orchestrator = Orchestrator::new(&self.formats)
             .with_scope(live_scope)
             .with_modality::<Text>(text_analyzer, text_anon);
 
         #[cfg(feature = "internal_tabular")]
-        {
+        let orchestrator = {
             let anon = assemble_empty::<Tabular>(&catalog);
-            let analyzer = spec
-                .compile_tabular(&self.ner, &self.pattern_guardrails)
-                .map_err(compile_err)?;
-            orchestrator = orchestrator.with_modality::<Tabular>(analyzer, anon);
-        }
+            let analyzer = spec.compile_tabular(&self.ner, &self.pattern_guardrails)?;
+            orchestrator.with_modality::<Tabular>(analyzer, anon)
+        };
 
         #[cfg(feature = "internal_image")]
-        {
+        let orchestrator = {
             let anon = assemble_empty::<Image>(&catalog);
-            let analyzer = spec
-                .compile_image(&self.ner, &self.llm, &self.pattern_guardrails)
-                .map_err(compile_err)?;
-            orchestrator = orchestrator.with_modality::<Image>(analyzer, anon);
-        }
+            let analyzer = spec.compile_image(&self.ner, &self.llm, &self.pattern_guardrails)?;
+            orchestrator.with_modality::<Image>(analyzer, anon)
+        };
 
         #[cfg(feature = "internal_audio")]
-        {
+        let orchestrator = {
             let anon = assemble_empty::<Audio>(&catalog);
-            let analyzer = spec
-                .compile_audio(&self.ner, &self.pattern_guardrails)
-                .map_err(compile_err)?;
-            orchestrator = orchestrator.with_modality::<Audio>(analyzer, anon);
-        }
+            let analyzer = spec.compile_audio(&self.ner, &self.pattern_guardrails)?;
+            orchestrator.with_modality::<Audio>(analyzer, anon)
+        };
 
         Ok((orchestrator, persisted_scope))
     }
@@ -168,13 +157,12 @@ impl Engine {
             attach_policies_text,
         )?;
 
-        #[allow(unused_mut)]
-        let mut orchestrator = Orchestrator::new(&self.formats)
+        let orchestrator = Orchestrator::new(&self.formats)
             .with_scope(live_scope)
             .with_modality::<Text>(Analyzer::<Text>::new(), text_anon);
 
         #[cfg(feature = "internal_tabular")]
-        {
+        let orchestrator = {
             let anon = assemble::<Tabular, _, _>(
                 catalog,
                 overrides,
@@ -182,11 +170,11 @@ impl Engine {
                 attach_override_tabular,
                 attach_policies_tabular,
             )?;
-            orchestrator = orchestrator.with_modality::<Tabular>(Analyzer::<Tabular>::new(), anon);
-        }
+            orchestrator.with_modality::<Tabular>(Analyzer::<Tabular>::new(), anon)
+        };
 
         #[cfg(feature = "internal_image")]
-        {
+        let orchestrator = {
             let anon = assemble::<Image, _, _>(
                 catalog,
                 overrides,
@@ -194,11 +182,11 @@ impl Engine {
                 attach_override_image,
                 attach_policies_image,
             )?;
-            orchestrator = orchestrator.with_modality::<Image>(Analyzer::<Image>::new(), anon);
-        }
+            orchestrator.with_modality::<Image>(Analyzer::<Image>::new(), anon)
+        };
 
         #[cfg(feature = "internal_audio")]
-        {
+        let orchestrator = {
             let anon = assemble::<Audio, _, _>(
                 catalog,
                 overrides,
@@ -206,8 +194,8 @@ impl Engine {
                 attach_override_audio,
                 attach_policies_audio,
             )?;
-            orchestrator = orchestrator.with_modality::<Audio>(Analyzer::<Audio>::new(), anon);
-        }
+            orchestrator.with_modality::<Audio>(Analyzer::<Audio>::new(), anon)
+        };
 
         Ok(orchestrator)
     }
@@ -250,17 +238,7 @@ where
 {
     let mut anonymizer = Anonymizer::<M>::new().with_catalog(catalog.clone());
     for (id, action) in overrides {
-        anonymizer = attach_override(anonymizer, *id, action).map_err(compile_err)?;
+        anonymizer = attach_override(anonymizer, *id, action)?;
     }
-    attach_policies(anonymizer, policies.iter()).map_err(compile_err)
-}
-
-/// Translate an `elide::Error` from a `compile_*` call into the
-/// runtime's error type. Compile failures are caller-driven (e.g.
-/// unsupported recognizer for the modality), so they map to
-/// [`Validation`].
-///
-/// [`Validation`]: nvisy_core::ErrorKind::Validation
-fn compile_err(err: elide::Error) -> Error {
-    Error::validation(format!("orchestrator compile failed: {err}"), COMPONENT).with_source(err)
+    Ok(attach_policies(anonymizer, policies.iter())?)
 }

--- a/crates/nvisy-engine/src/pipeline/report.rs
+++ b/crates/nvisy-engine/src/pipeline/report.rs
@@ -7,16 +7,18 @@
 //!   [`Report`], [`take_body`] and [`take_part`] move each typed
 //!   `Vec<Entity<M>>` out of the report into the matching
 //!   [`RecognizedGroup`] variant for the caller to hold.
-//! - **Rebuild**: at anonymize time, [`insert_body`] and
-//!   [`insert_part`] feed a fresh [`Report`] from the returned
-//!   groups (cloning entities; the returned body is the source
-//!   of truth for re-apply idempotency).
+//! - **Rebuild**: at anonymize time,
+//!   [`RecognizedGroup::insert_into_body`] and
+//!   [`RecognizedGroup::insert_as_part`] feed a fresh [`Report`]
+//!   from the returned groups (cloning entities; the returned
+//!   body is the source of truth for re-apply idempotency).
 //!
 //! Plus two byte-level helpers used at the anonymize seam:
-//! [`collect_overrides_into`] walks reviewer overrides off any
-//! group, and [`encode_redacted`] picks the right typed handle
-//! to re-encode through after `anonymize_with` mutated the
-//! document in place.
+//! [`RecognizedGroup::collect_overrides_into`] walks reviewer
+//! overrides off any group, and
+//! [`RecognizedGroup::encode_redacted_from`] picks the right
+//! typed handle to re-encode through after `anonymize_with`
+//! mutated the document in place.
 //!
 //! All helpers are stateless: no [`Engine`] state, no I/O. The
 //! per-modality dispatch is collapsed onto one trait
@@ -98,43 +100,80 @@ pub(super) fn take_part<M: GroupCarrier>(
     Some(M::into_group(entities))
 }
 
-/// Insert the body group into `report` under its modality.
-pub(super) fn insert_body(report: Report, group: &RecognizedGroup) -> Report {
-    match group {
-        RecognizedGroup::Text { entities } => report.insert_body::<Text>(clone_entities(entities)),
-        #[cfg(feature = "internal_tabular")]
-        RecognizedGroup::Tabular { entities } => {
-            report.insert_body::<Tabular>(clone_entities(entities))
-        }
-        #[cfg(feature = "internal_image")]
-        RecognizedGroup::Image { entities } => {
-            report.insert_body::<Image>(clone_entities(entities))
-        }
-        #[cfg(feature = "internal_audio")]
-        RecognizedGroup::Audio { entities } => {
-            report.insert_body::<Audio>(clone_entities(entities))
+impl RecognizedGroup {
+    /// Insert this group into `report` under its modality, as
+    /// the body.
+    pub(super) fn insert_into_body(&self, report: Report) -> Report {
+        match self {
+            Self::Text { entities } => report.insert_body::<Text>(clone_entities(entities)),
+            #[cfg(feature = "internal_tabular")]
+            Self::Tabular { entities } => report.insert_body::<Tabular>(clone_entities(entities)),
+            #[cfg(feature = "internal_image")]
+            Self::Image { entities } => report.insert_body::<Image>(clone_entities(entities)),
+            #[cfg(feature = "internal_audio")]
+            Self::Audio { entities } => report.insert_body::<Audio>(clone_entities(entities)),
         }
     }
-}
 
-/// Insert one part group into `report` under its modality.
-pub(super) fn insert_part(report: Report, id: &str, group: &RecognizedGroup) -> Report {
-    let part_id = PartId::from(id.to_owned());
-    match group {
-        RecognizedGroup::Text { entities } => {
-            report.insert_part::<Text>(part_id, clone_entities(entities))
+    /// Insert this group into `report` under its modality, as a
+    /// container part keyed by `id`.
+    pub(super) fn insert_as_part(&self, report: Report, id: &str) -> Report {
+        let part_id = PartId::from(id.to_owned());
+        match self {
+            Self::Text { entities } => {
+                report.insert_part::<Text>(part_id, clone_entities(entities))
+            }
+            #[cfg(feature = "internal_tabular")]
+            Self::Tabular { entities } => {
+                report.insert_part::<Tabular>(part_id, clone_entities(entities))
+            }
+            #[cfg(feature = "internal_image")]
+            Self::Image { entities } => {
+                report.insert_part::<Image>(part_id, clone_entities(entities))
+            }
+            #[cfg(feature = "internal_audio")]
+            Self::Audio { entities } => {
+                report.insert_part::<Audio>(part_id, clone_entities(entities))
+            }
         }
-        #[cfg(feature = "internal_tabular")]
-        RecognizedGroup::Tabular { entities } => {
-            report.insert_part::<Tabular>(part_id, clone_entities(entities))
+    }
+
+    /// Append every reviewer override on this group to `out`.
+    ///
+    /// Iterates the variant-appropriate `Vec<EntityRecord<M>>`
+    /// and keeps only records whose `reviewer_override` field is
+    /// set.
+    pub(super) fn collect_overrides_into(&self, out: &mut Vec<(Uuid, PolicyAction)>) {
+        match self {
+            Self::Text { entities } => extend_overrides(out, entities),
+            #[cfg(feature = "internal_tabular")]
+            Self::Tabular { entities } => extend_overrides(out, entities),
+            #[cfg(feature = "internal_image")]
+            Self::Image { entities } => extend_overrides(out, entities),
+            #[cfg(feature = "internal_audio")]
+            Self::Audio { entities } => extend_overrides(out, entities),
         }
-        #[cfg(feature = "internal_image")]
-        RecognizedGroup::Image { entities } => {
-            report.insert_part::<Image>(part_id, clone_entities(entities))
-        }
-        #[cfg(feature = "internal_audio")]
-        RecognizedGroup::Audio { entities } => {
-            report.insert_part::<Audio>(part_id, clone_entities(entities))
+    }
+
+    /// Recover the typed handle for this group's modality (the
+    /// document body's modality) and re-encode it into an
+    /// [`AnonymizedDocument`].
+    ///
+    /// Called after `anonymize_with` mutated `handle` in place.
+    /// The apply-time re-encode needs the typed form because
+    /// [`elide::codec::DocumentHandle::encode`] is per-modality.
+    pub(super) fn encode_redacted_from(
+        &self,
+        handle: UntypedDocumentHandle,
+    ) -> Result<AnonymizedDocument> {
+        match self {
+            Self::Text { .. } => encode_typed::<Text>(handle, "Text"),
+            #[cfg(feature = "internal_tabular")]
+            Self::Tabular { .. } => encode_typed::<Tabular>(handle, "Tabular"),
+            #[cfg(feature = "internal_image")]
+            Self::Image { .. } => encode_typed::<Image>(handle, "Image"),
+            #[cfg(feature = "internal_audio")]
+            Self::Audio { .. } => encode_typed::<Audio>(handle, "Audio"),
         }
     }
 }
@@ -146,47 +185,12 @@ where
     records.iter().map(|r| r.entity.clone()).collect()
 }
 
-/// Append every reviewer override on `group` to `out`. Iterates
-/// the variant-appropriate `Vec<EntityRecord<M>>` and keeps only
-/// records whose `override` field is set.
-pub(super) fn collect_overrides_into(out: &mut Vec<(Uuid, PolicyAction)>, group: &RecognizedGroup) {
-    match group {
-        RecognizedGroup::Text { entities } => extend_overrides(out, entities),
-        #[cfg(feature = "internal_tabular")]
-        RecognizedGroup::Tabular { entities } => extend_overrides(out, entities),
-        #[cfg(feature = "internal_image")]
-        RecognizedGroup::Image { entities } => extend_overrides(out, entities),
-        #[cfg(feature = "internal_audio")]
-        RecognizedGroup::Audio { entities } => extend_overrides(out, entities),
-    }
-}
-
 fn extend_overrides<M: Modality>(out: &mut Vec<(Uuid, PolicyAction)>, records: &[EntityRecord<M>]) {
     out.extend(records.iter().filter_map(|r| {
         r.reviewer_override
             .as_ref()
             .map(|a| (r.entity.id, a.clone()))
     }));
-}
-
-/// After `anonymize_with` mutated `handle` in place, recover the
-/// typed handle for the doc's body modality and re-encode it.
-/// `handle` was a typed `DocumentHandle<M>` before being erased;
-/// the apply-time re-encode needs the typed form because
-/// [`elide::codec::DocumentHandle::encode`] is per-modality.
-pub(super) fn encode_redacted(
-    handle: UntypedDocumentHandle,
-    body: &RecognizedGroup,
-) -> Result<AnonymizedDocument> {
-    match body {
-        RecognizedGroup::Text { .. } => encode_typed::<Text>(handle, "Text"),
-        #[cfg(feature = "internal_tabular")]
-        RecognizedGroup::Tabular { .. } => encode_typed::<Tabular>(handle, "Tabular"),
-        #[cfg(feature = "internal_image")]
-        RecognizedGroup::Image { .. } => encode_typed::<Image>(handle, "Image"),
-        #[cfg(feature = "internal_audio")]
-        RecognizedGroup::Audio { .. } => encode_typed::<Audio>(handle, "Audio"),
-    }
 }
 
 fn encode_typed<M>(handle: UntypedDocumentHandle, name: &'static str) -> Result<AnonymizedDocument>

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -39,8 +39,8 @@ fn default_spec() -> AnalyzerParams {
                 context_enhanced: true,
                 ..Default::default()
             }),
-            ner: false,
-            llm: false,
+            ner: Some(false),
+            llm: Some(false),
         },
         enrichers: nvisy_schema::plan::EnricherParams {
             language: None,

--- a/crates/nvisy-engine/tests/patterns.rs
+++ b/crates/nvisy-engine/tests/patterns.rs
@@ -27,8 +27,8 @@ fn spec_with_pattern_params(params: PatternRecognizerParams) -> AnalyzerParams {
     AnalyzerParams {
         recognizers: nvisy_schema::plan::RecognizerParams {
             pattern: Some(params),
-            ner: false,
-            llm: false,
+            ner: Some(false),
+            llm: Some(false),
         },
         ..Default::default()
     }

--- a/crates/nvisy-policy/Cargo.toml
+++ b/crates/nvisy-policy/Cargo.toml
@@ -23,16 +23,14 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-# Elide's stable wire vocabulary: entity types (Label) plus modality
-# types (Waveform is pulled by the audio redaction spec) plus primitive
-# types (Color). elide-core is the SDK-safe subset.
+# Elide crates
 elide-core = { workspace = true, features = ["serde", "schema", "audio"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }
 schemars = { workspace = true, features = ["uuid1", "semver1"] }
 
-# Derive macros
+# Derive macros and error handling
 derive_more = { workspace = true, features = ["display"] }
 strum = { workspace = true, features = ["derive"] }
 

--- a/crates/nvisy-schema/Cargo.toml
+++ b/crates/nvisy-schema/Cargo.toml
@@ -32,18 +32,12 @@ default = []
 test-utils = []
 
 [dependencies]
-# Sibling schema crates re-exported through this umbrella so a
-# single `nvisy-schema` dep gives an SDK caller the whole wire
-# surface. Consumers who want tighter dep trees can depend on
-# `nvisy-policy` or `nvisy-context` directly and skip this crate.
+# Elide crates
+elide-core = { workspace = true, features = ["serde", "schema", "image", "audio", "tabular"] }
+
+# Internal crates
 nvisy-context = { workspace = true, features = [] }
 nvisy-policy = { workspace = true, features = [] }
-
-# Elide's stable wire vocabulary: primitive types (LanguageTag,
-# CountryCode, BoundingBox, ConfidenceThreshold) + modality types +
-# entity types. No codec, no LLM, no runtime plumbing — elide-core is
-# the SDK-safe subset.
-elide-core = { workspace = true, features = ["serde", "schema", "image", "audio", "tabular"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nvisy-schema/src/plan/recognizer.rs
+++ b/crates/nvisy-schema/src/plan/recognizer.rs
@@ -10,11 +10,12 @@
 //!   ([`CustomDictionary`]) alongside the shipped `builtins`;
 //!   the engine compiles them per request.
 //! - **NER** is a **deployment-owned lineup** gated by a
-//!   boolean toggle. Provider, model, and (future) credentials
-//!   live in the deployment config; the wire only opts in or
-//!   out.
-//! - **LLM** is the same shape as NER: a deployment-owned
-//!   lineup gated by a boolean toggle.
+//!   three-state toggle. Provider, model, and (future)
+//!   credentials live in the deployment config; the wire opts in
+//!   (`true`), opts out (`false`), or leaves it to the default
+//!   (`None`, softly-on: attach when the deployment has any NER
+//!   configured, skip otherwise).
+//! - **LLM** is the same shape as NER.
 //!
 //! Rationale for the NER/LLM shape: policies stay portable
 //! across deployments, the operator controls model choice and
@@ -31,7 +32,8 @@ use super::pattern::{CustomDictionary, CustomPatternRule};
 /// Recognizer slots an analyzer can fill.
 ///
 /// Pattern is at-most-one (per-request); NER and LLM are
-/// deployment-owned lineups each gated by a boolean toggle.
+/// deployment-owned lineups each gated by a three-state
+/// [`Option<bool>`] toggle.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RecognizerParams {
@@ -42,26 +44,26 @@ pub struct RecognizerParams {
     pub pattern: Option<PatternRecognizerParams>,
     /// Run the deployment's NER recognizer lineup.
     ///
-    /// `false` skips NER recognition entirely; `true` attaches
-    /// every deployment-configured recognizer. When the
-    /// deployment has no NER recognizers configured, `true` fails
-    /// the analyzer compile with a `Validation` error.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub ner: bool,
+    /// - `Some(true)`: explicit opt-in. Attaches every
+    ///   deployment-configured recognizer. Fails the analyzer
+    ///   compile with a `Validation` error when the deployment
+    ///   has no NER recognizers configured.
+    /// - `Some(false)`: explicit opt-out. Skips NER entirely.
+    /// - `None`: softly-on default. Attaches every configured
+    ///   recognizer if the deployment has any; skips silently
+    ///   otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ner: Option<bool>,
     /// Run the deployment's LLM recognizer lineup.
     ///
-    /// `false` skips LLM recognition entirely; `true` attaches
-    /// every deployment-configured recognizer whose declared
-    /// modalities match the analyzer's modality. When the
-    /// deployment has no LLM recognizers configured for this
-    /// modality, `true` fails the analyzer compile with a
-    /// `Validation` error.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub llm: bool,
-}
-
-fn is_false(b: &bool) -> bool {
-    !*b
+    /// Same three-state semantics as [`ner`]. The lineup is
+    /// filtered by declared modality — only recognizers whose
+    /// `modalities` list contains the analyzer's modality
+    /// attach.
+    ///
+    /// [`ner`]: RecognizerParams::ner
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub llm: Option<bool>,
 }
 
 /// Params for the `elide-pattern` recognizer.


### PR DESCRIPTION
## Summary

Four small quality passes from a walkthrough of \`nvisy-engine\`:

1. **\`RecognizerParams.ner/llm\` → \`Option<bool>\`** — three-state semantics. Softly-on default (\`None\`) skips silently when the deployment lineup is empty; \`Some(true)\` is explicit opt-in and errors on empty lineup; \`Some(false)\` is explicit opt-out. Requests that used to send \`{}\` no longer explode on deployments without NER/LLM configured. Dispatch moves into \`attach_ner_lineup\` / \`attach_llm_lineup\` — per-modality entries pass the toggle through.
2. **\`RecognizedGroup\` methods** — four free fns in \`pipeline/report.rs\` become methods on \`RecognizedGroup\`: \`insert_body\` → \`insert_into_body\`, \`insert_part\` → \`insert_as_part\`, \`collect_overrides_into\` stays as a method, \`encode_redacted\` → \`encode_redacted_from\`. Reads more naturally at the call site.
3. **Engine walkthrough cleanups**:
   - New \`impl From<elide_core::Error> for nvisy_core::Error\`. \`?\` composes across the seam; deletes \`compile_err\` fn + \`COMPONENT\` const in \`pipeline::orchestrator\`; trims two \`.map_err\` blocks in \`pipeline::mod\`.
   - Remove both \`#[allow(unused_mut)]\` from \`pipeline::orchestrator\` — replaced with cfg-gated shadowing \`let orchestrator = { ... }\` blocks. Respects the standing no-\`allow\`-attrs rule.
   - Visibility harmonization: \`attach_llm_lineup\` → \`pub(in crate::analyzer)\` (matches siblings). \`override_attribution\` + \`attach_override\` in \`anonymizer/compile/selector\` → \`pub(super)\` (only used within \`compile/\`).
4. **Cargo.toml heading harmonization** — every per-crate \`[dependencies]\` and \`[dev-dependencies]\` now uses the exact section-heading vocabulary from the workspace root: \`Elide crates\`, \`Elide extensions\`, \`Internal crates\`, \`Serialization\`, \`Derive macros and error handling\`, \`Primitive datatypes\`, \`Encoding and hashing\`, \`Test utilities\`, \`Async runtime and parallelism\`, \`Observability\`, \`AI / LLM frameworks\`. Same order across every crate; no per-line justification prose.

## Test plan

- [ ] CI green
- [ ] \`make rust-ci\` locally (verified before push)
- [ ] Anyone calling with \`{}\` (default \`RecognizerParams\`) against a bare deployment doesn't hit an unexpected error — softly-on default absorbs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)