### PR TITLE
Bump elide: localized labels + LabelCatalog tag-filter helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "bytes",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "bytes",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1058,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1074,7 +1074,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#0d51da7ac1a7d6ca9aa57b362325de483c34726e"
+source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/elide-bento/src/ner/request.rs
+++ b/crates/elide-bento/src/ner/request.rs
@@ -6,6 +6,7 @@
 //! structured records (also part of the upstream schema) are
 //! omitted — this backend surfaces entity extraction only.
 
+use elide_core::primitive::LanguageTag;
 use elide_ner::backend::NerRequest;
 use serde::Serialize;
 
@@ -26,15 +27,21 @@ impl WireNerRequest {
     /// Translate an elide [`NerRequest`] into the wire shape,
     /// pinning the service-default threshold when the request has
     /// no per-label thresholds of its own.
+    ///
+    /// Label name/description are localized in the request's
+    /// asserted language when set; otherwise English is used as
+    /// the fallback locale (matching elide's own default).
     pub(super) fn from_request(request: &NerRequest<'_>, default_threshold: f32) -> Self {
+        let english = LanguageTag::english();
+        let language = request.language.unwrap_or(&english);
         let entities = request
             .labels
             .map(|labels| {
                 labels
                     .iter()
                     .map(|label| WireEntitySpec {
-                        label: label.name().to_owned(),
-                        description: label.description().map(str::to_owned),
+                        label: label.name(language).to_owned(),
+                        description: label.description(language).map(str::to_owned),
                         threshold: None,
                     })
                     .collect()

--- a/crates/nvisy-engine/src/analyzer/catalog.rs
+++ b/crates/nvisy-engine/src/analyzer/catalog.rs
@@ -130,7 +130,7 @@ mod tests {
     fn custom_labels_land_in_the_catalog() {
         let policy = policy_with_labels(Labels {
             builtins: Vec::new(),
-            custom: vec![Label::new("project_code")],
+            custom: vec![Label::new("project_code", "Project code")],
         });
         let catalog = compile_catalog(std::slice::from_ref(&policy));
         assert!(catalog.contains(&LabelRef::new("project_code")));

--- a/crates/nvisy-engine/src/entity/mod.rs
+++ b/crates/nvisy-engine/src/entity/mod.rs
@@ -7,18 +7,28 @@
 //! [`EntityGroup`] wraps a whole `Vec` of records, tagged by
 //! modality, as the unit an [`Audit`] holds in `body` and every
 //! `parts` entry. [`Label`] and [`LabelRef`] name the entity
-//! kind; [`LabelCatalog`] holds the deployment's label vocabulary.
-//! [`Provenance`] carries the audit trail (which rule / model /
-//! pattern produced each detection).
+//! kind; each label carries per-language [`Localization`] entries
+//! (name + optional description) so NER and LLM backends render
+//! labels in the analysis language. [`LabelCatalog`] holds the
+//! deployment's label vocabulary and exposes tag-filter helpers
+//! ([`LabelCatalog::tagged`], [`LabelCatalog::refs_tagged`],
+//! [`LabelCatalog::filter_tag`]) — the primitive regulatory policy
+//! templates compose on top of to resolve `tags: ["phi"]`-style
+//! selectors into concrete label sets. [`Provenance`] carries
+//! the audit trail (which rule / model / pattern produced each
+//! detection).
 //!
 //! [`Audit`]: crate::Audit
+//! [`LabelCatalog::tagged`]: elide_core::entity::LabelCatalog::tagged
+//! [`LabelCatalog::refs_tagged`]: elide_core::entity::LabelCatalog::refs_tagged
+//! [`LabelCatalog::filter_tag`]: elide_core::entity::LabelCatalog::filter_tag
 
 mod group;
 mod record;
 
 pub use nvisy_schema::entity::{
     Attribution, Entity, EntityCoRef, EntityRef, Event, EventKind, Label, LabelCatalog, LabelRef,
-    ModelEvent, PatternEvent, Provenance, RuleMatch,
+    Localization, ModelEvent, PatternEvent, Provenance, RuleMatch,
 };
 
 pub use self::group::EntityGroup;

--- a/crates/nvisy-schema/src/entity.rs
+++ b/crates/nvisy-schema/src/entity.rs
@@ -3,11 +3,15 @@
 //! [`Entity`] is the modality-generic detection record produced
 //! by the analyzer and consumed by the anonymizer. [`Label`] and
 //! [`LabelRef`] name the entity kind; [`LabelCatalog`] holds the
-//! deployment's label vocabulary. [`Provenance`] carries the
-//! audit trail (which rule / model / pattern produced each
-//! detection).
+//! deployment's label vocabulary. Each label carries per-language
+//! [`Localization`] entries (name + optional description); NER
+//! and LLM backends render these in the analysis language.
+//! [`Provenance`] carries the audit trail (which rule / model /
+//! pattern produced each detection).
 
 pub use elide_core::entity::provenance::{
     Attribution, Event, EventKind, ModelEvent, PatternEvent, Provenance, RuleMatch,
 };
-pub use elide_core::entity::{Entity, EntityCoRef, EntityRef, Label, LabelCatalog, LabelRef};
+pub use elide_core::entity::{
+    Entity, EntityCoRef, EntityRef, Label, LabelCatalog, LabelRef, Localization,
+};


### PR DESCRIPTION
## Summary

Adapts the runtime to two elide changes on `main`:

- **Localized labels** ([elide#141](https://github.com/nvisycom/elide/pull/141)): `Label` splits identity from display — stable `id` (the catalog key) plus per-language `localizations`. `Label::name` / `Label::description` now take a `&LanguageTag`; `Label::new` becomes `(id, English name)`.
- **Tag-filter primitive** ([elide#142](https://github.com/nvisycom/elide/pull/142)): `LabelCatalog::tagged`, `refs_tagged`, and `filter_tag(tag) -> LabelCatalog`. The enabling primitive regulatory policy templates (issue #86) compose on top of to resolve `tags: [\"phi\"]` selectors into concrete label sets.

Runtime-side changes are small — only `elide-bento`'s NER wire request actually broke; everything else adapts through re-exports:

- `elide-bento`'s `WireNerRequest::from_request` threads the request's language into `Label::name`/`description`, falling back to `LanguageTag::english()`.
- `nvisy-schema` and `nvisy-engine::entity` re-export `Localization` so downstream template authors can build multi-language labels without pulling `elide-core` directly.
- Engine's entity-module docstring calls out both the localization contract and the tag-filter helpers.
- Fixed one `compile_catalog` unit test (`Label::new` signature change).

**Not in this PR** (intentional split): the actual regulatory templates (HIPAA, GDPR, PCI-DSS, CCPA) — those land as a follow-up against #86 once this primitive is in place.

## Test plan

- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (26 engine tests + 2 policy tests green)
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)