### PR TITLE
Re-export nvisy_core essentials from nvisy-engine

### DIFF
--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -27,3 +27,17 @@ pub use self::analyzer::PatternGuardrails;
 pub use self::pipeline::{
     AnalyzedDocument, AnonymizedDocument, Engine, EntityRecord, RecognizedGroup,
 };
+
+/// Deployment-owned LLM recognizer lineup consumed by
+/// [`Engine::with_llm`]. Re-exported from [`nvisy_core::llm`] so
+/// engine callers don't need `nvisy-core` as a separate dep.
+pub use nvisy_core::llm;
+/// Deployment-owned NER recognizer lineup consumed by
+/// [`Engine::with_ner`]. Re-exported from [`nvisy_core::ner`] so
+/// engine callers don't need `nvisy-core` as a separate dep.
+pub use nvisy_core::ner;
+/// Runtime error vocabulary. [`Error`] is what every fallible
+/// `Engine` method returns via [`Result`]. Re-exported from
+/// [`nvisy_core`] so engine callers don't need it as a separate
+/// dep.
+pub use nvisy_core::{Error, ErrorKind, Result};


### PR DESCRIPTION
## Summary

\`Engine::with_ner\` and \`Engine::with_llm\` take \`nvisy_core::ner::NerConfig\` and \`nvisy_core::llm::LlmConfig\` in their signatures. Every fallible \`Engine\` method returns \`Result<T, nvisy_core::Error>\`. Callers embedding the engine had to add \`nvisy-core\` as a separate dep just to name the types they were already handing to (or receiving from) the engine.

## Changes

\`crates/nvisy-engine/src/lib.rs\` now re-exports:

- \`nvisy_core::ner\` module — \`NerConfig\`, \`NerBackendConfig\`, \`NerRecognizer\` for building deployment NER lineups.
- \`nvisy_core::llm\` module — \`LlmConfig\`, \`LlmBackendConfig\`, \`LlmRecognizer\`, \`LlmPrompt\`, \`LlmRecognizerModality\` for building deployment LLM lineups.
- \`nvisy_core::{Error, ErrorKind, Result}\` — the runtime error vocabulary every \`Engine\` method surfaces.

Engine consumers can now depend on just \`nvisy-engine\` for the full runtime-side API.

## Test plan

- [ ] CI green (verified: \`make rust-ci\` locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)