### PR TITLE
Bump elide + forward document codecs (PDF, PDF-render, RTF)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -929,6 +929,7 @@ dependencies = [
  "rig",
  "schemars",
  "serde",
+ "serde_json",
  "thiserror",
  "tracing",
  "unicode-normalization",
@@ -937,7 +938,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -951,7 +952,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -961,7 +962,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -975,7 +976,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -995,7 +996,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1010,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#6c0331db2926bf5a55ed895feb9c9ed6cf6a0304"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1787,15 +1788,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -3166,18 +3158,42 @@ checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rig"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aac59326725633a25c21ef2c24d33c4d00dc38a1f0cc097205a7a9bde70b482"
+checksum = "2ce03971e6115d30ef53fb3244d06718a4e62bbde82c103065600c09459b989a"
 dependencies = [
+ "rig-agent",
  "rig-core",
+ "rig-derive",
+]
+
+[[package]]
+name = "rig-agent"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0796bbf47d7b76670401aac975bc619cf7fba3482b22dfe14992edaa9c2e04"
+dependencies = [
+ "async-stream",
+ "fastrand",
+ "futures",
+ "http",
+ "indexmap",
+ "rig-core",
+ "rig-derive",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
 name = "rig-core"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8731dd5532b3a12ce1613af73073fb2051ef750f50c504778c21d55ae933cac"
+checksum = "35f5520515ae8f6851adcbc6fde9eea8e96f657418c062e16c82cd81cce44e8e"
 dependencies = [
  "as-any",
  "async-stream",
@@ -3210,16 +3226,14 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e98dde7a4e59e083e7396126ee4c83498c5bff605d126654e67815fa230a78"
+checksum = "eb868fcebdf3ba425e3afad2e4926bb6d9e1188a856843b00bcee2e15c07424f"
 dependencies = [
  "convert_case 0.11.0",
- "indoc",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.118",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +395,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +433,26 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86919cef3e37b9356ccf54d4421208c17ecfda01beae61393e7ffd72916c0ef1"
+dependencies = [
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -852,7 +894,9 @@ dependencies = [
  "image",
  "imageproc",
  "mp3lame-encoder",
+ "pdfium-render",
  "quick-xml",
+ "rayon",
  "scraper",
  "serde_json",
  "sha2 0.11.0",
@@ -1602,6 +1646,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "iban_validate"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2042,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2194,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -2499,6 +2583,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pdfium-render"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826f8f64bc88cb15381cbb5aa245c1500632cd8a453b244bc2b0cbaff7098077"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "image",
+ "itertools",
+ "js-sys",
+ "libloading",
+ "log",
+ "maybe-owned",
+ "once_cell",
+ "utf16string",
+ "vecmath",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2718,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piston-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
 
 [[package]]
 name = "png"
@@ -4333,6 +4449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4366,6 +4491,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vecmath"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
+dependencies = [
+ "piston-float",
+]
 
 [[package]]
 name = "version_check"
@@ -4574,6 +4708,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,6 +4753,15 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]

--- a/crates/elide-bento/src/error.rs
+++ b/crates/elide-bento/src/error.rs
@@ -27,12 +27,12 @@ pub(crate) enum BentoError {
 
 impl From<BentoError> for Error {
     /// Map transport to [`ErrorKind::Transport`] and protocol to
-    /// [`ErrorKind::Validation`], carrying the original error as the
+    /// [`ErrorKind::Provider`], carrying the original error as the
     /// source cause.
     fn from(err: BentoError) -> Self {
         let kind = match err {
             BentoError::Transport(_) => ErrorKind::Transport,
-            BentoError::Protocol(_) => ErrorKind::Validation,
+            BentoError::Protocol(_) => ErrorKind::Provider,
         };
         Error::new(kind, err)
     }

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -19,7 +19,7 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 
 [features]
-default = ["tabular", "image", "audio", "codec-docx"]
+default = ["tabular", "image", "audio", "document"]
 
 ## Tabular modality (analyzer + anonymizer + redaction operators)
 ## plus every tabular codec elide ships (CSV, XLSX).
@@ -31,6 +31,11 @@ image = ["internal_image", "codec-png", "codec-jpeg", "codec-tiff"]
 ## plus the WAV codec. MP3 is opt-in via `codec-mp3` because of
 ## patent licensing.
 audio = ["internal_audio", "codec-wav"]
+## Container-document codecs: DOCX, PDF, RTF. Standalone: text and
+## image modalities are still needed to handle the parts these
+## containers embed. `codec-pdf-render` (rasterising pages for
+## OCR) is opt-in via its own toggle.
+document = ["codec-docx", "codec-pdf", "codec-rtf"]
 
 ## Individual codec toggles. Each pulls in its modality's shared
 ## code (`internal_*`), so `codec-png` alone works without also
@@ -45,8 +50,16 @@ codec-wav = ["internal_audio", "elide/codec-wav"]
 ## downstream. Off by default even when `audio` is enabled.
 codec-mp3 = ["internal_audio", "elide/codec-mp3"]
 ## DOCX documents (a zip archive with an XML body plus embedded
-## image parts). Standalone: not implied by `image` or `tabular`.
+## image parts).
 codec-docx = ["elide/codec-docx"]
+## PDF documents (text extraction).
+codec-pdf = ["elide/codec-pdf"]
+## PDF page rasterisation for downstream OCR. Standalone toggle
+## on top of `codec-pdf`; opt-in because it drags in a native
+## rendering dep.
+codec-pdf-render = ["codec-pdf", "elide/codec-pdf-render"]
+## RTF documents.
+codec-rtf = ["elide/codec-rtf"]
 
 # Internal shared-code gates. Not part of the public feature
 # surface: enabled transitively by every user-facing feature that

--- a/crates/nvisy-engine/src/analyzer/enricher/ocr.rs
+++ b/crates/nvisy-engine/src/analyzer/enricher/ocr.rs
@@ -30,7 +30,7 @@ pub(in crate::analyzer) fn attach(
         // skipping OCR.
         _ => {
             return Err(Error::new(
-                ErrorKind::Validation,
+                ErrorKind::CapabilityUnavailable,
                 "OCR enricher uses a backend kind this engine binary doesn't \
                  understand; upgrade the engine or downgrade the config",
             ));

--- a/crates/nvisy-engine/src/analyzer/enricher/stt.rs
+++ b/crates/nvisy-engine/src/analyzer/enricher/stt.rs
@@ -23,7 +23,7 @@ pub(in crate::analyzer) fn attach(
     let _ = analyzer;
     match &spec.backend {
         SttBackendParams::Bento { .. } => Err(Error::new(
-            ErrorKind::Validation,
+            ErrorKind::CapabilityUnavailable,
             "analyzer compile: BentoML STT backend needs an elide-bento `BentoStt` \
              client; not wired into the compile surface yet",
         )),
@@ -32,7 +32,7 @@ pub(in crate::analyzer) fn attach(
         // `SttBackendParams` is `#[non_exhaustive]`. Unknown
         // variants surface as Validation.
         _ => Err(Error::new(
-            ErrorKind::Validation,
+            ErrorKind::CapabilityUnavailable,
             "analyzer compile: STT enricher uses a backend kind this engine binary \
              doesn't understand; upgrade the engine or downgrade the config",
         )),

--- a/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
@@ -61,7 +61,7 @@ where
     for recognizer in &selected {
         if recognizer.modalities.is_empty() {
             return Err(Error::new(
-                ErrorKind::Validation,
+                ErrorKind::Configuration,
                 format!(
                     "LLM recognizer `{}` declares empty `modalities`; \
                      add at least one modality or remove the recognizer",
@@ -77,7 +77,7 @@ where
     }
     if modality_matched == 0 && matches!(selection, Some(ProviderSelection::All(true))) {
         return Err(Error::new(
-            ErrorKind::Validation,
+            ErrorKind::Configuration,
             format!(
                 "AnalyzerParams.recognizers.llm = true but the deployment has no LLM \
                  recognizer configured for the {modality:?} modality; add one to \

--- a/crates/nvisy-engine/src/analyzer/recognizer/pattern.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/pattern.rs
@@ -105,7 +105,7 @@ fn check_custom_count(
     let total = spec.custom.len() + spec.custom_dictionaries.len();
     if total > guardrails.max_custom_rules {
         return Err(Error::new(
-            ErrorKind::Validation,
+            ErrorKind::Configuration,
             format!(
                 "pattern recognizer: {} custom rules requested \
                  (custom={} + customDictionaries={}) exceeds the \
@@ -145,7 +145,7 @@ fn compile_custom_variant(
 ) -> Result<Variant, Error> {
     if variant.regex.len() > guardrails.max_regex_source_len {
         return Err(Error::new(
-            ErrorKind::Validation,
+            ErrorKind::Configuration,
             format!(
                 "pattern recognizer: regex source of {} bytes exceeds \
                  the deployment cap of {} bytes",

--- a/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
@@ -82,7 +82,7 @@ fn select_allowlisted<'a, T: Named>(
 
 fn empty_lineup(field: &str) -> Error {
     Error::new(
-        ErrorKind::Validation,
+        ErrorKind::Configuration,
         format!(
             "AnalyzerParams.recognizers.{field} = true but the deployment has no \
              {field} recognizer configured; leave `{field}` unset / false to opt out"
@@ -92,7 +92,7 @@ fn empty_lineup(field: &str) -> Error {
 
 fn empty_allowlist(field: &str) -> Error {
     Error::new(
-        ErrorKind::Validation,
+        ErrorKind::Configuration,
         format!(
             "AnalyzerParams.recognizers.{field} is an empty allowlist; use \
              `{field}: false` to opt out entirely, or list at least one recognizer name"
@@ -104,7 +104,7 @@ fn unknown_names(field: &str, unknown: &[&str], available: &HashSet<&str>) -> Er
     let mut available: Vec<&str> = available.iter().copied().collect();
     available.sort_unstable();
     Error::new(
-        ErrorKind::Validation,
+        ErrorKind::Configuration,
         format!(
             "AnalyzerParams.recognizers.{field} names unknown recognizer(s) {unknown:?}; \
              available in this deployment: {available:?}"

--- a/crates/nvisy-engine/src/anonymizer/operator/text.rs
+++ b/crates/nvisy-engine/src/anonymizer/operator/text.rs
@@ -105,7 +105,7 @@ impl TryFrom<&TextRedaction> for TextOp {
 
 fn stateful_not_wired(operator: &'static str, infrastructure: &'static str) -> Error {
     Error::new(
-        ErrorKind::Validation,
+        ErrorKind::CapabilityUnavailable,
         format!(
             "policy compile: `{operator}` needs an engine-side {infrastructure}; \
              stateful operator infrastructure is not wired into the compile surface yet",

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -253,7 +253,7 @@ impl Engine {
 
         let body_group = body_group.ok_or_else(|| {
             Error::new(
-                ErrorKind::Validation,
+                ErrorKind::CapabilityUnavailable,
                 format!(
                     "codec resolved {extension:?} to a modality the orchestrator \
                      has no pipeline for"
@@ -320,7 +320,7 @@ impl Engine {
     ) -> Result<AnonymizedDocument> {
         let body_group = analyzed.body.as_ref().ok_or_else(|| {
             Error::new(
-                ErrorKind::Validation,
+                ErrorKind::Configuration,
                 "anonymize_document: body group is missing — analyze must run first",
             )
         })?;
@@ -354,7 +354,7 @@ impl Engine {
             .await
             .map_err(|err| {
                 Error::new(
-                    ErrorKind::Validation,
+                    ErrorKind::MalformedInput,
                     format!("codec decode failed for extension {extension:?}: {err}"),
                 )
             })


### PR DESCRIPTION
## Summary
Bumps elide `6c0331db → 97d03a75` and closes the codec-feature gap the recent bump exposed.

### ErrorKind migration
Upstream refactored the `ErrorKind` enum: the overloaded `Validation` variant is gone, replaced with a more granular set. Migrated 13 callsites:

- **MalformedInput**: codec decode failures.
- **Configuration**: pattern-recognizer caps, allowlist validation, LLM lineup opt-in, missing body group on anonymize.
- **CapabilityUnavailable**: codec→modality with no pipeline, STT/OCR backend kinds not understood, text stateful operator infrastructure not wired.
- **Provider**: elide-bento's `Protocol` errors (service returned unexpected shape).

### Codec feature forwards
Elide added `codec-pdf`, `codec-pdf-render`, `codec-rtf`; engine never forwarded them. Added each as standalone toggles plus a new `document` blanket (docx + pdf + rtf) that replaces the narrower `codec-docx` slot in the default feature set.

`codec-pdf-render` stays opt-in — drags in a native page-rasterisation dep.

### Also
Rig `0.40 → 0.41` transitive (adds `rig-agent` subcrate).

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets` (no warnings)
- [x] `cargo test --workspace --all-features`
- [x] `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features --no-deps`
- [x] `cargo deny check`
- [x] Individual codec toggles build standalone: `codec-pdf`, `codec-rtf`, `codec-pdf-render`

🤖 Generated with [Claude Code](https://claude.com/claude-code)