### PR TITLE
Add per-request recognizer allowlist + list accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "bytes",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "bytes",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -937,7 +937,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -995,7 +995,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#a29a152ec00d3d2d3ca36ee4b9e55a867744b17e"
+source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/elide-bento/src/ner/mod.rs
+++ b/crates/elide-bento/src/ner/mod.rs
@@ -77,13 +77,15 @@ impl BentoNer {
         self
     }
 
-    /// Send one batched `/recognize` POST and parse the response
-    /// body. Clones the cached endpoint so per-request headers
-    /// layer on without touching the original.
+    /// Send one batched `/recognize` POST end-to-end: encode
+    /// each [`NerRequest`] to its wire form, POST the batch
+    /// (layering `x-request-id` when any request carries a
+    /// correlation id), decode the wire responses back to
+    /// [`NerResponse`]s.
     async fn post_recognize(
         &self,
         requests: &[NerRequest<'_>],
-    ) -> Result<Vec<WireNerResponse>, BentoError> {
+    ) -> Result<Vec<NerResponse>, BentoError> {
         let body: Vec<WireNerRequest> = requests
             .iter()
             .map(|r| WireNerRequest::from_request(r, self.default_threshold))
@@ -92,10 +94,11 @@ impl BentoNer {
         if let Some(id) = requests.iter().find_map(|r| r.correlation_id) {
             endpoint = endpoint.with_request_id(id.to_string());
         }
-        endpoint
-            .invoke::<_, Vec<WireNerResponse>>(&body)
+        let wire: Vec<WireNerResponse> = endpoint
+            .invoke(&body)
             .await
-            .map_err(BentoError::Transport)
+            .map_err(BentoError::Transport)?;
+        Ok(wire.into_iter().map(WireNerResponse::decode).collect())
     }
 }
 
@@ -110,18 +113,10 @@ impl NerBackend for BentoNer {
     }
 
     async fn recognize(&self, request: NerRequest<'_>) -> Result<NerResponse> {
-        let responses = self.post_recognize(&[request]).await?;
-        let mut iter = responses.into_iter();
-        let response = iter
-            .next()
-            .ok_or_else(|| BentoError::Protocol("bento ner returned an empty batch".into()))?;
-        if iter.next().is_some() {
-            return Err(BentoError::Protocol(
-                "bento ner returned more responses than requests".into(),
-            )
-            .into());
-        }
-        Ok(response.decode())
+        let mut responses = self.recognize_batch(&[request]).await?;
+        responses.pop().ok_or_else(|| {
+            BentoError::Protocol("bento ner returned an empty batch".into()).into()
+        })
     }
 
     async fn recognize_batch(&self, requests: &[NerRequest<'_>]) -> Result<Vec<NerResponse>> {
@@ -137,6 +132,6 @@ impl NerBackend for BentoNer {
             ))
             .into());
         }
-        Ok(responses.into_iter().map(WireNerResponse::decode).collect())
+        Ok(responses)
     }
 }

--- a/crates/elide-bento/src/ocr/mod.rs
+++ b/crates/elide-bento/src/ocr/mod.rs
@@ -80,6 +80,30 @@ impl BentoOcr {
         self.default_threshold = threshold;
         self
     }
+
+    /// Send one batched `/recognize` POST end-to-end: encode
+    /// each [`OcrRequest`] to its wire form, POST the batch
+    /// (layering `x-request-id` when any request carries a
+    /// correlation id), decode the wire responses back to
+    /// [`OcrResponse`]s.
+    async fn post_recognize(
+        &self,
+        requests: &[OcrRequest<'_>],
+    ) -> Result<Vec<OcrResponse>, BentoError> {
+        let body: Vec<WireOcrRequest> = requests
+            .iter()
+            .map(|r| WireOcrRequest::from_request(r, self.default_threshold))
+            .collect();
+        let mut endpoint = self.endpoint.clone();
+        if let Some(id) = requests.iter().find_map(|r| r.correlation_id) {
+            endpoint = endpoint.with_request_id(id.to_string());
+        }
+        let wire: Vec<WireOcrResponse> = endpoint
+            .invoke(&body)
+            .await
+            .map_err(BentoError::Transport)?;
+        Ok(wire.into_iter().map(WireOcrResponse::decode).collect())
+    }
 }
 
 #[async_trait::async_trait]
@@ -93,28 +117,25 @@ impl OcrBackend for BentoOcr {
     }
 
     async fn recognize(&self, request: OcrRequest<'_>) -> Result<OcrResponse> {
-        let body = vec![WireOcrRequest::from_request(
-            &request,
-            self.default_threshold,
-        )];
-        let mut endpoint = self.endpoint.clone();
-        if let Some(id) = request.correlation_id {
-            endpoint = endpoint.with_request_id(id.to_string());
+        let mut responses = self.recognize_batch(&[request]).await?;
+        responses.pop().ok_or_else(|| {
+            BentoError::Protocol("bento ocr returned an empty batch".into()).into()
+        })
+    }
+
+    async fn recognize_batch(&self, requests: &[OcrRequest<'_>]) -> Result<Vec<OcrResponse>> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
         }
-        let responses: Vec<WireOcrResponse> = endpoint
-            .invoke(&body)
-            .await
-            .map_err(BentoError::Transport)?;
-        let mut iter = responses.into_iter();
-        let response = iter
-            .next()
-            .ok_or_else(|| BentoError::Protocol("bento ocr returned an empty batch".into()))?;
-        if iter.next().is_some() {
-            return Err(BentoError::Protocol(
-                "bento ocr returned more responses than requests".into(),
-            )
+        let responses = self.post_recognize(requests).await?;
+        if responses.len() != requests.len() {
+            return Err(BentoError::Protocol(format!(
+                "bento ocr returned {} responses for {} requests",
+                responses.len(),
+                requests.len(),
+            ))
             .into());
         }
-        Ok(response.decode())
+        Ok(responses)
     }
 }

--- a/crates/nvisy-engine/src/analyzer/audio.rs
+++ b/crates/nvisy-engine/src/analyzer/audio.rs
@@ -41,7 +41,7 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner.as_ref())?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/analyzer/image.rs
+++ b/crates/nvisy-engine/src/analyzer/image.rs
@@ -5,8 +5,8 @@
 //! over the OCR'd text (the OCR enricher stamps a `Layout` onto
 //! the recognizer artifacts upstream), and LLM is available
 //! image-natively for vision-language models. NER and LLM are
-//! opt-in via `spec.recognizers.ner = true` /
-//! `spec.recognizers.llm = true`; the deployment's [`NerConfig`]
+//! selected out of the deployment's lineup via
+//! `spec.recognizers.{ner,llm}`; the deployment's [`NerConfig`]
 //! and [`LlmConfig`] provide the actual recognizer lineups.
 //!
 //! Modality-foreign enrichers (`language`, `stt`) on `spec` are
@@ -46,8 +46,8 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
-    analyzer = attach_llm_lineup(analyzer, llm, AttachTo::Image, spec.recognizers.llm)?;
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner.as_ref())?;
+    analyzer = attach_llm_lineup(analyzer, llm, AttachTo::Image, spec.recognizers.llm.as_ref())?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/analyzer/mod.rs
+++ b/crates/nvisy-engine/src/analyzer/mod.rs
@@ -61,10 +61,10 @@ use crate::provider::ner::NerConfig;
 /// enrichers the modality supports and rejects the rest at
 /// compile time (e.g. OCR on text, LLM on tabular). Every
 /// compile fn consults the deployment [`NerConfig`] when the
