### PR TITLE
Bump elide, adopt Scope.tags rename, drop redundant elide-llm dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,7 +839,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "bytes",
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "bytes",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -941,7 +941,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#b0fbfbade1f51610ec31e8a200a6fc1abc3ac76e"
+source = "git+https://github.com/nvisycom/elide?branch=main#d26329519f48d85602b23899dd59789f99d67120"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -2465,7 +2465,6 @@ dependencies = [
  "elide",
  "elide-bento",
  "elide-core",
- "elide-llm",
  "elide-ocr",
  "elide-stt",
  "hipstr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,8 +2465,6 @@ dependencies = [
  "elide",
  "elide-bento",
  "elide-core",
- "elide-ocr",
- "elide-stt",
  "hipstr",
  "nvisy-core",
  "nvisy-engine",

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -66,7 +66,6 @@ test-utils = [
     "elide/mock",
     "elide-ocr/mock",
     "elide-stt/mock",
-    "elide-llm/mock",
 ]
 
 [package.metadata.docs.rs]
@@ -75,9 +74,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Elide crates
-elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "llm", "llm-rig", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "serde", "schema", "sha2"] }
+elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "llm", "llm-rig", "llm-jinja2", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "serde", "schema", "sha2"] }
 elide-core = { workspace = true, features = ["serde", "schema", "image", "audio", "tabular"] }
-elide-llm = { workspace = true, features = ["jinja2"] }
 elide-ocr = { workspace = true, features = [] }
 elide-stt = { workspace = true, features = [] }
 

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -64,8 +64,6 @@ test-utils = [
     "nvisy-core/test-utils",
     "nvisy-schema/test-utils",
     "elide/mock",
-    "elide-ocr/mock",
-    "elide-stt/mock",
 ]
 
 [package.metadata.docs.rs]
@@ -74,10 +72,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Elide crates
-elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "llm", "llm-rig", "llm-jinja2", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "serde", "schema", "sha2"] }
+elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "ocr", "stt", "llm", "llm-rig", "llm-jinja2", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "serde", "schema", "sha2"] }
 elide-core = { workspace = true, features = ["serde", "schema", "image", "audio", "tabular"] }
-elide-ocr = { workspace = true, features = [] }
-elide-stt = { workspace = true, features = [] }
 
 # Elide extensions
 elide-bento = { workspace = true, features = ["ner", "ocr"] }

--- a/crates/nvisy-engine/src/analyzer/enricher/ocr.rs
+++ b/crates/nvisy-engine/src/analyzer/enricher/ocr.rs
@@ -6,12 +6,12 @@
 //! OCR.
 
 use elide::detection::Analyzer;
+#[cfg(feature = "test-utils")]
+use elide::enrichment::ocr::MockBackend as MockOcrBackend;
+use elide::enrichment::ocr::OcrEnricher;
 use elide_bento::BentoOcr;
 use elide_core::Error;
 use elide_core::modality::image::Image;
-#[cfg(feature = "test-utils")]
-use elide_ocr::MockBackend as MockOcrBackend;
-use elide_ocr::OcrEnricher;
 use nvisy_schema::plan::{OcrBackendParams, OcrEnricherParams};
 
 /// Attach an [`OcrEnricher`] for the image modality.

--- a/crates/nvisy-engine/src/analyzer/enricher/stt.rs
+++ b/crates/nvisy-engine/src/analyzer/enricher/stt.rs
@@ -6,15 +6,15 @@
 //! Validation.
 
 use elide::detection::Analyzer;
+#[cfg(feature = "test-utils")]
+use elide::enrichment::stt::{MockBackend as MockSttBackend, SttEnricher};
 use elide_core::modality::audio::Audio;
 use elide_core::{Error, ErrorKind};
-#[cfg(feature = "test-utils")]
-use elide_stt::{MockBackend as MockSttBackend, SttEnricher};
 use nvisy_schema::plan::{SttBackendParams, SttEnricherParams};
 
 /// Attach an [`SttEnricher`] for the audio modality.
 ///
