### PR TITLE
Bump elide, rename EntityRecord<M> schema per modality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -937,7 +937,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1020,7 +1020,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/nvisy-engine/src/pipeline/analyzed.rs
+++ b/crates/nvisy-engine/src/pipeline/analyzed.rs
@@ -139,7 +139,8 @@ pub enum RecognizedGroup {
 #[serde(rename_all = "camelCase")]
 #[serde(bound = "M::Location: Serialize + for<'a> Deserialize<'a>, \
                   M::Data: Serialize + for<'a> Deserialize<'a>")]
-#[schemars(bound = "M::Location: JsonSchema, M::Data: JsonSchema")]
+#[schemars(bound = "M: JsonSchema, M::Location: JsonSchema, M::Data: JsonSchema")]
+#[schemars(rename = "{M}EntityRecord")]
 pub struct EntityRecord<M: Modality> {
     /// The elide entity, as recognition produced it.
     pub entity: Entity<M>,


### PR DESCRIPTION
## Summary
Bumps elide `97d03a75 → 5f613868` for [nvisycom/elide#137](https://github.com/nvisycom/elide/pull/137), which prefixed generic `JsonSchema` names with their modality so OpenAPI consumers see stable, self-describing schemas (`TextProvenance` / `ImageEntity` / ...) instead of positional disambiguators (`Provenance2` / `Provenance3` / ...).

Audited the workspace for the same pattern and found one match: `EntityRecord<M>` in `nvisy-engine`. It's used in every `RecognizedGroup` variant (`Text`/`Tabular`/`Image`/`Audio`), so its OpenAPI schema would have collided into `EntityRecord` / `EntityRecord2` / `EntityRecord3` / `EntityRecord4`.

Fix: `schemars(rename = "{M}EntityRecord")` on the struct, plus extending the schemars bound with `M: JsonSchema` so the `{M}` interpolation resolves. Now renders as `TextEntityRecord`, `ImageEntityRecord`, `TabularEntityRecord`, `AudioEntityRecord`.

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets` (no warnings)
- [x] `cargo test --workspace --all-features`
- [x] `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features --no-deps`
- [x] `cargo deny check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)