### PR TITLE
Restore primitive as its own engine module

### DIFF
--- a/crates/nvisy-engine/src/entity.rs
+++ b/crates/nvisy-engine/src/entity.rs
@@ -1,4 +1,4 @@
-//! Detected entities and the leaf types their fields carry.
+//! Detected entities, their labels, and their audit trail.
 //!
 //! [`Entity`] is the modality-generic detection record produced
 //! by the analyzer and consumed by the anonymizer; [`EntityRecord`]
@@ -8,19 +8,10 @@
 //! the deployment's label vocabulary. [`Provenance`] carries the
 //! audit trail (which rule / model / pattern produced each
 //! detection).
-//!
-//! Primitive value types ([`BoundingBox`], [`Confidence`],
-//! [`Language`], ...) appear as leaf fields on entities and on
-//! wire schemas that constrain detection.
 
 pub use nvisy_schema::entity::{
     Attribution, Entity, EntityCoRef, EntityRef, Event, EventKind, Label, LabelCatalog, LabelRef,
     ModelEvent, PatternEvent, Provenance, RuleMatch,
-};
-pub use nvisy_schema::primitive::{
-    BoundingBox, Color, Confidence, ConfidenceThreshold, CountryCode, Dimensions, Dpi, Language,
-    LanguageProvenance, LanguageSpan, LanguageTag, Languages, PixelRegion, Point, Polygon,
-    TimeSpan, UnitBoundingBox,
 };
 
 pub use crate::pipeline::EntityRecord;

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -25,6 +25,7 @@ pub mod entity;
 pub mod modality;
 pub mod plan;
 mod pipeline;
+pub mod primitive;
 pub mod provider;
 
 #[doc(inline)]

--- a/crates/nvisy-engine/src/primitive.rs
+++ b/crates/nvisy-engine/src/primitive.rs
@@ -1,0 +1,16 @@
+//! Primitive value types wire schemas carry directly.
+//!
+//! Bounding boxes, confidence, colors, languages, country codes,
+//! time spans, and friends. Appear as leaf fields on entities,
+//! on the recognition [`Scope`], on [`plan`] recognizer params,
+//! and on [`policy`] operators.
+//!
+//! [`Scope`]: crate::Scope
+//! [`plan`]: crate::plan
+//! [`policy`]: crate::policy
+
+pub use nvisy_schema::primitive::{
+    BoundingBox, Color, Confidence, ConfidenceThreshold, CountryCode, Dimensions, Dpi, Language,
+    LanguageProvenance, LanguageSpan, LanguageTag, Languages, PixelRegion, Point, Polygon,
+    TimeSpan, UnitBoundingBox,
+};


### PR DESCRIPTION
## Summary
`BoundingBox`, `Confidence`, `Language`, `TimeSpan`, and friends are first-class value types callers reach for directly — building `Inclusion` annotations, constructing a `Scope`, comparing entity confidences. They deserve their own module rather than being buried under `entity`.

Engine root goes from 5 modules to 6: adds `primitive` back alongside `entity`, `modality`, `plan`, `policy`, `provider`.

## Test plan
- [x] \`cargo check --workspace --all-features\`
- [x] \`cargo clippy --workspace --all-features --all-targets\` (no warnings)
- [x] \`RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features --no-deps\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)