-/// [`SttEnricher`]: elide_stt::SttEnricher
+/// [`SttEnricher`]: elide::enrichment::stt::SttEnricher
 pub(in crate::analyzer) fn attach(
     analyzer: Analyzer<Audio>,
     spec: &SttEnricherParams,

--- a/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
@@ -5,13 +5,13 @@
 //! `test-utils` feature).
 
 use elide::detection::Analyzer;
+#[cfg(feature = "test-utils")]
+use elide::recognition::llm::backend::MockBackend as MockLlmBackend;
+use elide::recognition::llm::backend::{LlmBackend, LlmModality, RigBackend};
+use elide::recognition::llm::prompt::{DefaultPrompt, Jinja2Prompt, Prompt};
+use elide::recognition::llm::provider::Provider;
 use elide::recognition::llm::{LlmRecognizer, LlmRecognizerBuilder};
 use elide_core::{Error, ErrorKind};
-#[cfg(feature = "test-utils")]
-use elide_llm::backend::MockBackend as MockLlmBackend;
-use elide_llm::backend::{LlmBackend, LlmModality, RigBackend};
-use elide_llm::prompt::{DefaultPrompt, Jinja2Prompt, Prompt};
-use elide_llm::provider::Provider;
 use nvisy_core::llm::{
     LlmBackendConfig, LlmConfig, LlmPrompt, LlmRecognizer as ConfigRecognizer,
     LlmRecognizerModality,

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -12,7 +12,7 @@
 //! re-resolve policies and overrides per document at anonymize
 //! time without mutating a shared anonymizer.
 //!
-//! [`RigBackend`]: elide_llm::backend::RigBackend
+//! [`RigBackend`]: elide::recognition::llm::backend::RigBackend
 //!
 //! Two entry points:
 //!
@@ -77,7 +77,7 @@ impl Engine {
         let persisted_scope = Scope {
             languages: spec.scope.languages.clone(),
             countries: spec.scope.countries.clone(),
-            labels: spec.scope.labels.clone(),
+            tags: spec.scope.tags.clone(),
             catalog: catalog.clone(),
             correlation_id: None,
         };

--- a/crates/nvisy-schema/src/plan/analyzer.rs
+++ b/crates/nvisy-schema/src/plan/analyzer.rs
@@ -21,14 +21,14 @@ use super::recognizer::RecognizerParams;
 /// The caller-asserted scope lives under [`scope`], a single
 /// nested object grouping the four knobs the engine assembles
 /// into an `elide::recognition::Scope` at compile time
-/// ([`languages`], [`countries`], [`labels`], [`label_catalog`]).
+/// ([`languages`], [`countries`], [`tags`], [`label_catalog`]).
 /// `Scope`'s fifth knob, `correlation_id`, is server-minted per
 /// request and never appears on the wire.
 ///
 /// [`scope`]: AnalyzerParams::scope
 /// [`languages`]: ScopeParams::languages
 /// [`countries`]: ScopeParams::countries
-/// [`labels`]: ScopeParams::labels
+/// [`tags`]: ScopeParams::tags
 /// [`label_catalog`]: ScopeParams::label_catalog
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -52,7 +52,7 @@ pub struct AnalyzerParams {
     pub deduplication: DeduplicationParams,
     /// Caller-asserted scope.
     ///
-    /// Languages, jurisdictions, document labels, and the
+    /// Languages, jurisdictions, document tags, and the
     /// per-request entity-label catalog. Engine assembles this
     /// (plus a server-minted correlation id) into an
     /// `elide::recognition::Scope` at compile time.
@@ -84,19 +84,20 @@ pub struct ScopeParams {
     /// jurisdiction don't lose detections.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub countries: Vec<CountryCode>,
-    /// Document-level classification labels.
+    /// Document-level classification tags.
     ///
     /// E.g. `"medical"`, `"gdpr-request"`. Recognizers may use
     /// these to bias their behaviour for domain-specific terms;
     /// those that don't ignore the field.
     ///
-    /// Distinct from [`label_catalog`]: these classify the
-    /// *document*, whereas the catalog names the entity *types*
-    /// to emit.
+    /// Named `tags`, not `labels`, to keep "label" reserved for
+    /// the entity taxonomy ([`label_catalog`]): these classify
+    /// the *document*, whereas the catalog names the entity
+    /// *types* to emit.
     ///
     /// [`label_catalog`]: ScopeParams::label_catalog
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub labels: Vec<String>,
+    pub tags: Vec<String>,
     /// Per-request entity-label catalog.
     ///
     /// Builtins selected by name + custom inline schemas. Drives

--- a/crates/nvisy-schema/src/plan/analyzer.rs
+++ b/crates/nvisy-schema/src/plan/analyzer.rs
@@ -90,10 +90,9 @@ pub struct ScopeParams {
     /// these to bias their behaviour for domain-specific terms;
     /// those that don't ignore the field.
     ///
-    /// Named `tags`, not `labels`, to keep "label" reserved for
-    /// the entity taxonomy ([`label_catalog`]): these classify
-    /// the *document*, whereas the catalog names the entity
-    /// *types* to emit.
+    /// Distinct from [`label_catalog`]: tags classify the
+    /// *document*, whereas the catalog names the entity *types*
+    /// to emit.
     ///
     /// [`label_catalog`]: ScopeParams::label_catalog
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## Summary

Adopts three upstream elide changes on rev \`d2632951\`.

## Changes

- **Elide rev** \`b0fbfbad\` → \`d2632951\`.
- **\`Scope.labels\` → \`Scope.tags\`** on the elide side. Ripples to the wire: \`ScopeParams.labels\` → \`ScopeParams.tags\`. Docstring reproduces elide's rationale — "label" stays reserved for the entity taxonomy (\`LabelRef\`/\`LabelCatalog\`), \`tags\` classify the document.
- **Fold \`elide-llm\` into the \`elide\` umbrella** in \`nvisy-engine\`. Jinja2 prompt loader now flows through the umbrella's \`llm-jinja2\` feature, so the direct dep on \`elide-llm\` is gone. Imports rewritten from \`elide_llm::{backend,prompt,provider}::*\` to \`elide::recognition::llm::{backend,prompt,provider}::*\`. The stale \`"elide-llm/mock"\` in the \`test-utils\` feature is dropped — \`"elide/mock"\` propagates it via \`elide-llm?/mock\` under the umbrella.

\`nvisy-core\` keeps its direct \`elide-llm\` dep (it uses \`elide_llm::provider::{AuthenticatedProvider, UnauthenticatedProvider}\` for the deployment LLM config).

## Wire break

Callers who serialize \`ScopeParams\` with an explicit \`"labels": [...]\` field now need to send \`"tags": [...]\` instead. The old field name is not aliased — an explicit break, matching the elide rename.

## Test plan

- [ ] CI green (verified: \`make rust-ci\` locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)