-/// request toggles `recognizers.ner = true`; text and image
-/// also consult [`LlmConfig`] when `recognizers.llm = true`.
-/// Every method consults [`PatternGuardrails`] when the pattern
-/// recognizer is enabled.
+/// request's `recognizers.ner` selects any recognizer; text
+/// and image also consult [`LlmConfig`] when
+/// `recognizers.llm` does. Every method consults
+/// [`PatternGuardrails`] when the pattern recognizer is enabled.
 ///
 /// Non-text methods are gated on their modality's feature.
 pub(crate) trait AnalyzerCompile {

--- a/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
@@ -1,8 +1,12 @@
 //! Attach the deployment's LLM lineup to a per-modality
 //! [`Analyzer`]. Walks [`LlmConfig::recognizers`], filters by
-//! modality, and builds one `LlmRecognizer<M>` per matching
-//! entry via elide's `RigBackend` (or `MockBackend` under the
-//! `test-utils` feature).
+//! [`ProviderSelection`] and then by modality, and builds one
+//! `LlmRecognizer<M>` per matching entry via elide's `RigBackend`
+//! (or `MockBackend` under the `test-utils` feature).
+//!
+//! [`Analyzer`]: elide::detection::Analyzer
+//! [`LlmConfig::recognizers`]: crate::provider::llm::LlmConfig::recognizers
+//! [`ProviderSelection`]: nvisy_schema::plan::ProviderSelection
 
 use elide::detection::Analyzer;
 #[cfg(feature = "test-utils")]
@@ -12,22 +16,22 @@ use elide::recognition::llm::prompt::{DefaultPrompt, Jinja2Prompt, Prompt};
 use elide::recognition::llm::provider::Provider;
 use elide::recognition::llm::{LlmRecognizer, LlmRecognizerBuilder};
 use elide_core::{Error, ErrorKind};
+use nvisy_schema::plan::ProviderSelection;
 
+use super::selection::select;
 use crate::provider::llm::{
     AttachTo, LlmConfig, LlmPrompt, LlmRecognizer as ConfigRecognizer, LlmSource,
 };
 
-/// Attach every LLM recognizer in `llm.recognizers` whose
-/// modality list includes `modality` to `analyzer`, dispatched on
-/// the request's three-state toggle.
+/// Attach LLM recognizers selected by `selection` whose modality
+/// list includes `modality`.
 ///
-/// - `Some(true)`: explicit opt-in. Attaches every configured
-///   recognizer whose declared modalities include `modality`;
-///   errors when zero match.
-/// - `Some(false)`: explicit opt-out. Returns the analyzer
-///   unchanged.
-/// - `None`: softly-on default. Attaches every matching
-///   recognizer if any match; skips silently otherwise.
+/// The name allowlist runs first; the modality filter then drops
+/// any allowlisted recognizer that doesn't attach to this
+/// analyzer's modality. Only `All(true)` requires at least one
+/// modality-matching recognizer to remain — `Only(names)`
+/// silently skips if every named recognizer is scoped to a
+/// different modality.
 ///
 /// Errors on: any recognizer whose `modalities` list is empty
 /// (bad config), Jinja2 prompt load/compile failure, provider
@@ -44,7 +48,7 @@ pub(in crate::analyzer) fn attach_llm_lineup<M>(
     mut analyzer: Analyzer<M>,
     llm: &LlmConfig,
     modality: AttachTo,
-    toggle: Option<bool>,
+    selection: Option<&ProviderSelection>,
 ) -> Result<Analyzer<M>, Error>
 where
     M: LlmModality,
@@ -52,11 +56,15 @@ where
     DefaultPrompt: Prompt<M>,
     Jinja2Prompt<M>: Prompt<M>,
 {
-    if toggle == Some(false) {
-        return Ok(analyzer);
-    }
-    let mut matched = 0usize;
-    for recognizer in &llm.recognizers {
+    let selected = select(
+        selection,
+        &llm.recognizers,
+        |r| r.name.as_str(),
+        "llm",
+        "[[llm.recognizers]]",
+    )?;
+    let mut modality_matched = 0usize;
+    for recognizer in &selected {
         if recognizer.modalities.is_empty() {
             return Err(Error::new(
                 ErrorKind::Validation,
@@ -70,10 +78,10 @@ where
         if !recognizer.modalities.contains(&modality) {
             continue;
         }
-        matched += 1;
+        modality_matched += 1;
         analyzer = attach_one(analyzer, recognizer)?;
     }
-    if matched == 0 && toggle == Some(true) {
+    if modality_matched == 0 && matches!(selection, Some(ProviderSelection::All(true))) {
         return Err(Error::new(
             ErrorKind::Validation,
             format!(

--- a/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
@@ -56,13 +56,7 @@ where
     DefaultPrompt: Prompt<M>,
     Jinja2Prompt<M>: Prompt<M>,
 {
-    let selected = select(
-        selection,
-        &llm.recognizers,
-        |r| r.name.as_str(),
-        "llm",
-        "[[llm.recognizers]]",
-    )?;
+    let selected = select(selection, &llm.recognizers, "llm")?;
     let mut modality_matched = 0usize;
     for recognizer in &selected {
         if recognizer.modalities.is_empty() {

--- a/crates/nvisy-engine/src/analyzer/recognizer/mod.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/mod.rs
@@ -21,6 +21,7 @@ mod guardrails;
 mod llm;
 mod ner;
 mod pattern;
+mod selection;
 
 pub use self::guardrails::PatternGuardrails;
 pub(super) use self::llm::attach_llm_lineup;

--- a/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
@@ -42,13 +42,7 @@ where
     M: TextRecognizable,
     NerRecognizer: Recognizer<M> + 'static,
 {
-    let selected = select(
-        selection,
-        &ner.recognizers,
-        |r| r.name.as_str(),
-        "ner",
-        "[[ner.recognizers]]",
-    )?;
+    let selected = select(selection, &ner.recognizers, "ner")?;
     for recognizer in selected {
         analyzer = attach_ner_one(analyzer, recognizer)?;
     }

--- a/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
@@ -5,53 +5,51 @@
 //!
 //! Symmetric with [`super::llm`]; called by every per-modality
 //! compile function with the request's
-//! `AnalyzerParams.recognizers.ner` three-state toggle.
+//! `AnalyzerParams.recognizers.ner` [`ProviderSelection`].
 //!
 //! [`Analyzer`]: elide::detection::Analyzer
 //! [`NerConfig::recognizers`]: crate::provider::ner::NerConfig::recognizers
+//! [`ProviderSelection`]: nvisy_schema::plan::ProviderSelection
 
 use elide::detection::Analyzer;
 use elide::recognition::ner::NerRecognizer;
 use elide_bento::ner::BentoNer;
 use elide_core::modality::TextRecognizable;
 use elide_core::recognition::Recognizer;
-use elide_core::{Error, ErrorKind};
+use elide_core::Error;
+use nvisy_schema::plan::ProviderSelection;
 
+use super::selection::select;
 use crate::provider::ner::{NerBackend, NerConfig, NerRecognizer as ConfigNerRecognizer};
 
-/// Attach every recognizer from the deployment's NER lineup,
-/// dispatched on the request's three-state toggle.
+/// Attach recognizers from the deployment's NER lineup selected
+/// by `selection`.
 ///
-/// - `Some(true)`: explicit opt-in. Attaches every configured
-///   recognizer; errors if the lineup is empty.
-/// - `Some(false)`: explicit opt-out. Returns the analyzer
-///   unchanged.
 /// - `None`: softly-on default. Attaches every configured
 ///   recognizer if the lineup is non-empty; skips silently
 ///   otherwise.
+/// - `Some(All(true))`: explicit opt-in. Attaches every
+///   configured recognizer; errors if the lineup is empty.
+/// - `Some(All(false))`: explicit opt-out.
+/// - `Some(Only(names))`: attach only the named recognizers.
+///   Empty list and unknown names error.
 pub(in crate::analyzer) fn attach_ner_lineup<M>(
     mut analyzer: Analyzer<M>,
     ner: &NerConfig,
-    toggle: Option<bool>,
+    selection: Option<&ProviderSelection>,
 ) -> Result<Analyzer<M>, Error>
 where
     M: TextRecognizable,
     NerRecognizer: Recognizer<M> + 'static,
 {
-    match toggle {
-        Some(false) => return Ok(analyzer),
-        None if ner.recognizers.is_empty() => return Ok(analyzer),
-        Some(true) if ner.recognizers.is_empty() => {
-            return Err(Error::new(
-                ErrorKind::Validation,
-                "AnalyzerParams.recognizers.ner = true but the deployment has no NER \
-                 recognizer configured; add one to `[[ner.recognizers]]` in the \
-                 deployment config or leave `ner` unset / false",
-            ));
-        }
-        _ => {}
-    }
-    for recognizer in &ner.recognizers {
+    let selected = select(
+        selection,
+        &ner.recognizers,
+        |r| r.name.as_str(),
+        "ner",
+        "[[ner.recognizers]]",
+    )?;
+    for recognizer in selected {
         analyzer = attach_ner_one(analyzer, recognizer)?;
     }
     Ok(analyzer)

--- a/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
@@ -1,0 +1,79 @@
+//! Resolve a [`ProviderSelection`] against a deployment-configured
+//! lineup, returning the borrowed subset the analyzer should attach.
+//!
+//! Shared by [`super::ner`] and [`super::llm`]; validation errors
+//! (empty allowlist, unknown recognizer name, opt-in with an empty
+//! deployment lineup) surface here so both call sites report them
+//! the same way.
+//!
+//! [`ProviderSelection`]: nvisy_schema::plan::ProviderSelection
+
+use elide_core::{Error, ErrorKind};
+use nvisy_schema::plan::ProviderSelection;
+
+/// Filter `lineup` by `selection`, returning the recognizers to
+/// attach in configuration order.
+///
+/// `name_of` extracts a recognizer's name for allowlist matching;
+/// `kind` (`"ner"` / `"llm"`) and `toml_path`
+/// (`"[[ner.recognizers]]"` / `"[[llm.recognizers]]"`) shape the
+/// error messages.
+pub(super) fn select<'a, T, F>(
+    selection: Option<&ProviderSelection>,
+    lineup: &'a [T],
+    name_of: F,
+    kind: &'static str,
+    toml_path: &'static str,
+) -> Result<Vec<&'a T>, Error>
+where
+    F: Fn(&T) -> &str,
+{
+    match selection {
+        None => Ok(lineup.iter().collect()),
+        Some(ProviderSelection::All(false)) => Ok(Vec::new()),
+        Some(ProviderSelection::All(true)) => {
+            if lineup.is_empty() {
+                return Err(Error::new(
+                    ErrorKind::Validation,
+                    format!(
+                        "AnalyzerParams.recognizers.{kind} = true but the deployment has no \
+                         {} recognizer configured; add one to `{toml_path}` in the deployment \
+                         config or leave `{kind}` unset / false",
+                        kind.to_ascii_uppercase(),
+                    ),
+                ));
+            }
+            Ok(lineup.iter().collect())
+        }
+        Some(ProviderSelection::Only(names)) => {
+            if names.is_empty() {
+                return Err(Error::new(
+                    ErrorKind::Validation,
+                    format!(
+                        "AnalyzerParams.recognizers.{kind} is an empty allowlist; use \
+                         `{kind}: false` to opt out entirely, or list at least one recognizer name"
+                    ),
+                ));
+            }
+            let unknown: Vec<&str> = names
+                .iter()
+                .filter(|n| !lineup.iter().any(|r| name_of(r) == n.as_str()))
+                .map(String::as_str)
+                .collect();
+            if !unknown.is_empty() {
+                let available: Vec<&str> = lineup.iter().map(&name_of).collect();
+                return Err(Error::new(
+                    ErrorKind::Validation,
+                    format!(
+                        "AnalyzerParams.recognizers.{kind} names unknown recognizer(s) {unknown:?}; \
+                         available in this deployment: {available:?}"
+                    ),
+                ));
+            }
+            Ok(lineup
+                .iter()
+                .filter(|r| names.iter().any(|n| n == name_of(r)))
+                .collect())
+        }
+    }
+}

--- a/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
@@ -8,72 +8,106 @@
 //!
 //! [`ProviderSelection`]: nvisy_schema::plan::ProviderSelection
 
+use std::collections::HashSet;
+
 use elide_core::{Error, ErrorKind};
 use nvisy_schema::plan::ProviderSelection;
+
+use crate::provider::{LlmRecognizer, NerRecognizer};
+
+/// One thing every allowlist-selectable recognizer needs: a name.
+pub(super) trait Named {
+    fn name(&self) -> &str;
+}
+
+impl Named for NerRecognizer {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Named for LlmRecognizer {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
 
 /// Filter `lineup` by `selection`, returning the recognizers to
 /// attach in configuration order.
 ///
-/// `name_of` extracts a recognizer's name for allowlist matching;
-/// `kind` (`"ner"` / `"llm"`) and `toml_path`
-/// (`"[[ner.recognizers]]"` / `"[[llm.recognizers]]"`) shape the
-/// error messages.
-pub(super) fn select<'a, T, F>(
+/// `field` is the recognizer-kind field name on
+/// `RecognizerParams` (`"ner"` / `"llm"`), interpolated verbatim
+/// into validation error messages.
+pub(super) fn select<'a, T: Named>(
     selection: Option<&ProviderSelection>,
     lineup: &'a [T],
-    name_of: F,
-    kind: &'static str,
-    toml_path: &'static str,
-) -> Result<Vec<&'a T>, Error>
-where
-    F: Fn(&T) -> &str,
-{
+    field: &'static str,
+) -> Result<Vec<&'a T>, Error> {
     match selection {
         None => Ok(lineup.iter().collect()),
         Some(ProviderSelection::All(false)) => Ok(Vec::new()),
         Some(ProviderSelection::All(true)) => {
             if lineup.is_empty() {
-                return Err(Error::new(
-                    ErrorKind::Validation,
-                    format!(
-                        "AnalyzerParams.recognizers.{kind} = true but the deployment has no \
-                         {} recognizer configured; add one to `{toml_path}` in the deployment \
-                         config or leave `{kind}` unset / false",
-                        kind.to_ascii_uppercase(),
-                    ),
-                ));
+                return Err(empty_lineup(field));
             }
             Ok(lineup.iter().collect())
         }
-        Some(ProviderSelection::Only(names)) => {
-            if names.is_empty() {
-                return Err(Error::new(
-                    ErrorKind::Validation,
-                    format!(
-                        "AnalyzerParams.recognizers.{kind} is an empty allowlist; use \
-                         `{kind}: false` to opt out entirely, or list at least one recognizer name"
-                    ),
-                ));
-            }
-            let unknown: Vec<&str> = names
-                .iter()
-                .filter(|n| !lineup.iter().any(|r| name_of(r) == n.as_str()))
-                .map(String::as_str)
-                .collect();
-            if !unknown.is_empty() {
-                let available: Vec<&str> = lineup.iter().map(&name_of).collect();
-                return Err(Error::new(
-                    ErrorKind::Validation,
-                    format!(
-                        "AnalyzerParams.recognizers.{kind} names unknown recognizer(s) {unknown:?}; \
-                         available in this deployment: {available:?}"
-                    ),
-                ));
-            }
-            Ok(lineup
-                .iter()
-                .filter(|r| names.iter().any(|n| n == name_of(r)))
-                .collect())
-        }
+        Some(ProviderSelection::Only(names)) => select_allowlisted(lineup, names, field),
     }
+}
+
+fn select_allowlisted<'a, T: Named>(
+    lineup: &'a [T],
+    names: &[String],
+    field: &'static str,
+) -> Result<Vec<&'a T>, Error> {
+    if names.is_empty() {
+        return Err(empty_allowlist(field));
+    }
+    let available: HashSet<&str> = lineup.iter().map(Named::name).collect();
+    let unknown: Vec<&str> = names
+        .iter()
+        .map(String::as_str)
+        .filter(|n| !available.contains(n))
+        .collect();
+    if !unknown.is_empty() {
+        return Err(unknown_names(field, &unknown, &available));
+    }
+    let allowed: HashSet<&str> = names.iter().map(String::as_str).collect();
+    Ok(lineup
+        .iter()
+        .filter(|r| allowed.contains(r.name()))
+        .collect())
+}
+
+fn empty_lineup(field: &str) -> Error {
+    Error::new(
+        ErrorKind::Validation,
+        format!(
+            "AnalyzerParams.recognizers.{field} = true but the deployment has no \
+             {field} recognizer configured; leave `{field}` unset / false to opt out"
+        ),
+    )
+}
+
+fn empty_allowlist(field: &str) -> Error {
+    Error::new(
+        ErrorKind::Validation,
+        format!(
+            "AnalyzerParams.recognizers.{field} is an empty allowlist; use \
+             `{field}: false` to opt out entirely, or list at least one recognizer name"
+        ),
+    )
+}
+
+fn unknown_names(field: &str, unknown: &[&str], available: &HashSet<&str>) -> Error {
+    let mut available: Vec<&str> = available.iter().copied().collect();
+    available.sort_unstable();
+    Error::new(
+        ErrorKind::Validation,
+        format!(
+            "AnalyzerParams.recognizers.{field} names unknown recognizer(s) {unknown:?}; \
+             available in this deployment: {available:?}"
+        ),
+    )
 }

--- a/crates/nvisy-engine/src/analyzer/tabular.rs
+++ b/crates/nvisy-engine/src/analyzer/tabular.rs
@@ -35,7 +35,7 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner.as_ref())?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/analyzer/text.rs
+++ b/crates/nvisy-engine/src/analyzer/text.rs
@@ -2,7 +2,7 @@
 //! [`elide::detection::Analyzer<Text>`].
 //!
 //! Text supports the full recognizer set: Pattern, NER, and LLM.
-//! NER and LLM are three-state toggles on
+//! NER and LLM are selected out of the deployment's lineup by
 //! `spec.recognizers.{ner,llm}` (see
 //! [`nvisy_schema::plan::RecognizerParams`]); the deployment's
 //! [`NerConfig`] and [`LlmConfig`] provide the actual recognizer
@@ -46,8 +46,8 @@ pub(super) fn compile(
     if let Some(pattern) = &spec.recognizers.pattern {
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
-    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner)?;
-    analyzer = attach_llm_lineup(analyzer, llm, AttachTo::Text, spec.recognizers.llm)?;
+    analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner.as_ref())?;
+    analyzer = attach_llm_lineup(analyzer, llm, AttachTo::Text, spec.recognizers.llm.as_ref())?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/entity.rs
+++ b/crates/nvisy-engine/src/entity.rs
@@ -1,0 +1,26 @@
+//! Detected entities and the leaf types their fields carry.
+//!
+//! [`Entity`] is the modality-generic detection record produced
+//! by the analyzer and consumed by the anonymizer; [`EntityRecord`]
+//! is the engine's wrapper that pairs one entity with an optional
+//! reviewer override for the apply-time re-decision. [`Label`]
+//! and [`LabelRef`] name the entity kind; [`LabelCatalog`] holds
+//! the deployment's label vocabulary. [`Provenance`] carries the
+//! audit trail (which rule / model / pattern produced each
+//! detection).
+//!
+//! Primitive value types ([`BoundingBox`], [`Confidence`],
+//! [`Language`], ...) appear as leaf fields on entities and on
+//! wire schemas that constrain detection.
+
+pub use nvisy_schema::entity::{
+    Attribution, Entity, EntityCoRef, EntityRef, Event, EventKind, Label, LabelCatalog, LabelRef,
+    ModelEvent, PatternEvent, Provenance, RuleMatch,
+};
+pub use nvisy_schema::primitive::{
+    BoundingBox, Color, Confidence, ConfidenceThreshold, CountryCode, Dimensions, Dpi, Language,
+    LanguageProvenance, LanguageSpan, LanguageTag, Languages, PixelRegion, Point, Polygon,
+    TimeSpan, UnitBoundingBox,
+};
+
+pub use crate::pipeline::EntityRecord;

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -40,5 +40,6 @@ pub use nvisy_schema::{annotation, entity, file, modality, plan, primitive};
 pub use self::analyzer::PatternGuardrails;
 pub use self::pipeline::{
     AnalyzedDocument, AnonymizedDocument, Engine, EntityRecord, RecognizedGroup,
+    RegisteredRecognizer,
 };
 pub use self::provider::{llm, ner};

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -21,8 +21,11 @@
 
 mod analyzer;
 mod anonymizer;
+pub mod entity;
+pub mod modality;
+pub mod plan;
 mod pipeline;
-mod provider;
+pub mod provider;
 
 #[doc(inline)]
 pub use elide::codec::FormatRegistry;
@@ -30,16 +33,14 @@ pub use elide::codec::FormatRegistry;
 pub use elide::recognition::Scope;
 #[doc(inline)]
 pub use elide_core::{Error, ErrorKind, Result};
+#[doc(inline)]
+pub use nvisy_schema::file::{Document, FileMetadata};
 /// Authored redaction governance: policies, rules, predicates,
 /// operators, retention.
 #[doc(inline)]
 pub use nvisy_schema::policy;
-#[doc(inline)]
-pub use nvisy_schema::{annotation, entity, file, modality, plan, primitive};
 
 pub use self::analyzer::PatternGuardrails;
 pub use self::pipeline::{
-    AnalyzedDocument, AnonymizedDocument, Engine, EntityRecord, RecognizedGroup,
-    RegisteredRecognizer,
+    AnalyzedDocument, AnonymizedDocument, Engine, RecognizedGroup, RegisteredRecognizer,
 };
-pub use self::provider::{llm, ner};

--- a/crates/nvisy-engine/src/modality.rs
+++ b/crates/nvisy-engine/src/modality.rs
@@ -1,0 +1,12 @@
+//! Modality markers and traits parameterising `Entity<M>` and
+//! `EntityRecord<M>`.
+//!
+//! [`Modality`] is the trait every marker implements; [`Text`],
+//! [`Tabular`], [`Image`], and [`Audio`] are the four markers.
+//! [`Waveform`] appears directly on audio redaction operators
+//! in [`crate::policy`].
+
+pub use nvisy_schema::modality::{
+    Audio, Image, Modality, ModalityData, ModalityLocation, ModalityReplacement, Tabular, Text,
+    Waveform,
+};

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -6,9 +6,9 @@
 //!   bytes into a modality-typed [`DocumentHandle`] at analyze +
 //!   anonymize time.
 //! - The deployment's NER + LLM lineups (see [`crate::provider::ner`]
-//!   and [`crate::provider::llm`]). Consulted by the analyzer compile
-//!   whenever the request's `AnalyzerParams.recognizers.ner` or
-//!   `.llm` toggle is on.
+//!   and [`crate::provider::llm`]). Consulted by the analyzer
+//!   compile whenever the request's
+//!   `AnalyzerParams.recognizers.{ner,llm}` selects any recognizer.
 //!
 //! [`Engine`] clones cheaply (`Arc` under the hood). Callers pass
 //! a clone into every request-scoped code path they run.
@@ -75,7 +75,10 @@
 
 mod analyzed;
 mod orchestrator;
+mod registered;
 mod report;
+
+pub use self::registered::RegisteredRecognizer;
 
 use std::any::TypeId;
 use std::collections::HashMap;
@@ -146,9 +149,9 @@ impl Engine {
 
     /// Set the deployment's NER configuration.
     ///
-    /// Consumed once at setup; the analyzer compile reads it
-    /// every time a request submits
-    /// `AnalyzerParams.recognizers.ner = true`.
+    /// Consumed once at setup; the analyzer compile reads it on
+    /// every request whose `AnalyzerParams.recognizers.ner`
+    /// selects any of the configured recognizers.
     #[must_use]
     pub fn with_ner(mut self, ner: NerConfig) -> Self {
         self.ner = Arc::new(ner);
@@ -157,9 +160,9 @@ impl Engine {
 
     /// Set the deployment's LLM configuration.
     ///
-    /// Consumed once at setup; the analyzer compile reads it
-    /// every time a request submits
-    /// `AnalyzerParams.recognizers.llm = true`.
+    /// Consumed once at setup; the analyzer compile reads it on
+    /// every request whose `AnalyzerParams.recognizers.llm`
+    /// selects any of the configured recognizers.
     #[must_use]
     pub fn with_llm(mut self, llm: LlmConfig) -> Self {
         self.llm = Arc::new(llm);
@@ -188,6 +191,27 @@ impl Engine {
     /// [`UntypedDocumentHandle`].
     pub fn formats(&self) -> &FormatRegistry {
         &self.formats
+    }
+
+    /// Every NER recognizer this engine has registered, in
+    /// configuration order.
+    ///
+    /// Feeds a "list recognizers" endpoint. Each entry carries
+    /// name, optional description, and provider slug; connection
+    /// details and (future) credentials stay in the private
+    /// [`NerConfig`].
+    pub fn ner_recognizers(&self) -> impl ExactSizeIterator<Item = RegisteredRecognizer<'_>> {
+        self.ner.recognizers.iter().map(Into::into)
+    }
+
+    /// Every LLM recognizer this engine has registered, in
+    /// configuration order.
+    ///
+    /// Same shape as [`ner_recognizers`], for the LLM lineup.
+    ///
+    /// [`ner_recognizers`]: Self::ner_recognizers
+    pub fn llm_recognizers(&self) -> impl ExactSizeIterator<Item = RegisteredRecognizer<'_>> {
+        self.llm.recognizers.iter().map(Into::into)
     }
 
     /// Analyze one document into an [`AnalyzedDocument`].

--- a/crates/nvisy-engine/src/pipeline/registered.rs
+++ b/crates/nvisy-engine/src/pipeline/registered.rs
@@ -1,0 +1,54 @@
+//! [`RegisteredRecognizer`]: the public view of one recognizer
+//! in the engine's NER or LLM lineup.
+//!
+//! Returned by [`crate::Engine::ner_recognizers`] and
+//! [`crate::Engine::llm_recognizers`] so operators and SDK
+//! callers can list what's registered without seeing backend
+//! connection details or (future) credentials.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::provider::llm::LlmRecognizer;
+use crate::provider::ner::NerRecognizer;
+
+/// Public view of one recognizer in the engine's NER or LLM
+/// lineup.
+///
+/// Carries the name a request's allowlist picks by, an optional
+/// human-readable description, and a provider slug identifying
+/// the backend kind. Connection details and (future)
+/// credentials stay in the private `NerConfig` / `LlmConfig`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisteredRecognizer<'a> {
+    /// Recognizer name — the identifier a request's allowlist
+    /// picks by.
+    pub name: &'a str,
+    /// Optional human-readable description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<&'a str>,
+    /// Provider slug. NER: `"bento"`, `"mock"`. LLM: `"openai"`,
+    /// `"anthropic"`, `"gemini"`, `"ollama"`, `"mock"`.
+    pub provider: &'static str,
+}
+
+impl<'a> From<&'a NerRecognizer> for RegisteredRecognizer<'a> {
+    fn from(r: &'a NerRecognizer) -> Self {
+        Self {
+            name: &r.name,
+            description: r.description.as_deref(),
+            provider: r.backend.provider(),
+        }
+    }
+}
+
+impl<'a> From<&'a LlmRecognizer> for RegisteredRecognizer<'a> {
+    fn from(r: &'a LlmRecognizer) -> Self {
+        Self {
+            name: &r.name,
+            description: r.description.as_deref(),
+            provider: r.source.provider(),
+        }
+    }
+}

--- a/crates/nvisy-engine/src/plan.rs
+++ b/crates/nvisy-engine/src/plan.rs
@@ -1,0 +1,19 @@
+//! Authored recognition plan and caller-supplied annotations.
+//!
+//! Serialisable description of how to build an analyzer for a
+//! request. Symmetric with [`policy`]. Where policy describes
+//! redaction governance (which entities to hide and how), the
+//! plan describes recognition (which entities to find and how).
+//! Both are pure data; the engine compiles them into elide
+//! runtime values at request time.
+//!
+//! [`policy`]: crate::policy
+
+pub use nvisy_schema::annotation::{Annotations, Exclusion, Inclusion};
+pub use nvisy_schema::plan::{
+    AnalyzerParams, AnyAnnotations, CustomDictionary, CustomDictionaryTerm, CustomPatternContext,
+    CustomPatternRule, CustomPatternVariant, DeduplicationParams, EnricherParams,
+    LabelCatalogParams, LanguageEnricherParams, MAX_REGEX_SOURCE_LEN, MergingStrategyParams,
+    OcrBackendParams, OcrEnricherParams, PatternRecognizerParams, ProviderSelection,
+    RecognizerParams, ScopeParams, SttBackendParams, SttEnricherParams, TiebreakerParams,
+};

--- a/crates/nvisy-engine/src/provider/llm/mod.rs
+++ b/crates/nvisy-engine/src/provider/llm/mod.rs
@@ -1,9 +1,10 @@
 //! LLM deployment configuration.
 //!
-//! The wire's `RecognizerParams.llm` is only a boolean; every
-//! detail about which LLM(s) actually run lives here, on the
-//! deployment's side. Sidecar users configure their own lineup;
-//! SaaS operators configure the lineup their tenants share.
+//! The wire's `RecognizerParams.llm` selects recognizers by
+//! name (or the whole lineup); every detail about which LLM(s)
+//! actually run lives here, on the deployment's side. Sidecar
+//! users configure their own lineup; SaaS operators configure
+//! the lineup their tenants share.
 //!
 //! ## Layout
 //!

--- a/crates/nvisy-engine/src/provider/llm/recognizer.rs
+++ b/crates/nvisy-engine/src/provider/llm/recognizer.rs
@@ -10,7 +10,7 @@ use super::{AttachTo, LlmPrompt};
 ///
 /// Every entry in [`LlmConfig::recognizers`] runs on every
 /// analyzer whose modality is listed in [`modalities`], provided
-/// the request toggled `recognizers.llm = true`.
+/// the request's `recognizers.llm` selects this recognizer.
 ///
 /// [`LlmConfig::recognizers`]: super::LlmConfig::recognizers
 /// [`modalities`]: Self::modalities
@@ -22,6 +22,11 @@ pub struct LlmRecognizer {
     /// configured recognizer. Must be unique across the
     /// deployment's LLM lineup.
     pub name: String,
+    /// Optional human-readable description. Surfaces on the
+    /// list-recognizers accessor so operators and SDK callers
+    /// can identify what each recognizer is for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Source selection + its per-kind fields, flattened onto
     /// the recognizer's wire shape.
     #[serde(flatten)]
@@ -59,6 +64,21 @@ pub enum LlmSource {
     #[cfg(feature = "test-utils")]
     #[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))]
     Mock,
+}
+
+impl LlmSource {
+    /// Provider slug for the list-recognizers accessor.
+    #[must_use]
+    pub fn provider(&self) -> &'static str {
+        match self {
+            Self::OpenAi(_) => "openai",
+            Self::Anthropic(_) => "anthropic",
+            Self::Gemini(_) => "gemini",
+            Self::Ollama(_) => "ollama",
+            #[cfg(feature = "test-utils")]
+            Self::Mock => "mock",
+        }
+    }
 }
 
 fn default_modalities() -> Vec<AttachTo> {

--- a/crates/nvisy-engine/src/provider/mod.rs
+++ b/crates/nvisy-engine/src/provider/mod.rs
@@ -7,5 +7,11 @@
 //! at deployment startup; requests only name which of the
 //! operator's recognizers to run.
 
-pub mod llm;
-pub mod ner;
+pub(crate) mod llm;
+pub(crate) mod ner;
+
+pub use self::llm::{
+    AttachTo, AuthenticatedProvider, LlmConfig, LlmPrompt, LlmRecognizer, LlmSource,
+    UnauthenticatedProvider,
+};
+pub use self::ner::{NerBackend, NerConfig, NerRecognizer};

--- a/crates/nvisy-engine/src/provider/mod.rs
+++ b/crates/nvisy-engine/src/provider/mod.rs
@@ -1,10 +1,11 @@
 //! Deployment-owned recognizer provider configuration.
 //!
-//! The wire's `RecognizerParams.{ner,llm}` are three-state
-//! toggles; every detail about which recognizers actually run
-//! lives here, on the deployment's side. Operators pick model,
-//! backend, and (future) credentials at deployment startup;
-//! requests only opt in or out.
+//! The wire's `RecognizerParams.{ner,llm}` selects recognizers
+//! by name (or the whole lineup); every detail about which
+//! recognizers actually run lives here, on the deployment's
+//! side. Operators pick model, backend, and (future) credentials
+//! at deployment startup; requests only name which of the
+//! operator's recognizers to run.
 
 pub mod llm;
 pub mod ner;

--- a/crates/nvisy-engine/src/provider/ner/mod.rs
+++ b/crates/nvisy-engine/src/provider/ner/mod.rs
@@ -1,10 +1,12 @@
 //! NER deployment configuration.
 //!
-//! The wire's `RecognizerParams.ner` is only a boolean; every
-//! detail about which NER recognizer(s) actually run lives here,
-//! on the deployment's side. Symmetric with [`super::llm`]:
-//! deployment operator owns model choice, connection details,
-//! and (future) credentials; the wire only opts in or out.
+//! The wire's `RecognizerParams.ner` selects recognizers by
+//! name (or the whole lineup); every detail about which NER
+//! recognizer(s) actually run lives here, on the deployment's
+//! side. Symmetric with [`super::llm`]: deployment operator
+//! owns model choice, connection details, and (future)
+//! credentials; the wire only names which of the operator's
+//! recognizers to run.
 //!
 //! ## Layout
 //!
@@ -27,8 +29,9 @@ pub use self::recognizer::{NerBackend, NerRecognizer};
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NerConfig {
-    /// The recognizer lineup. Every entry runs when the request
-    /// toggles `recognizers.ner = true`.
+    /// The recognizer lineup. Each entry runs when the request's
+    /// `recognizers.ner` selects it (by allowlist name or by
+    /// running the whole lineup).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub recognizers: Vec<NerRecognizer>,
 }

--- a/crates/nvisy-engine/src/provider/ner/recognizer.rs
+++ b/crates/nvisy-engine/src/provider/ner/recognizer.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// One entry in the deployment's NER lineup.
 ///
 /// Every entry in [`NerConfig::recognizers`] runs when the
-/// request toggles `recognizers.ner = true`.
+/// request's `recognizers.ner` selects it.
 ///
 /// [`NerConfig::recognizers`]: super::NerConfig::recognizers
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -17,6 +17,11 @@ pub struct NerRecognizer {
     /// configured recognizer. Must be unique across the
     /// deployment's NER lineup.
     pub name: String,
+    /// Optional human-readable description. Surfaces on the
+    /// list-recognizers accessor so operators and SDK callers
+    /// can identify what each recognizer is for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Backend selection + its per-kind fields, flattened onto
     /// the recognizer's wire shape.
     #[serde(flatten)]
@@ -46,4 +51,16 @@ pub enum NerBackend {
     #[cfg(feature = "test-utils")]
     #[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))]
     Mock,
+}
+
+impl NerBackend {
+    /// Provider slug for the list-recognizers accessor.
+    #[must_use]
+    pub fn provider(&self) -> &'static str {
+        match self {
+            Self::Bento { .. } => "bento",
+            #[cfg(feature = "test-utils")]
+            Self::Mock => "mock",
+        }
+    }
 }

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -13,7 +13,7 @@ use nvisy_engine::{AnalyzedDocument, Engine, RecognizedGroup};
 use nvisy_schema::file::Document;
 use nvisy_schema::plan::{
     AnalyzerParams, EnricherParams, LabelCatalogParams, OcrBackendParams, OcrEnricherParams,
-    PatternRecognizerParams, RecognizerParams, ScopeParams,
+    PatternRecognizerParams, ProviderSelection, RecognizerParams, ScopeParams,
 };
 use nvisy_schema::policy::PolicyAction;
 use nvisy_schema::policy::redaction::{ModalityRedactions, TextRedaction};
@@ -39,8 +39,8 @@ fn default_spec() -> AnalyzerParams {
                 context_enhanced: true,
                 ..Default::default()
             }),
-            ner: Some(false),
-            llm: Some(false),
+            ner: Some(ProviderSelection::All(false)),
+            llm: Some(ProviderSelection::All(false)),
         },
         enrichers: EnricherParams {
             language: None,

--- a/crates/nvisy-engine/tests/patterns.rs
+++ b/crates/nvisy-engine/tests/patterns.rs
@@ -11,7 +11,7 @@ use nvisy_schema::file::Document;
 use nvisy_schema::plan::{
     AnalyzerParams, CustomDictionary, CustomDictionaryTerm, CustomPatternContext,
     CustomPatternRule, CustomPatternVariant, MAX_REGEX_SOURCE_LEN, PatternRecognizerParams,
-    RecognizerParams,
+    ProviderSelection, RecognizerParams,
 };
 
 const SAMPLE_DOCX: &[u8] = include_bytes!("testdata/sample.docx");
@@ -28,8 +28,8 @@ fn spec_with_pattern_params(params: PatternRecognizerParams) -> AnalyzerParams {
     AnalyzerParams {
         recognizers: RecognizerParams {
             pattern: Some(params),
-            ner: Some(false),
-            llm: Some(false),
+            ner: Some(ProviderSelection::All(false)),
+            llm: Some(ProviderSelection::All(false)),
         },
         ..Default::default()
     }

--- a/crates/nvisy-schema/src/plan/mod.rs
+++ b/crates/nvisy-schema/src/plan/mod.rs
@@ -50,4 +50,4 @@ pub use self::pattern::{
     CustomDictionary, CustomDictionaryTerm, CustomPatternContext, CustomPatternRule,
     CustomPatternVariant, MAX_REGEX_SOURCE_LEN,
 };
-pub use self::recognizer::{PatternRecognizerParams, RecognizerParams};
+pub use self::recognizer::{PatternRecognizerParams, ProviderSelection, RecognizerParams};

--- a/crates/nvisy-schema/src/plan/recognizer.rs
+++ b/crates/nvisy-schema/src/plan/recognizer.rs
@@ -9,12 +9,13 @@
 //!   ([`CustomPatternRule`]) and dictionaries
 //!   ([`CustomDictionary`]) alongside the shipped `builtins`;
 //!   the engine compiles them per request.
-//! - **NER** is a **deployment-owned lineup** gated by a
-//!   three-state toggle. Provider, model, and (future)
+//! - **NER** is a **deployment-owned lineup** selected by a
+//!   [`ProviderSelection`]. Provider, model, and (future)
 //!   credentials live in the deployment config; the wire opts in
-//!   (`true`), opts out (`false`), or leaves it to the default
-//!   (`None`, softly-on: attach when the deployment has any NER
-//!   configured, skip otherwise).
+//!   (`true`), opts out (`false`), names a subset by recognizer
+//!   name, or leaves it to the default (`None`, softly-on:
+//!   attach when the deployment has any NER configured, skip
+//!   otherwise).
 //! - **LLM** is the same shape as NER.
 //!
 //! Rationale for the NER/LLM shape: policies stay portable
@@ -32,8 +33,8 @@ use super::pattern::{CustomDictionary, CustomPatternRule};
 /// Recognizer slots an analyzer can fill.
 ///
 /// Pattern is at-most-one (per-request); NER and LLM are
-/// deployment-owned lineups each gated by a three-state
-/// [`Option<bool>`] toggle.
+/// deployment-owned lineups each selected by a
+/// [`ProviderSelection`].
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RecognizerParams {
@@ -42,28 +43,41 @@ pub struct RecognizerParams {
     /// At most one per analyzer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pattern: Option<PatternRecognizerParams>,
-    /// Run the deployment's NER recognizer lineup.
+    /// Select which of the deployment's NER recognizers to run.
     ///
-    /// - `Some(true)`: explicit opt-in. Attaches every
-    ///   deployment-configured recognizer. Fails the analyzer
-    ///   compile with a `Validation` error when the deployment
-    ///   has no NER recognizers configured.
-    /// - `Some(false)`: explicit opt-out. Skips NER entirely.
-    /// - `None`: softly-on default. Attaches every configured
-    ///   recognizer if the deployment has any; skips silently
-    ///   otherwise.
+    /// See [`ProviderSelection`] for the shape. `None` is the
+    /// softly-on default: attach every configured recognizer if
+    /// the deployment has any, skip silently otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ner: Option<bool>,
-    /// Run the deployment's LLM recognizer lineup.
+    pub ner: Option<ProviderSelection>,
+    /// Select which of the deployment's LLM recognizers to run.
     ///
-    /// Same three-state semantics as [`ner`]. The lineup is
-    /// filtered by declared modality — only recognizers whose
-    /// `modalities` list contains the analyzer's modality
-    /// attach.
+    /// Same shape as [`ner`]. The lineup is additionally filtered
+    /// by declared modality — only recognizers whose `modalities`
+    /// list contains the analyzer's modality attach.
     ///
     /// [`ner`]: RecognizerParams::ner
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub llm: Option<bool>,
+    pub llm: Option<ProviderSelection>,
+}
+
+/// How to pick recognizers out of a deployment-configured lineup.
+///
+/// Untagged on the wire: `true` / `false` / a list of names.
+///
+/// - `All(true)`: explicit opt-in. Attaches every configured
+///   recognizer; fails the analyzer compile if the lineup is
+///   empty.
+/// - `All(false)`: explicit opt-out. Skips the lineup entirely.
+/// - `Only(names)`: attach only the named recognizers. An empty
+///   list and any unknown name fail the analyzer compile.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ProviderSelection {
+    /// Whole-lineup toggle.
+    All(bool),
+    /// Allowlist by recognizer name.
+    Only(Vec<String>),
 }
 
 /// Params for the `elide-pattern` recognizer.


### PR DESCRIPTION
## Summary
- Wire selects deployment NER/LLM recognizers by name instead of just a boolean toggle. `RecognizerParams.{ner,llm}` become `Option<ProviderSelection>`: `true` runs the whole lineup, `false` skips it, `["a","b"]` runs only the named recognizers. Empty allowlist and unknown names fail the analyzer compile with the available names in the error message.
- New `Engine::ner_recognizers()` / `Engine::llm_recognizers()` returning `impl ExactSizeIterator<Item = RegisteredRecognizer<'_>>` so hosts can list what's registered without leaking backend credentials or connection details. Each recognizer gains an optional `description` field for the UI.
- Bumps elide `a29a152e → 6c0331db` (adds `OcrBackend::recognize_batch` with a sequential default). Refactors `BentoNer` and `BentoOcr` so `post_recognize` does the full encode-transport-decode hop inside one function, and `recognize` delegates to `recognize_batch` for single-request dispatch.

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets` (no warnings)
- [x] `cargo test --workspace --all-features`
- [x] `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features --no-deps`
- [x] `cargo deny check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)