### PR TITLE
Phase 1: elide operator wiring, PolicyRule::Table, LabelGroup primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,18 +931,18 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "elide-codec",
  "elide-context",
  "elide-core",
  "elide-detection",
+ "elide-engine",
  "elide-lingua",
  "elide-llm",
  "elide-ner",
  "elide-ocr",
- "elide-orchestration",
  "elide-pattern",
  "elide-redaction",
  "elide-stt",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1004,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1033,9 +1033,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "elide-engine"
+version = "0.1.0"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+dependencies = [
+ "bytes",
+ "elide-codec",
+ "elide-core",
+ "elide-detection",
+ "elide-redaction",
+ "erased-serde",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1046,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1057,11 +1072,12 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "derive_builder",
  "elide-core",
+ "hipstr",
  "minijinja",
  "reqwest-middleware",
  "reqwest-retry",
@@ -1078,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1092,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1100,24 +1116,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "elide-orchestration"
-version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
-dependencies = [
- "bytes",
- "elide-codec",
- "elide-core",
- "elide-detection",
- "elide-redaction",
- "erased-serde",
- "serde",
- "uuid",
-]
-
-[[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1137,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1160,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
+source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +443,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +461,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -505,6 +557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,7 +642,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -629,6 +689,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -797,6 +875,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -852,7 +931,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -888,7 +967,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "bytes",
@@ -914,7 +993,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -925,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "bytes",
@@ -943,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -956,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -967,7 +1046,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -978,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -999,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1013,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1023,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1038,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1058,23 +1137,30 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
+ "aes-gcm",
  "async-trait",
+ "base64 0.23.0",
  "bytes",
  "elide-core",
  "elide-fake",
  "hex",
  "hipstr",
+ "hmac",
+ "jiff",
+ "schemars",
+ "serde",
  "sha2 0.11.0",
  "tracing",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
+source = "git+https://github.com/nvisycom/elide?branch=main#61d98f54e5104c748679277f6f0082a5f8fb59ee"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1424,6 +1510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "glam"
 version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1645,15 @@ checksum = "07a5072958d04f9147e517881d929d3f4706612712f8f4cfcd247f2b716d5262"
 dependencies = [
  "loom",
  "serde",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1886,6 +1990,15 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2519,6 +2632,7 @@ version = "0.1.0"
 dependencies = [
  "derive_more",
  "elide-core",
+ "elide-redaction",
  "hipstr",
  "schemars",
  "serde",
@@ -2766,6 +2880,17 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4448,6 +4573,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "bytes",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "bytes",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1058,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1074,7 +1074,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e692762894a4578c6ab4ade0b63be131279e9559"
+source = "git+https://github.com/nvisycom/elide?branch=main#762b92517f4675fedede243845294642b849eb89"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/elide-bento/src/ner/mod.rs
+++ b/crates/elide-bento/src/ner/mod.rs
@@ -114,9 +114,9 @@ impl NerBackend for BentoNer {
 
     async fn recognize(&self, request: NerRequest<'_>) -> Result<NerResponse> {
         let mut responses = self.recognize_batch(&[request]).await?;
-        responses.pop().ok_or_else(|| {
-            BentoError::Protocol("bento ner returned an empty batch".into()).into()
-        })
+        responses
+            .pop()
+            .ok_or_else(|| BentoError::Protocol("bento ner returned an empty batch".into()).into())
     }
 
     async fn recognize_batch(&self, requests: &[NerRequest<'_>]) -> Result<Vec<NerResponse>> {

--- a/crates/elide-bento/src/ocr/mod.rs
+++ b/crates/elide-bento/src/ocr/mod.rs
@@ -118,9 +118,9 @@ impl OcrBackend for BentoOcr {
 
     async fn recognize(&self, request: OcrRequest<'_>) -> Result<OcrResponse> {
         let mut responses = self.recognize_batch(&[request]).await?;
-        responses.pop().ok_or_else(|| {
-            BentoError::Protocol("bento ocr returned an empty batch".into()).into()
-        })
+        responses
+            .pop()
+            .ok_or_else(|| BentoError::Protocol("bento ocr returned an empty batch".into()).into())
     }
 
     async fn recognize_batch(&self, requests: &[OcrRequest<'_>]) -> Result<Vec<OcrResponse>> {

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -91,7 +91,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Elide crates
-elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "ocr", "stt", "llm", "llm-rig", "llm-jinja2", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "fake", "serde", "schema", "sha2"] }
+elide = { workspace = true, features = ["codec", "codec-text", "pattern", "ner", "ocr", "stt", "llm", "llm-rig", "llm-jinja2", "llm-openai", "llm-anthropic", "llm-gemini", "lingua", "fake", "serde", "schema", "sha2", "hmac", "aes", "datetime"] }
 elide-core = { workspace = true, features = ["serde", "schema", "image", "audio", "tabular"] }
 
 # Elide extensions

--- a/crates/nvisy-engine/src/analyzer/audio.rs
+++ b/crates/nvisy-engine/src/analyzer/audio.rs
@@ -16,7 +16,7 @@
 //! [`AnalyzerParams`]: nvisy_schema::plan::AnalyzerParams
 
 use elide::detection::Analyzer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::audio::Audio;
 use nvisy_schema::plan::AnalyzerParams;
 
@@ -31,7 +31,7 @@ pub(super) fn compile(
     spec: &AnalyzerParams,
     ner: &NerConfig,
     guardrails: &PatternGuardrails,
-) -> Result<Analyzer<Audio>, Error> {
+) -> Result<Analyzer<Audio>> {
     let mut analyzer = Analyzer::<Audio>::new();
 
     if let Some(stt) = &spec.enrichers.stt {

--- a/crates/nvisy-engine/src/analyzer/catalog.rs
+++ b/crates/nvisy-engine/src/analyzer/catalog.rs
@@ -1,21 +1,31 @@
-//! Compile a slice of [`PolicyDefinition`] into an
-//! [`elide_core::entity::LabelCatalog`].
+//! Compile a slice of [`PolicyDefinition`] and the request's
+//! [`LabelGroup`]s into an [`elide_core::entity::LabelCatalog`].
 //!
 //! Walks every policy's [`labels`] block, unions the builtin
-//! selections and the inline custom schemas into one catalog.
-//! Kept engine-side so the cached `with_builtins` lookup and the
-//! warn-and-skip policy for unknown builtin names stay out of
+//! selections and the inline custom schemas into one catalog,
+//! then stamps a `group:<name>` synthetic tag on every label
+//! listed in each [`LabelGroup`]. Kept engine-side so the cached
+//! `with_builtins` lookup, the warn-and-skip policy for unknown
+//! builtin names, and the group tag synthesis stay out of
 //! `nvisy-policy`.
 //!
 //! [`PolicyDefinition`]: nvisy_schema::policy::PolicyDefinition
+//! [`LabelGroup`]: nvisy_schema::policy::LabelGroup
 //! [`labels`]: nvisy_schema::policy::PolicyDefinition::labels
 
 use std::sync::OnceLock;
 
 use elide_core::entity::LabelCatalog;
-use nvisy_schema::policy::{Labels, PolicyDefinition};
+use nvisy_schema::policy::{LabelGroup, Labels, PolicyDefinition};
 
-/// Compile the label catalog for a request from its policy set.
+/// Prefix elide-side synthetic tags carry so a `LabelGroup`
+/// named `hipaa_18` becomes the tag `group:hipaa_18` on every
+/// listed label. Keeps synthetic tags in their own namespace,
+/// away from elide's data-category tags (`pii`, `phi`, …).
+pub(crate) const GROUP_TAG_PREFIX: &str = "group:";
+
+/// Compile the label catalog for a request from its policy set
+/// and its [`LabelGroup`]s.
 ///
 /// Every policy contributes its [`labels`] block; builtins are
 /// resolved once against the cached full builtin catalog, custom
@@ -23,17 +33,61 @@ use nvisy_schema::policy::{Labels, PolicyDefinition};
 /// or between builtins and customs follow
 /// [`LabelCatalog::insert`] semantics: last write wins.
 ///
-/// Unknown builtin names log a warning and are skipped — typos
-/// shouldn't fail the request.
+/// After label union, each [`LabelGroup`] stamps a
+/// `group:<name>` tag onto every listed label present in the
+/// catalog — the compile-time rewrite that makes
+/// [`Predicate::LabelInGroup { group }`] lower to
+/// [`TagOneOf`]`{ tags: ["group:<name>"] }`. A label listed in a
+/// group but absent from the catalog is silently skipped; groups
+/// can safely reference labels this build doesn't ship (e.g.
+/// modality-gated ones).
 ///
+/// Unknown builtin names log a warning and are skipped — typos
+/// shouldn't fail the request. Unknown group *names* are
+/// separately validated by [`validate_groups_referenced_in_policies`].
+///
+/// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
 /// [`labels`]: nvisy_schema::policy::PolicyDefinition::labels
 /// [`LabelCatalog::insert`]: elide_core::entity::LabelCatalog::insert
-pub(crate) fn compile_catalog(policies: &[PolicyDefinition]) -> LabelCatalog {
+/// [`Predicate::LabelInGroup { group }`]: nvisy_schema::policy::predicate::Predicate::LabelInGroup
+/// [`TagOneOf`]: nvisy_schema::policy::predicate::Predicate::TagOneOf
+pub(crate) fn compile_catalog(
+    policies: &[PolicyDefinition],
+    groups: &[LabelGroup],
+) -> LabelCatalog {
     let mut catalog = LabelCatalog::new();
     for policy in policies {
         insert_params(&mut catalog, &policy.labels);
     }
+    apply_group_tags(&mut catalog, groups);
     catalog
+}
+
+/// Stamp `group:<name>` on every label a group lists that the
+/// catalog carries. Preserves the label's existing tag list —
+/// elide's `with_tags` builder *replaces* the tag list, so we
+/// read the current tags, append the synthetic one, and
+/// re-insert (last-write-wins on the catalog side).
+fn apply_group_tags(catalog: &mut LabelCatalog, groups: &[LabelGroup]) {
+    for group in groups {
+        let synthetic_tag = format!("{GROUP_TAG_PREFIX}{}", group.name);
+        for label_ref in &group.labels {
+            let Some(label) = catalog.get(label_ref) else {
+                continue;
+            };
+            if label.has_tag(&synthetic_tag) {
+                continue;
+            }
+            let merged: Vec<_> = label
+                .tags()
+                .iter()
+                .cloned()
+                .chain(std::iter::once(synthetic_tag.clone().into()))
+                .collect();
+            let stamped = label.clone().with_tags(merged);
+            catalog.insert(stamped);
+        }
+    }
 }
 
 fn insert_params(catalog: &mut LabelCatalog, params: &Labels) {
@@ -72,6 +126,7 @@ fn builtin_catalog() -> &'static LabelCatalog {
 mod tests {
     use elide_core::entity::{Label, LabelRef};
     use hipstr::HipStr;
+    use nvisy_schema::policy::LabelGroup;
     use uuid::Uuid;
 
     use super::*;
@@ -91,13 +146,13 @@ mod tests {
 
     #[test]
     fn empty_policy_set_yields_empty_catalog() {
-        assert!(compile_catalog(&[]).is_empty());
+        assert!(compile_catalog(&[], &[]).is_empty());
     }
 
     #[test]
     fn policy_with_no_labels_contributes_nothing() {
         let policy = policy_with_labels(Labels::default());
-        assert!(compile_catalog(std::slice::from_ref(&policy)).is_empty());
+        assert!(compile_catalog(std::slice::from_ref(&policy), &[]).is_empty());
     }
 
     #[test]
@@ -106,7 +161,7 @@ mod tests {
             builtins: vec![LabelRef::new("email_address")],
             custom: Vec::new(),
         });
-        let catalog = compile_catalog(std::slice::from_ref(&policy));
+        let catalog = compile_catalog(std::slice::from_ref(&policy), &[]);
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert_eq!(catalog.len(), 1);
     }
@@ -120,7 +175,7 @@ mod tests {
             ],
             custom: Vec::new(),
         });
-        let catalog = compile_catalog(std::slice::from_ref(&policy));
+        let catalog = compile_catalog(std::slice::from_ref(&policy), &[]);
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert!(!catalog.contains(&LabelRef::new("definitely_not_a_real_label")));
         assert_eq!(catalog.len(), 1);
@@ -132,7 +187,7 @@ mod tests {
             builtins: Vec::new(),
             custom: vec![Label::new("project_code", "Project code")],
         });
-        let catalog = compile_catalog(std::slice::from_ref(&policy));
+        let catalog = compile_catalog(std::slice::from_ref(&policy), &[]);
         assert!(catalog.contains(&LabelRef::new("project_code")));
     }
 
@@ -146,9 +201,63 @@ mod tests {
             builtins: vec![LabelRef::new("phone_number")],
             custom: Vec::new(),
         });
-        let catalog = compile_catalog(&[a, b]);
+        let catalog = compile_catalog(&[a, b], &[]);
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert!(catalog.contains(&LabelRef::new("phone_number")));
         assert_eq!(catalog.len(), 2);
+    }
+
+    #[test]
+    fn group_stamps_synthetic_tag_and_preserves_existing_tags() {
+        let policy = policy_with_labels(Labels {
+            builtins: vec![LabelRef::new("email_address")],
+            custom: Vec::new(),
+        });
+        let group = LabelGroup {
+            name: HipStr::from("contact_sweep"),
+            description: None,
+            labels: vec![LabelRef::new("email_address")],
+        };
+        let catalog = compile_catalog(std::slice::from_ref(&policy), &[group]);
+        let stamped = catalog.get(&LabelRef::new("email_address")).unwrap();
+        assert!(stamped.has_tag("group:contact_sweep"));
+        // Elide's builtin email_address carries `contact_info` and `pii`;
+        // synthesis appends, doesn't replace.
+        assert!(stamped.has_tag("pii"));
+        assert!(stamped.has_tag("contact_info"));
+    }
+
+    #[test]
+    fn group_referencing_absent_label_is_silently_skipped() {
+        // No policy contributes labels; the group's target label
+        // isn't in the catalog, so the group is a no-op.
+        let group = LabelGroup {
+            name: HipStr::from("nothing_present"),
+            description: None,
+            labels: vec![LabelRef::new("email_address")],
+        };
+        let catalog = compile_catalog(&[], &[group]);
+        assert!(catalog.is_empty());
+    }
+
+    #[test]
+    fn repeated_group_application_is_idempotent() {
+        // Two groups with the same name applied twice should not
+        // double-stamp the tag (has_tag short-circuits).
+        let policy = policy_with_labels(Labels {
+            builtins: vec![LabelRef::new("email_address")],
+            custom: Vec::new(),
+        });
+        let group = LabelGroup {
+            name: HipStr::from("dup"),
+            description: None,
+            labels: vec![LabelRef::new("email_address")],
+        };
+        let catalog = compile_catalog(std::slice::from_ref(&policy), &[group.clone(), group]);
+        let stamped = catalog.get(&LabelRef::new("email_address")).unwrap();
+        assert_eq!(
+            stamped.tags().iter().filter(|t| t.as_str() == "group:dup").count(),
+            1,
+        );
     }
 }

--- a/crates/nvisy-engine/src/analyzer/enricher/ocr.rs
+++ b/crates/nvisy-engine/src/analyzer/enricher/ocr.rs
@@ -11,14 +11,14 @@ use elide::enrichment::ocr::MockBackend as MockOcrBackend;
 use elide::enrichment::ocr::OcrEnricher;
 use elide_bento::ocr::BentoOcr;
 use elide_core::modality::image::Image;
-use elide_core::{Error, ErrorKind};
+use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::plan::{OcrBackendParams, OcrEnricherParams};
 
 /// Attach an [`OcrEnricher`] for the image modality.
 pub(in crate::analyzer) fn attach(
     analyzer: Analyzer<Image>,
     spec: &OcrEnricherParams,
-) -> Result<Analyzer<Image>, Error> {
+) -> Result<Analyzer<Image>> {
     let enricher = match &spec.backend {
         OcrBackendParams::Bento { base_url, model } => {
             OcrEnricher::new(BentoOcr::new(base_url.clone(), model.clone())?)

--- a/crates/nvisy-engine/src/analyzer/enricher/stt.rs
+++ b/crates/nvisy-engine/src/analyzer/enricher/stt.rs
@@ -9,7 +9,7 @@ use elide::detection::Analyzer;
 #[cfg(feature = "test-utils")]
 use elide::enrichment::stt::{MockBackend as MockSttBackend, SttEnricher};
 use elide_core::modality::audio::Audio;
-use elide_core::{Error, ErrorKind};
+use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::plan::{SttBackendParams, SttEnricherParams};
 
 /// Attach an [`SttEnricher`] for the audio modality.
@@ -18,7 +18,7 @@ use nvisy_schema::plan::{SttBackendParams, SttEnricherParams};
 pub(in crate::analyzer) fn attach(
     analyzer: Analyzer<Audio>,
     spec: &SttEnricherParams,
-) -> Result<Analyzer<Audio>, Error> {
+) -> Result<Analyzer<Audio>> {
     #[cfg(not(feature = "test-utils"))]
     let _ = analyzer;
     match &spec.backend {

--- a/crates/nvisy-engine/src/analyzer/image.rs
+++ b/crates/nvisy-engine/src/analyzer/image.rs
@@ -19,7 +19,7 @@
 //! [`LlmConfig`]: crate::provider::llm::LlmConfig
 
 use elide::detection::Analyzer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::image::Image;
 use nvisy_schema::plan::AnalyzerParams;
 
@@ -36,7 +36,7 @@ pub(super) fn compile(
     ner: &NerConfig,
     llm: &LlmConfig,
     guardrails: &PatternGuardrails,
-) -> Result<Analyzer<Image>, Error> {
+) -> Result<Analyzer<Image>> {
     let mut analyzer = Analyzer::<Image>::new();
 
     if let Some(ocr) = &spec.enrichers.ocr {
@@ -47,7 +47,12 @@ pub(super) fn compile(
         analyzer = attach_pattern(analyzer, pattern, guardrails)?;
     }
     analyzer = attach_ner_lineup(analyzer, ner, spec.recognizers.ner.as_ref())?;
-    analyzer = attach_llm_lineup(analyzer, llm, AttachTo::Image, spec.recognizers.llm.as_ref())?;
+    analyzer = attach_llm_lineup(
+        analyzer,
+        llm,
+        AttachTo::Image,
+        spec.recognizers.llm.as_ref(),
+    )?;
 
     Ok(attach_dedup(analyzer, &spec.deduplication))
 }

--- a/crates/nvisy-engine/src/analyzer/mod.rs
+++ b/crates/nvisy-engine/src/analyzer/mod.rs
@@ -49,7 +49,7 @@ use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_schema::plan::AnalyzerParams;
 
-pub(crate) use self::catalog::compile_catalog;
+pub(crate) use self::catalog::{GROUP_TAG_PREFIX, compile_catalog};
 pub use self::recognizer::PatternGuardrails;
 use crate::provider::llm::LlmConfig;
 use crate::provider::ner::NerConfig;

--- a/crates/nvisy-engine/src/analyzer/mod.rs
+++ b/crates/nvisy-engine/src/analyzer/mod.rs
@@ -39,7 +39,7 @@ mod tabular;
 mod text;
 
 use elide::detection::Analyzer;
-use elide_core::Error;
+use elide_core::Result;
 #[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
 #[cfg(feature = "internal_image")]
@@ -74,14 +74,14 @@ pub(crate) trait AnalyzerCompile {
         ner: &NerConfig,
         llm: &LlmConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Text>, Error>;
+    ) -> Result<Analyzer<Text>>;
     /// Build the tabular-modality analyzer.
     #[cfg(feature = "internal_tabular")]
     fn compile_tabular(
         &self,
         ner: &NerConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Tabular>, Error>;
+    ) -> Result<Analyzer<Tabular>>;
     /// Build the image-modality analyzer.
     #[cfg(feature = "internal_image")]
     fn compile_image(
@@ -89,14 +89,14 @@ pub(crate) trait AnalyzerCompile {
         ner: &NerConfig,
         llm: &LlmConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Image>, Error>;
+    ) -> Result<Analyzer<Image>>;
     /// Build the audio-modality analyzer.
     #[cfg(feature = "internal_audio")]
     fn compile_audio(
         &self,
         ner: &NerConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Audio>, Error>;
+    ) -> Result<Analyzer<Audio>>;
 }
 
 impl AnalyzerCompile for AnalyzerParams {
@@ -105,7 +105,7 @@ impl AnalyzerCompile for AnalyzerParams {
         ner: &NerConfig,
         llm: &LlmConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Text>, Error> {
+    ) -> Result<Analyzer<Text>> {
         self::text::compile(self, ner, llm, guardrails)
     }
 
@@ -114,7 +114,7 @@ impl AnalyzerCompile for AnalyzerParams {
         &self,
         ner: &NerConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Tabular>, Error> {
+    ) -> Result<Analyzer<Tabular>> {
         self::tabular::compile(self, ner, guardrails)
     }
 
@@ -124,7 +124,7 @@ impl AnalyzerCompile for AnalyzerParams {
         ner: &NerConfig,
         llm: &LlmConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Image>, Error> {
+    ) -> Result<Analyzer<Image>> {
         self::image::compile(self, ner, llm, guardrails)
     }
 
@@ -133,7 +133,7 @@ impl AnalyzerCompile for AnalyzerParams {
         &self,
         ner: &NerConfig,
         guardrails: &PatternGuardrails,
-    ) -> Result<Analyzer<Audio>, Error> {
+    ) -> Result<Analyzer<Audio>> {
         self::audio::compile(self, ner, guardrails)
     }
 }

--- a/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/llm.rs
@@ -15,7 +15,7 @@ use elide::recognition::llm::backend::{LlmBackend, LlmModality, RigBackend};
 use elide::recognition::llm::prompt::{DefaultPrompt, Jinja2Prompt, Prompt};
 use elide::recognition::llm::provider::Provider;
 use elide::recognition::llm::{LlmRecognizer, LlmRecognizerBuilder};
-use elide_core::{Error, ErrorKind};
+use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::plan::ProviderSelection;
 
 use super::selection::select;
@@ -49,7 +49,7 @@ pub(in crate::analyzer) fn attach_llm_lineup<M>(
     llm: &LlmConfig,
     modality: AttachTo,
     selection: Option<&ProviderSelection>,
-) -> Result<Analyzer<M>, Error>
+) -> Result<Analyzer<M>>
 where
     M: LlmModality,
     RigBackend: LlmBackend<M>,
@@ -88,7 +88,7 @@ where
     Ok(analyzer)
 }
 
-fn attach_one<M>(analyzer: Analyzer<M>, spec: &ConfigRecognizer) -> Result<Analyzer<M>, Error>
+fn attach_one<M>(analyzer: Analyzer<M>, spec: &ConfigRecognizer) -> Result<Analyzer<M>>
 where
     M: LlmModality,
     RigBackend: LlmBackend<M>,
@@ -110,7 +110,7 @@ where
 fn attach_source<M>(
     builder: LlmRecognizerBuilder<M>,
     spec: &ConfigRecognizer,
-) -> Result<LlmRecognizerBuilder<M>, Error>
+) -> Result<LlmRecognizerBuilder<M>>
 where
     M: LlmModality,
     RigBackend: LlmBackend<M>,

--- a/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/ner.rs
@@ -14,9 +14,9 @@
 use elide::detection::Analyzer;
 use elide::recognition::ner::NerRecognizer;
 use elide_bento::ner::BentoNer;
+use elide_core::Result;
 use elide_core::modality::TextRecognizable;
 use elide_core::recognition::Recognizer;
-use elide_core::Error;
 use nvisy_schema::plan::ProviderSelection;
 
 use super::selection::select;
@@ -37,7 +37,7 @@ pub(in crate::analyzer) fn attach_ner_lineup<M>(
     mut analyzer: Analyzer<M>,
     ner: &NerConfig,
     selection: Option<&ProviderSelection>,
-) -> Result<Analyzer<M>, Error>
+) -> Result<Analyzer<M>>
 where
     M: TextRecognizable,
     NerRecognizer: Recognizer<M> + 'static,
@@ -49,10 +49,7 @@ where
     Ok(analyzer)
 }
 
-fn attach_ner_one<M>(
-    analyzer: Analyzer<M>,
-    spec: &ConfigNerRecognizer,
-) -> Result<Analyzer<M>, Error>
+fn attach_ner_one<M>(analyzer: Analyzer<M>, spec: &ConfigNerRecognizer) -> Result<Analyzer<M>>
 where
     M: TextRecognizable,
     NerRecognizer: Recognizer<M> + 'static,

--- a/crates/nvisy-engine/src/analyzer/recognizer/pattern.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/pattern.rs
@@ -31,7 +31,7 @@ use elide::recognition::pattern::{
 use elide_core::modality::TextRecognizable;
 use elide_core::primitive::LanguageTag;
 use elide_core::recognition::Recognizer;
-use elide_core::{Error, ErrorKind};
+use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::plan::{
     CustomDictionary, CustomDictionaryTerm, CustomPatternContext, CustomPatternRule,
     CustomPatternVariant, PatternRecognizerParams,
@@ -52,7 +52,7 @@ pub(in crate::analyzer) fn attach<M>(
     analyzer: Analyzer<M>,
     spec: &PatternRecognizerParams,
     guardrails: &PatternGuardrails,
-) -> Result<Analyzer<M>, Error>
+) -> Result<Analyzer<M>>
 where
     M: TextRecognizable,
     PatternRecognizer: Recognizer<M> + 'static,
@@ -101,7 +101,7 @@ fn with_limits(
 fn check_custom_count(
     spec: &PatternRecognizerParams,
     guardrails: &PatternGuardrails,
-) -> Result<(), Error> {
+) -> Result<()> {
     let total = spec.custom.len() + spec.custom_dictionaries.len();
     if total > guardrails.max_custom_rules {
         return Err(Error::new(
@@ -120,10 +120,7 @@ fn check_custom_count(
     Ok(())
 }
 
-fn compile_custom_rule(
-    rule: &CustomPatternRule,
-    guardrails: &PatternGuardrails,
-) -> Result<Regex, Error> {
+fn compile_custom_rule(rule: &CustomPatternRule, guardrails: &PatternGuardrails) -> Result<Regex> {
     let variants = rule
         .variants
         .iter()
@@ -142,7 +139,7 @@ fn compile_custom_rule(
 fn compile_custom_variant(
     variant: &CustomPatternVariant,
     guardrails: &PatternGuardrails,
-) -> Result<Variant, Error> {
+) -> Result<Variant> {
     if variant.regex.len() > guardrails.max_regex_source_len {
         return Err(Error::new(
             ErrorKind::Configuration,
@@ -161,7 +158,7 @@ fn compile_custom_variant(
     Ok(out)
 }
 
-fn compile_custom_dictionary(dict: &CustomDictionary) -> Result<Dictionary, Error> {
+fn compile_custom_dictionary(dict: &CustomDictionary) -> Result<Dictionary> {
     let terms = dict
         .terms
         .iter()

--- a/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/selection.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashSet;
 
-use elide_core::{Error, ErrorKind};
+use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::plan::ProviderSelection;
 
 use crate::provider::{LlmRecognizer, NerRecognizer};
@@ -42,7 +42,7 @@ pub(super) fn select<'a, T: Named>(
     selection: Option<&ProviderSelection>,
     lineup: &'a [T],
     field: &'static str,
-) -> Result<Vec<&'a T>, Error> {
+) -> Result<Vec<&'a T>> {
     match selection {
         None => Ok(lineup.iter().collect()),
         Some(ProviderSelection::All(false)) => Ok(Vec::new()),
@@ -60,7 +60,7 @@ fn select_allowlisted<'a, T: Named>(
     lineup: &'a [T],
     names: &[String],
     field: &'static str,
-) -> Result<Vec<&'a T>, Error> {
+) -> Result<Vec<&'a T>> {
     if names.is_empty() {
         return Err(empty_allowlist(field));
     }

--- a/crates/nvisy-engine/src/analyzer/tabular.rs
+++ b/crates/nvisy-engine/src/analyzer/tabular.rs
@@ -15,7 +15,7 @@
 //! [`AnalyzerParams`]: nvisy_schema::plan::AnalyzerParams
 
 use elide::detection::Analyzer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::tabular::Tabular;
 use nvisy_schema::plan::AnalyzerParams;
 
@@ -29,7 +29,7 @@ pub(super) fn compile(
     spec: &AnalyzerParams,
     ner: &NerConfig,
     guardrails: &PatternGuardrails,
-) -> Result<Analyzer<Tabular>, Error> {
+) -> Result<Analyzer<Tabular>> {
     let mut analyzer = Analyzer::<Tabular>::new();
 
     if let Some(pattern) = &spec.recognizers.pattern {

--- a/crates/nvisy-engine/src/analyzer/text.rs
+++ b/crates/nvisy-engine/src/analyzer/text.rs
@@ -18,7 +18,7 @@
 //! [`LlmConfig`]: crate::provider::llm::LlmConfig
 
 use elide::detection::Analyzer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::text::Text;
 use nvisy_schema::plan::AnalyzerParams;
 
@@ -36,7 +36,7 @@ pub(super) fn compile(
     ner: &NerConfig,
     llm: &LlmConfig,
     guardrails: &PatternGuardrails,
-) -> Result<Analyzer<Text>, Error> {
+) -> Result<Analyzer<Text>> {
     let mut analyzer = Analyzer::<Text>::new();
 
     if let Some(language) = &spec.enrichers.language {

--- a/crates/nvisy-engine/src/anonymizer/audio.rs
+++ b/crates/nvisy-engine/src/anonymizer/audio.rs
@@ -2,7 +2,7 @@
 //! [`Anonymizer<Audio>`].
 
 use elide::redaction::Anonymizer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::audio::Audio;
 use nvisy_schema::policy::PolicyDefinition;
 use nvisy_schema::policy::redaction::ModalityRedactions;
@@ -21,7 +21,7 @@ use super::operator::audio::AudioOp;
 pub(crate) fn attach_policies_audio<'a>(
     anonymizer: Anonymizer<Audio>,
     policies: impl Iterator<Item = &'a PolicyDefinition>,
-) -> Result<Anonymizer<Audio>, Error> {
+) -> Result<Anonymizer<Audio>> {
     attach_policies(anonymizer, policies, compile_one)
 }
 
@@ -31,14 +31,14 @@ pub(crate) fn attach_override_audio(
     anonymizer: Anonymizer<Audio>,
     entity_id: Uuid,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Audio>, Error> {
+) -> Result<Anonymizer<Audio>> {
     attach_one_override(anonymizer, entity_id, redactions, compile_one)
 }
 
 fn compile_one(
     target: Target<'_, Audio>,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Audio>, Error> {
+) -> Result<Anonymizer<Audio>> {
     let Some(spec) = &redactions.audio else {
         return Ok(target.passthrough());
     };

--- a/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
@@ -19,7 +19,7 @@
 //! [`with_fallback`]: elide::redaction::Anonymizer::with_fallback
 
 use elide::redaction::Anonymizer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::entity::provenance::Attribution;
 use elide_core::modality::Modality;
 use elide_core::operator::Operator;
@@ -108,10 +108,10 @@ pub(in crate::anonymizer) fn attach_policies<'a, M, F>(
     mut anonymizer: Anonymizer<M>,
     policies: impl Iterator<Item = &'a PolicyDefinition>,
     mut compile_one: F,
-) -> Result<Anonymizer<M>, Error>
+) -> Result<Anonymizer<M>>
 where
     M: Modality + 'static,
-    F: FnMut(Target<'_, M>, &ModalityRedactions) -> Result<Anonymizer<M>, Error>,
+    F: FnMut(Target<'_, M>, &ModalityRedactions) -> Result<Anonymizer<M>>,
 {
     for policy in policies {
         for rule in &policy.rules {
@@ -145,10 +145,10 @@ pub(in crate::anonymizer) fn attach_one_override<M, F>(
     entity_id: Uuid,
     redactions: &ModalityRedactions,
     compile_one: F,
-) -> Result<Anonymizer<M>, Error>
+) -> Result<Anonymizer<M>>
 where
     M: Modality + 'static,
-    F: FnOnce(Target<'_, M>, &ModalityRedactions) -> Result<Anonymizer<M>, Error>,
+    F: FnOnce(Target<'_, M>, &ModalityRedactions) -> Result<Anonymizer<M>>,
 {
     compile_one(
         Target::Override {

--- a/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
@@ -7,7 +7,7 @@
 //!   whose redaction spec carries this modality compiles its
 //!   operator and attaches it (rule predicate + attribution).
 //! - Then a policy `fallback` with this modality's arm set
-//!   becomes the anonymizer's [`with_fallback`].
+//!   attaches as a [`Rule::fallback`] on the anonymizer.
 //!
 //! The per-modality differences are exactly two: which
 //! `redactions.{modality}` field to read, and how to build (then
@@ -16,7 +16,7 @@
 //! every per-modality file stays under ~50 lines — just the
 //! `Op` enum + `build` + an `attach_to` dispatcher.
 //!
-//! [`with_fallback`]: elide::redaction::Anonymizer::with_fallback
+//! [`Rule::fallback`]: elide::redaction::Rule::fallback
 
 use elide::redaction::{Anonymizer, Rule};
 use elide_core::Result;
@@ -42,8 +42,10 @@ pub(in crate::anonymizer) enum Target<'a, M: Modality> {
         predicate: &'a Predicate,
         attribution: Attribution,
     },
-    /// PolicyDefinition `fallback`: catch-all redaction with `reason: None`.
-    /// Maps to [`Anonymizer::with_fallback`] + `because`.
+    /// PolicyDefinition `fallback`: catch-all redaction attached
+    /// via [`Rule::fallback`] with a `because(fallback_attribution)`.
+    ///
+    /// [`Rule::fallback`]: elide::redaction::Rule::fallback
     Fallback {
         anonymizer: Anonymizer<M>,
         attribution: Attribution,

--- a/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
@@ -18,7 +18,7 @@
 //!
 //! [`with_fallback`]: elide::redaction::Anonymizer::with_fallback
 
-use elide::redaction::Anonymizer;
+use elide::redaction::{Anonymizer, Rule};
 use elide_core::Result;
 use elide_core::entity::provenance::Attribution;
 use elide_core::modality::Modality;
@@ -35,7 +35,7 @@ use super::selector::{attach, attach_override, fallback_attribution, rule_attrib
 /// `Anonymizer<M>` through the right elide entry point.
 pub(in crate::anonymizer) enum Target<'a, M: Modality> {
     /// Rule attachment: predicate-guarded redaction with a
-    /// `policy_id` + `reason` attribution. Maps to
+    /// name + description attribution. Maps to
     /// [`super::selector::attach`].
     Rule {
         anonymizer: Anonymizer<M>,
@@ -64,7 +64,7 @@ impl<'a, M: Modality + 'static> Target<'a, M> {
     /// dispatchers per modality.
     pub(in crate::anonymizer) fn attach_with<O>(self, operator: O) -> Anonymizer<M>
     where
-        O: Operator<M> + Clone + 'static,
+        O: Operator<M> + 'static,
     {
         match self {
             Target::Rule {
@@ -75,7 +75,7 @@ impl<'a, M: Modality + 'static> Target<'a, M> {
             Target::Fallback {
                 anonymizer,
                 attribution,
-            } => anonymizer.with_fallback(operator).because(attribution),
+            } => anonymizer.with(Rule::fallback(operator).because(attribution)),
             Target::Override {
                 anonymizer,
                 entity_id,
@@ -115,14 +115,17 @@ where
 {
     for policy in policies {
         for rule in &policy.rules {
-            anonymizer = compile_one(
-                Target::Rule {
-                    anonymizer,
-                    predicate: &rule.predicate,
-                    attribution: rule_attribution(policy, rule),
-                },
-                &rule.action,
-            )?;
+            let attribution = rule_attribution(policy, rule);
+            for (predicate, action) in rule.attachments() {
+                anonymizer = compile_one(
+                    Target::Rule {
+                        anonymizer,
+                        predicate: &predicate,
+                        attribution: attribution.clone(),
+                    },
+                    action,
+                )?;
+            }
         }
         if let Some(redactions) = &policy.fallback {
             anonymizer = compile_one(

--- a/crates/nvisy-engine/src/anonymizer/compile/selector.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/selector.rs
@@ -2,30 +2,33 @@
 //! stamping the engine-internal attribution from policy + rule
 //! UUIDs.
 //!
-//! The wire now carries one composable [`Predicate`] per rule.
+//! The wire carries one composable [`Predicate`] per rule.
 //! [`attach`] pattern-matches that predicate against three
 //! degenerate shapes to keep elide's fast paths:
 //!
 //! - [`Predicate::LabelOneOf`] with a single label →
-//!   [`Anonymizer::with_label`] (audit records the matched
-//!   label).
+//!   [`Rule::label`] (audit records the matched label).
 //! - [`Predicate::TagOneOf`] with a single tag →
-//!   [`Anonymizer::with_tag`] (audit records the matched tag).
-//! - Anything else → [`Anonymizer::with_catalog_predicate`]
-//!   (audit records `Predicate`).
+//!   [`Rule::tag`] (audit records the matched tag).
+//! - Anything else → [`Rule::predicate`] with a closure over the
+//!   full [`MatchContext`] (audit records `Predicate`).
+//!
+//! [`Rule::label`]: elide::redaction::Rule::label
+//! [`Rule::tag`]: elide::redaction::Rule::tag
+//! [`Rule::predicate`]: elide::redaction::Rule::predicate
+//! [`MatchContext`]: elide::redaction::MatchContext
 //!
 //! Attribution always sits in elide's [`Attribution`] slot:
-//! `policy_id` from the policy's UUID, `reason` from the rule's
-//! UUID (or `None` for the policy fallback).
+//! `name` from the policy's UUID, `description` from the rule's
+//! UUID (or omitted for the policy fallback).
 //!
 //! [`Anonymizer`]: elide::redaction::Anonymizer
 //! [`PolicyRule`]: nvisy_schema::policy::PolicyRule
 //! [`Predicate`]: nvisy_schema::policy::predicate::Predicate
 //! [`Attribution`]: elide_core::entity::provenance::Attribution
 
-use elide::redaction::Anonymizer;
+use elide::redaction::{Anonymizer, MatchContext, Rule};
 use elide_core::entity::provenance::Attribution;
-use elide_core::entity::{Entity, LabelCatalog};
 use elide_core::modality::Modality;
 use elide_core::operator::Operator;
 use nvisy_schema::policy::predicate::Predicate;
@@ -33,30 +36,30 @@ use nvisy_schema::policy::{PolicyDefinition, PolicyRule};
 use uuid::Uuid;
 
 /// Build an [`Attribution`] for a concrete rule that fired.
+///
+/// `name` carries the policy's stable UUID (elide's
+/// [`Attribution::name`] is the "policy authority" slot) and
+/// `description` carries the rule's UUID so an audit can trace a
+/// redaction back to the exact rule inside the policy.
 pub(super) fn rule_attribution(policy: &PolicyDefinition, rule: &PolicyRule) -> Attribution {
-    Attribution {
-        policy_id: policy.id.to_string().into(),
-        reason: Some(rule.id.to_string().into()),
-    }
+    Attribution::new(policy.id.to_string()).with_description(rule.id().to_string())
 }
 
 /// Build an [`Attribution`] for a policy's `fallback`.
+///
+/// No `description` — the fallback is the policy's catch-all,
+/// there is no per-rule id to record.
 pub(super) fn fallback_attribution(policy: &PolicyDefinition) -> Attribution {
-    Attribution {
-        policy_id: policy.id.to_string().into(),
-        reason: None,
-    }
+    Attribution::new(policy.id.to_string())
 }
 
-/// Build an [`Attribution`] for a reviewer override. Uses the
-/// sentinel `policy_id = "override"` so audits can distinguish
-/// override-driven redactions from policy-driven ones; `reason`
-/// carries the overridden entity's id.
+/// Build an [`Attribution`] for a reviewer override.
+///
+/// Uses the sentinel `name = "override"` so audits can
+/// distinguish override-driven redactions from policy-driven
+/// ones; `description` carries the overridden entity's id.
 pub(super) fn override_attribution(entity_id: Uuid) -> Attribution {
-    Attribution {
-        policy_id: "override".into(),
-        reason: Some(entity_id.to_string().into()),
-    }
+    Attribution::new("override").with_description(entity_id.to_string())
 }
 
 /// Attach an `operator` to `anonymizer` for the single entity
@@ -72,20 +75,23 @@ where
     M: Modality,
     O: Operator<M> + 'static,
 {
-    let attribution = override_attribution(entity_id);
-    anonymizer
-        .with_predicate(move |entity: &Entity<M>| entity.id == entity_id, operator)
-        .because(attribution)
+    anonymizer.with(
+        Rule::predicate(
+            move |cx: &MatchContext<'_, M>| cx.entity.id == entity_id,
+            operator,
+        )
+        .because(override_attribution(entity_id)),
+    )
 }
 
 /// Attach `operator` to `anonymizer` for the rule's
 /// [`Predicate`], stamping `attribution` so every redaction it
-/// drives carries `policy_id` + `reason` on its provenance event.
+/// drives carries the policy's identity on its provenance event.
 ///
 /// Pattern-matches the predicate against degenerate single-label
 /// / single-tag shapes to keep elide's indexed fast paths. Any
-/// composite predicate falls through to
-/// [`Anonymizer::with_catalog_predicate`].
+/// composite predicate falls through to [`Rule::predicate`] with
+/// a closure over the full [`MatchContext`].
 pub(super) fn attach<M, O>(
     anonymizer: Anonymizer<M>,
     predicate: &Predicate,
@@ -94,52 +100,53 @@ pub(super) fn attach<M, O>(
 ) -> Anonymizer<M>
 where
     M: Modality,
-    O: Operator<M> + Clone + 'static,
+    O: Operator<M> + 'static,
 {
-    let anonymizer = match predicate {
+    let rule = match predicate {
         Predicate::LabelOneOf { labels } if labels.len() == 1 => {
-            anonymizer.with_label(labels[0].clone(), operator)
+            Rule::label(labels[0].clone(), operator)
         }
         Predicate::TagOneOf { tags } if tags.len() == 1 => {
-            anonymizer.with_tag(tags[0].clone(), operator)
+            Rule::tag(tags[0].clone(), operator)
         }
-        other => anonymizer.with_catalog_predicate(compile_predicate::<M>(other.clone()), operator),
+        other => Rule::predicate(compile_predicate::<M>(other.clone()), operator),
     };
-    anonymizer.because(attribution)
+    anonymizer.with(rule.because(attribution))
 }
 
 /// Compile a [`Predicate`] tree into a closure consumed by
-/// [`Anonymizer::with_catalog_predicate`]. The closure receives
-/// the per-anonymizer [`LabelCatalog`] alongside the entity so
-/// [`Predicate::TagOneOf`] resolves correctly even inside
-/// composites ([`All`] / [`Any`] / [`Not`]).
+/// [`Rule::predicate`]. The closure receives the full
+/// [`MatchContext`], so [`Predicate::TagOneOf`] resolves against
+/// the per-anonymizer [`LabelCatalog`] even inside composites
+/// ([`All`] / [`Any`] / [`Not`]).
 ///
-/// [`Anonymizer::with_catalog_predicate`]: elide::redaction::Anonymizer::with_catalog_predicate
 /// [`All`]: Predicate::All
 /// [`Any`]: Predicate::Any
 /// [`Not`]: Predicate::Not
 pub(super) fn compile_predicate<M>(
     predicate: Predicate,
-) -> impl Fn(&Entity<M>, &LabelCatalog) -> bool + Send + Sync + 'static
+) -> impl Fn(&MatchContext<'_, M>) -> bool + Send + Sync + 'static
 where
     M: Modality,
 {
-    move |entity, catalog| eval(&predicate, entity, catalog)
+    move |cx| eval(&predicate, cx)
 }
 
-fn eval<M: Modality>(predicate: &Predicate, entity: &Entity<M>, catalog: &LabelCatalog) -> bool {
+fn eval<M: Modality>(predicate: &Predicate, cx: &MatchContext<'_, M>) -> bool {
     match predicate {
-        Predicate::Confidence { min } => f32::from(entity.confidence) >= f32::from(*min),
-        Predicate::LabelOneOf { labels } => labels.iter().any(|l| l == &entity.label),
-        Predicate::TagOneOf { tags } => catalog
-            .get(&entity.label)
+        Predicate::Confidence { min } => f32::from(cx.entity.confidence) >= f32::from(*min),
+        Predicate::LabelOneOf { labels } => labels.iter().any(|l| l == &cx.entity.label),
+        Predicate::TagOneOf { tags } => cx
+            .catalog
+            .get(&cx.entity.label)
             .is_some_and(|label| tags.iter().any(|tag| label.has_tag(tag.as_str()))),
-        Predicate::CoRef { coref } => entity
+        Predicate::CoRef { coref } => cx
+            .entity
             .coref
             .as_ref()
             .is_some_and(|c| c.as_str() == coref.as_str()),
-        Predicate::All { all } => all.iter().all(|p| eval(p, entity, catalog)),
-        Predicate::Any { any } => any.iter().any(|p| eval(p, entity, catalog)),
-        Predicate::Not { not } => !eval(not, entity, catalog),
+        Predicate::All { all } => all.iter().all(|p| eval(p, cx)),
+        Predicate::Any { any } => any.iter().any(|p| eval(p, cx)),
+        Predicate::Not { not } => !eval(not, cx),
     }
 }

--- a/crates/nvisy-engine/src/anonymizer/compile/selector.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/selector.rs
@@ -130,9 +130,7 @@ where
 fn eval<M: Modality>(predicate: &Predicate, entity: &Entity<M>, catalog: &LabelCatalog) -> bool {
     match predicate {
         Predicate::Confidence { min } => f32::from(entity.confidence) >= f32::from(*min),
-        Predicate::LabelOneOf { labels } => labels
-            .iter()
-            .any(|l| l == &entity.label),
+        Predicate::LabelOneOf { labels } => labels.iter().any(|l| l == &entity.label),
         Predicate::TagOneOf { tags } => catalog
             .get(&entity.label)
             .is_some_and(|label| tags.iter().any(|tag| label.has_tag(tag.as_str()))),

--- a/crates/nvisy-engine/src/anonymizer/compile/selector.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/selector.rs
@@ -35,6 +35,8 @@ use nvisy_schema::policy::predicate::Predicate;
 use nvisy_schema::policy::{PolicyDefinition, PolicyRule};
 use uuid::Uuid;
 
+use crate::analyzer::GROUP_TAG_PREFIX;
+
 /// Build an [`Attribution`] for a concrete rule that fired.
 ///
 /// `name` carries the policy's stable UUID (elide's
@@ -109,6 +111,13 @@ where
         Predicate::TagOneOf { tags } if tags.len() == 1 => {
             Rule::tag(tags[0].clone(), operator)
         }
+        Predicate::LabelInGroup { group } => {
+            // Groups compile to a synthetic `group:<name>` tag on
+            // every listed label (see `analyzer::catalog`), so a
+            // group predicate takes the same fast path as any
+            // single-tag `TagOneOf`.
+            Rule::tag(format!("{GROUP_TAG_PREFIX}{group}"), operator)
+        }
         other => Rule::predicate(compile_predicate::<M>(other.clone()), operator),
     };
     anonymizer.with(rule.because(attribution))
@@ -140,6 +149,12 @@ fn eval<M: Modality>(predicate: &Predicate, cx: &MatchContext<'_, M>) -> bool {
             .catalog
             .get(&cx.entity.label)
             .is_some_and(|label| tags.iter().any(|tag| label.has_tag(tag.as_str()))),
+        Predicate::LabelInGroup { group } => {
+            let synthetic_tag = format!("{GROUP_TAG_PREFIX}{group}");
+            cx.catalog
+                .get(&cx.entity.label)
+                .is_some_and(|label| label.has_tag(&synthetic_tag))
+        }
         Predicate::CoRef { coref } => cx
             .entity
             .coref

--- a/crates/nvisy-engine/src/anonymizer/image.rs
+++ b/crates/nvisy-engine/src/anonymizer/image.rs
@@ -2,7 +2,7 @@
 //! [`Anonymizer<Image>`].
 
 use elide::redaction::Anonymizer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::image::Image;
 use nvisy_schema::policy::PolicyDefinition;
 use nvisy_schema::policy::redaction::ModalityRedactions;
@@ -21,7 +21,7 @@ use super::operator::image::ImageOp;
 pub(crate) fn attach_policies_image<'a>(
     anonymizer: Anonymizer<Image>,
     policies: impl Iterator<Item = &'a PolicyDefinition>,
-) -> Result<Anonymizer<Image>, Error> {
+) -> Result<Anonymizer<Image>> {
     attach_policies(anonymizer, policies, compile_one)
 }
 
@@ -31,14 +31,14 @@ pub(crate) fn attach_override_image(
     anonymizer: Anonymizer<Image>,
     entity_id: Uuid,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Image>, Error> {
+) -> Result<Anonymizer<Image>> {
     attach_one_override(anonymizer, entity_id, redactions, compile_one)
 }
 
 fn compile_one(
     target: Target<'_, Image>,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Image>, Error> {
+) -> Result<Anonymizer<Image>> {
     let Some(spec) = &redactions.image else {
         return Ok(target.passthrough());
     };

--- a/crates/nvisy-engine/src/anonymizer/mod.rs
+++ b/crates/nvisy-engine/src/anonymizer/mod.rs
@@ -48,6 +48,7 @@ mod text;
 pub(crate) use self::audio::{attach_override_audio, attach_policies_audio};
 #[cfg(feature = "internal_image")]
 pub(crate) use self::image::{attach_override_image, attach_policies_image};
+pub(crate) use self::operator::text::TextOperatorContext;
 #[cfg(feature = "internal_tabular")]
 pub(crate) use self::tabular::{attach_override_tabular, attach_policies_tabular};
 pub(crate) use self::text::{attach_override_text, attach_policies_text};

--- a/crates/nvisy-engine/src/anonymizer/operator/mod.rs
+++ b/crates/nvisy-engine/src/anonymizer/operator/mod.rs
@@ -1,16 +1,16 @@
 //! Per-modality operator vocabularies.
 //!
-//! Each submodule owns the `Op` enum plus a wire → runtime
-//! conversion — `From<&{Image,Audio}Redaction>` (infallible) or
-//! `TryFrom<&TextRedaction>` (fallible; text has stateful
-//! operators that aren't wired yet). Per-modality entry files in
-//! [`super`] dispatch a converted `Op` onto a
-//! [`super::compile::Target`] via `Op::attach_to`.
+//! [`text`] owns the text-and-tabular wire → runtime bridge: one
+//! [`compile_and_attach`] function that matches a
+//! [`TextRedaction`] and calls [`Target::attach_with`] with the
+//! concrete elide operator. Image and audio each own their own
+//! `Op` enum + `attach_to` dispatcher; those two vocabularies
+//! don't overlap with text.
 //!
-//! Text and tabular share the text vocabulary — cells in a
-//! tabular are `TextBacked` in elide, so every text operator
-//! also implements `Operator<Tabular>`. Image and audio each own
-//! their vocabulary; the operators don't cross modalities.
+//! [`text`]: self::text
+//! [`compile_and_attach`]: self::text::compile_and_attach
+//! [`Target::attach_with`]: super::compile::Target::attach_with
+//! [`TextRedaction`]: nvisy_schema::policy::redaction::TextRedaction
 
 #[cfg(feature = "internal_audio")]
 pub(super) mod audio;

--- a/crates/nvisy-engine/src/anonymizer/operator/text.rs
+++ b/crates/nvisy-engine/src/anonymizer/operator/text.rs
@@ -2,19 +2,258 @@
 //!
 //! Cells in a tabular are `TextBacked` in elide, so the same
 //! concrete operators (`Erase`, `Keep`, `Mask`, `Replace`,
-//! `Sha2Hash`) implement `Operator<Text>` *and*
-//! `Operator<Tabular>`. This module owns the `TextRedaction ->
-//! elide operator` bridge once; each per-modality file dispatches
-//! its variant onto a [`Target`] with the built operator.
+//! `Sha2Hash`, `HmacHash`, `Truncate`, `Clamp`, `GeneralizeDate`,
+//! `Fake`, `Pseudonymize`, `AesEncrypt`) implement `Operator<Text>`
+//! *and* `Operator<Tabular>`. This module owns the `TextRedaction
+//! -> elide operator` bridge once; per-modality entry files feed
+//! their [`Target`] here.
+//!
+//! Every arm returns an `Arc<dyn Operator<M> + Send + Sync +
+//! 'static>` — [`Arc`] so it stays [`Clone`] (elide's
+//! `Anonymizer::with_label` requires `O: Operator<M> + Clone`).
+//! Elide ships a blanket `impl<M, T: Operator<M> + ?Sized>
+//! Operator<M> for Arc<T>` (elide #160), so the shared handle is
+//! itself an operator and drops straight into `with_label`. That
+//! turns the wire → runtime bridge into a `match` returning one
+//! type — no per-variant enum, no fan-out of concrete
+//! `WithFallback<primary, fallback>` combinations at the source
+//! level.
+
+use std::sync::Arc;
 
 use elide::redaction::Anonymizer;
-use elide::redaction::operators::{Erase, Fake, Keep, Mask, Replace, Sha2Algorithm, Sha2Hash};
+use elide::redaction::generator::RandomToken;
+use elide::redaction::operators::{
+    AesEncrypt, Clamp, Erase, Fake, GeneralizeDate, HmacHash, Keep, KeyProvider, Mask,
+    Pseudonymize, Replace, Sha2Algorithm, Sha2Hash, Truncate, TryOperator, WithFallback,
+};
+use elide::redaction::vault::InMemoryVault;
+use elide_core::entity::LabelRef;
 use elide_core::modality::Modality;
+use elide_core::modality::text::TextReplacement;
 use elide_core::operator::Operator;
-use elide_core::{Error, ErrorKind};
-use nvisy_schema::policy::redaction::{HashAlgorithm, TextRedaction};
+use elide_core::{Error, ErrorKind, Result};
+use nvisy_schema::policy::redaction::{
+    ClampBucket, HashAlgorithm, TerminalFallback, TextRedaction,
+};
 
 use crate::anonymizer::compile::Target;
+
+/// Engine-side context the text operator compiler reads at
+/// build time: which stateful operators have infrastructure
+/// wired.
+///
+/// The pseudonym vault is [`InMemoryVault`] rather than a boxed
+/// trait object because [`Vault`] is generic (returns
+/// `impl Future`) and its method signatures aren't object-safe.
+/// Cross-request pseudonym consistency needs a durable backend
+/// — see elide #143 — and will require different plumbing (per-
+/// vault-id registry, likely) when that lands.
+///
+/// [`Vault`]: elide::redaction::vault::Vault
+#[derive(Clone)]
+pub(crate) struct TextOperatorContext {
+    /// Optional key provider for `HmacHash` and `Encrypt`. When
+    /// absent, those variants fail to compile with a clear
+    /// error — a policy that names them cannot run without one.
+    pub(crate) key_provider: Option<Arc<dyn KeyProvider>>,
+    /// Per-request pseudonym vault. A `Pseudonymize` variant
+    /// resolves through this vault; every mention of the same
+    /// entity resolves to the same surrogate within the request.
+    /// Cloning shares the underlying map (internal
+    /// `Arc<Mutex<...>>`).
+    pub(crate) pseudonym_vault: InMemoryVault<(LabelRef, String), TextReplacement>,
+}
+
+/// Type-erased shared handle to a modality-`M` operator.
+///
+/// `Arc<dyn Operator<M>>` — [`Arc`] rather than [`Box`] because
+/// elide's [`Anonymizer::with_label`] requires `O: Operator<M>
+/// + Clone`, and only `Arc` (not `Box`) makes a trait object
+/// cloneable. Elide's blanket forward `impl<M, T: Operator<M>
+/// + ?Sized> Operator<M> for Arc<T>` (elide #160) makes the
+/// shared handle itself an operator, so it drops directly into
+/// every elide entry point that accepts an `impl Operator<M>
+/// + Clone + 'static` — no unwrap, no dispatcher.
+///
+/// [`Anonymizer::with_label`]: elide::redaction::Anonymizer::with_label
+pub(in crate::anonymizer) type SharedTextOp<M> = Arc<dyn Operator<M> + Send + Sync + 'static>;
+
+/// Compile `spec` into a boxed operator and attach it to `target`.
+///
+/// Thin wrapper over [`build`] that immediately hands the built
+/// operator to [`Target::attach_with`]. Split so callers that
+/// want the operator without attaching (future test hooks, etc.)
+/// can reach for `build` directly.
+pub(in crate::anonymizer) fn compile_and_attach<M>(
+    spec: &TextRedaction,
+    ctx: &TextOperatorContext,
+    target: Target<'_, M>,
+) -> Result<Anonymizer<M>>
+where
+    M: Modality + Send + Sync + 'static,
+    Erase: Operator<M>,
+    Keep: Operator<M>,
+    Mask: Operator<M> + Clone,
+    Replace: Operator<M> + Clone,
+    Sha2Hash: Operator<M> + Clone,
+    HmacHash: Operator<M> + Clone,
+    Truncate: Operator<M> + Clone,
+    Clamp: TryOperator<M> + Clone,
+    GeneralizeDate: TryOperator<M> + Clone,
+    Fake<Replace>: Operator<M> + Clone,
+    Pseudonymize<InMemoryVault<(LabelRef, String), TextReplacement>, RandomToken>:
+        Operator<M> + Clone,
+    AesEncrypt: Operator<M> + Clone,
+{
+    Ok(target.attach_with(build(spec, ctx)?))
+}
+
+/// Build the concrete elide operator for `spec` and box it.
+///
+/// One match arm per wire variant. Each arm constructs the
+/// concrete elide operator (or the concrete
+/// `WithFallback<primary, fallback>` for a declinable primary
+/// with an explicit fallback) and returns it boxed. Consumers
+/// treat the result as an opaque `impl Operator<M>`; the
+/// concrete type lives only on the stack for the duration of the
+/// arm's `Arc::new`.
+///
+/// The where clause names every concrete elide operator this
+/// function might construct. Rust trait aliases don't propagate
+/// where-clauses to callers (RFC 1733 is unstable), so the list
+/// lives inline on each function that needs it rather than
+/// behind a supertrait. Text and tabular both satisfy it.
+pub(in crate::anonymizer) fn build<M>(
+    spec: &TextRedaction,
+    ctx: &TextOperatorContext,
+) -> Result<SharedTextOp<M>>
+where
+    M: Modality + Send + Sync + 'static,
+    Erase: Operator<M>,
+    Keep: Operator<M>,
+    Mask: Operator<M> + Clone,
+    Replace: Operator<M> + Clone,
+    Sha2Hash: Operator<M> + Clone,
+    HmacHash: Operator<M> + Clone,
+    Truncate: Operator<M> + Clone,
+    Clamp: TryOperator<M> + Clone,
+    GeneralizeDate: TryOperator<M> + Clone,
+    Fake<Replace>: Operator<M> + Clone,
+    Pseudonymize<InMemoryVault<(LabelRef, String), TextReplacement>, RandomToken>:
+        Operator<M> + Clone,
+    AesEncrypt: Operator<M> + Clone,
+{
+    Ok(match spec {
+        TextRedaction::Erase => Arc::new(Erase),
+        TextRedaction::Keep => Arc::new(Keep),
+        TextRedaction::Mask {
+            mask_char,
+            keep_prefix,
+            keep_suffix,
+        } => Arc::new(build_mask(*mask_char, *keep_prefix, *keep_suffix)),
+        TextRedaction::Replace { template } => Arc::new(Replace::new(template.clone())),
+        TextRedaction::Hash { algorithm, salt } => {
+            let mut op = Sha2Hash::new(to_sha2(*algorithm));
+            if let Some(s) = salt {
+                op = op.with_salt(s.as_bytes().to_vec());
+            }
+            Arc::new(op)
+        }
+        TextRedaction::HmacHash { algorithm } => {
+            let keys = ctx
+                .key_provider
+                .clone()
+                .ok_or_else(|| missing_infrastructure("hmac_hash", "KeyProvider"))?;
+            Arc::new(HmacHash::new(to_sha2(*algorithm), keys))
+        }
+        TextRedaction::Truncate {
+            keep_prefix,
+            keep_suffix,
+        } => Arc::new(Truncate::new(*keep_prefix, *keep_suffix)),
+        TextRedaction::Clamp {
+            ceiling,
+            ceiling_bucket,
+            floor,
+            floor_bucket,
+            fallback,
+        } => {
+            let clamp = build_clamp(
+                *ceiling,
+                ceiling_bucket.as_ref(),
+                *floor,
+                floor_bucket.as_ref(),
+            )?;
+            box_with_optional_fallback(clamp, fallback.as_ref())
+        }
+        TextRedaction::GeneralizeDate {
+            granularity,
+            style,
+            fallback,
+        } => {
+            let generalize = GeneralizeDate::new(*granularity).with_style(*style);
+            box_with_optional_fallback(generalize, fallback.as_ref())
+        }
+        TextRedaction::Fake {
+            default_language,
+            seed,
+            fallback_template,
+        } => {
+            let mut op = Fake::new(Replace::new(fallback_template.clone()));
+            if let Some(lang) = default_language {
+                op = op.with_default_language(lang.clone());
+            }
+            if let Some(s) = seed {
+                op = op.with_seed(*s);
+            }
+            Arc::new(op)
+        }
+        TextRedaction::Pseudonymize => {
+            Arc::new(Pseudonymize::new(ctx.pseudonym_vault.clone(), RandomToken))
+        }
+        TextRedaction::Encrypt => {
+            let keys = ctx
+                .key_provider
+                .clone()
+                .ok_or_else(|| missing_infrastructure("encrypt", "KeyProvider"))?;
+            Arc::new(AesEncrypt::new(keys))
+        }
+    })
+}
+
+/// Box `primary` bare, or box `WithFallback::new(primary, terminal)`
+/// when a fallback is set. One inner match over the 4 terminal
+/// variants — the concrete `WithFallback<primary, terminal>` never
+/// escapes this function.
+fn box_with_optional_fallback<M, P>(
+    primary: P,
+    fallback: Option<&TerminalFallback>,
+) -> SharedTextOp<M>
+where
+    M: Modality + Send + Sync + 'static,
+    P: TryOperator<M> + Clone + Send + Sync + 'static,
+    Erase: Operator<M>,
+    Keep: Operator<M>,
+    Replace: Operator<M> + Clone,
+    Mask: Operator<M> + Clone,
+{
+    match fallback {
+        None => Arc::new(primary),
+        Some(TerminalFallback::Erase) => Arc::new(WithFallback::new(primary, Erase)),
+        Some(TerminalFallback::Keep) => Arc::new(WithFallback::new(primary, Keep)),
+        Some(TerminalFallback::Replace { template }) => {
+            Arc::new(WithFallback::new(primary, Replace::new(template.clone())))
+        }
+        Some(TerminalFallback::Mask {
+            mask_char,
+            keep_prefix,
+            keep_suffix,
+        }) => Arc::new(WithFallback::new(
+            primary,
+            build_mask(*mask_char, *keep_prefix, *keep_suffix),
+        )),
+    }
+}
 
 /// Runtime conversion from the wire's [`HashAlgorithm`] to
 /// elide's [`Sha2Algorithm`]. Lives here rather than as a
@@ -27,109 +266,52 @@ fn to_sha2(algorithm: HashAlgorithm) -> Sha2Algorithm {
     }
 }
 
-/// Discriminated builder result so [`Target::attach_with`] can
-/// attach the right concrete operator type. We can't return
-/// `Box<dyn Operator<_>>` because [`Anonymizer::with_label`]
-/// takes `O: Operator<M> + 'static` by value.
-///
-/// [`Anonymizer::with_label`]: elide::redaction::Anonymizer::with_label
-pub(in crate::anonymizer) enum TextOp {
-    Erase,
-    Keep,
-    Mask(Mask),
-    Replace(Replace),
-    Hash(Sha2Hash),
-    /// `Fake` is generic over its fallback; we bind the fallback
-    /// to [`Replace`] at compile so the enum stays a fixed set of
-    /// concrete types.
-    Fake(Fake<Replace>),
+fn build_mask(mask_char: char, keep_prefix: usize, keep_suffix: usize) -> Mask {
+    Mask::new(mask_char)
+        .with_keep_prefix(keep_prefix)
+        .with_keep_suffix(keep_suffix)
 }
 
-impl TextOp {
-    /// Attach `self` to `target`. Works for any modality whose
-    /// anonymizer accepts the text operator set (elide ships
-    /// `impl Operator<Text>` and `impl Operator<Tabular>` on all
-    /// six concrete ops).
-    pub(in crate::anonymizer) fn attach_to<M>(self, target: Target<'_, M>) -> Anonymizer<M>
-    where
-        M: Modality + 'static,
-        Erase: Operator<M>,
-        Keep: Operator<M>,
-        Mask: Operator<M> + Clone,
-        Replace: Operator<M> + Clone,
-        Sha2Hash: Operator<M> + Clone,
-        Fake<Replace>: Operator<M> + Clone,
-    {
-        match self {
-            TextOp::Erase => target.attach_with(Erase),
-            TextOp::Keep => target.attach_with(Keep),
-            TextOp::Mask(op) => target.attach_with(op),
-            TextOp::Replace(op) => target.attach_with(op),
-            TextOp::Hash(op) => target.attach_with(op),
-            TextOp::Fake(op) => target.attach_with(op),
-        }
+/// Build an [`elide::Clamp`] from wire fields, validating the
+/// bucket/threshold pairing (a threshold without a bucket, or
+/// vice versa, is an author error).
+fn build_clamp(
+    ceiling: Option<f64>,
+    ceiling_bucket: Option<&ClampBucket>,
+    floor: Option<f64>,
+    floor_bucket: Option<&ClampBucket>,
+) -> Result<Clamp> {
+    validate_pair("ceiling", ceiling.is_some(), ceiling_bucket.is_some())?;
+    validate_pair("floor", floor.is_some(), floor_bucket.is_some())?;
+    let mut op = Clamp::new();
+    if let (Some(threshold), Some(bucket)) = (ceiling, ceiling_bucket) {
+        op = bucket.attach_ceiling(op, threshold);
     }
+    if let (Some(threshold), Some(bucket)) = (floor, floor_bucket) {
+        op = bucket.attach_floor(op, threshold);
+    }
+    Ok(op)
 }
 
-impl TryFrom<&TextRedaction> for TextOp {
-    type Error = Error;
-
-    /// `Pseudonymize` and `Encrypt` need engine-side
-    /// infrastructure (vault, key provider) that isn't wired
-    /// yet, so they error here — the wire declares them, the
-    /// runtime rejects them.
-    fn try_from(spec: &TextRedaction) -> Result<Self, Self::Error> {
-        Ok(match spec {
-            TextRedaction::Erase => Self::Erase,
-            TextRedaction::Keep => Self::Keep,
-            TextRedaction::Mask {
-                mask_char,
-                keep_prefix,
-                keep_suffix,
-            } => Self::Mask(
-                Mask::new(*mask_char)
-                    .with_keep_prefix(*keep_prefix)
-                    .with_keep_suffix(*keep_suffix),
+fn validate_pair(side: &'static str, threshold_set: bool, bucket_set: bool) -> Result<()> {
+    if threshold_set != bucket_set {
+        return Err(Error::new(
+            ErrorKind::Configuration,
+            format!(
+                "policy compile: `clamp.{side}` and `clamp.{side}_bucket` \
+                 must be set together",
             ),
-            TextRedaction::Replace { template } => Self::Replace(Replace::new(template.clone())),
-            TextRedaction::Hash { algorithm, salt } => {
-                let mut op = Sha2Hash::new(to_sha2(*algorithm));
-                if let Some(s) = salt {
-                    op = op.with_salt(s.as_bytes().to_vec());
-                }
-                Self::Hash(op)
-            }
-            TextRedaction::Fake {
-                default_language,
-                seed,
-                fallback_template,
-            } => {
-                let fallback = Replace::new(fallback_template.clone());
-                let mut op = Fake::new(fallback);
-                if let Some(lang) = default_language {
-                    op = op.with_default_language(lang.clone());
-                }
-                if let Some(s) = seed {
-                    op = op.with_seed(*s);
-                }
-                Self::Fake(op)
-            }
-            TextRedaction::Pseudonymize => {
-                return Err(stateful_not_wired("pseudonymize", "vault + generator"));
-            }
-            TextRedaction::Encrypt => {
-                return Err(stateful_not_wired("encrypt", "key provider"));
-            }
-        })
+        ));
     }
+    Ok(())
 }
 
-fn stateful_not_wired(operator: &'static str, infrastructure: &'static str) -> Error {
+fn missing_infrastructure(operator: &'static str, infrastructure: &'static str) -> Error {
     Error::new(
-        ErrorKind::CapabilityUnavailable,
+        ErrorKind::Configuration,
         format!(
-            "policy compile: `{operator}` needs an engine-side {infrastructure}; \
-             stateful operator infrastructure is not wired into the compile surface yet",
+            "policy compile: `{operator}` requires an engine-side {infrastructure}; \
+             wire one via `Engine::with_key_provider` (or the matching setter)",
         ),
     )
 }

--- a/crates/nvisy-engine/src/anonymizer/operator/text.rs
+++ b/crates/nvisy-engine/src/anonymizer/operator/text.rs
@@ -9,15 +9,18 @@
 //! their [`Target`] here.
 //!
 //! Every arm returns an `Arc<dyn Operator<M> + Send + Sync +
-//! 'static>` — [`Arc`] so it stays [`Clone`] (elide's
-//! `Anonymizer::with_label` requires `O: Operator<M> + Clone`).
-//! Elide ships a blanket `impl<M, T: Operator<M> + ?Sized>
-//! Operator<M> for Arc<T>` (elide #160), so the shared handle is
-//! itself an operator and drops straight into `with_label`. That
-//! turns the wire → runtime bridge into a `match` returning one
-//! type — no per-variant enum, no fan-out of concrete
+//! 'static>` — an [`Arc`] rather than a [`Box`] so the same
+//! handle can seed a [`Fake`] fallback as easily as it can
+//! attach on its own. Elide ships a blanket
+//! `impl<M, T: Operator<M> + ?Sized> Operator<M> for Arc<T>`
+//! (elide #160), so the shared handle is itself an operator and
+//! drops straight into [`Rule::label`]. That turns the wire →
+//! runtime bridge into a `match` returning one type — no
+//! per-variant enum, no fan-out of concrete
 //! `WithFallback<primary, fallback>` combinations at the source
 //! level.
+//!
+//! [`Rule::label`]: elide::redaction::Rule::label
 
 use std::sync::Arc;
 
@@ -65,16 +68,14 @@ pub(crate) struct TextOperatorContext {
 
 /// Type-erased shared handle to a modality-`M` operator.
 ///
-/// `Arc<dyn Operator<M>>` — [`Arc`] rather than [`Box`] because
-/// elide's [`Anonymizer::with_label`] requires `O: Operator<M>
-/// + Clone`, and only `Arc` (not `Box`) makes a trait object
-/// cloneable. Elide's blanket forward `impl<M, T: Operator<M>
-/// + ?Sized> Operator<M> for Arc<T>` (elide #160) makes the
-/// shared handle itself an operator, so it drops directly into
-/// every elide entry point that accepts an `impl Operator<M>
-/// + Clone + 'static` — no unwrap, no dispatcher.
+/// `Arc<dyn Operator<M>>` — [`Arc`] rather than [`Box`] so the
+/// same handle can seed a [`Fake`] fallback and still attach as
+/// its own operator. Elide's blanket forward
+/// `impl<M, T: Operator<M> + ?Sized> Operator<M> for Arc<T>`
+/// (elide #160) makes the shared handle itself an operator, so
+/// it drops directly into [`Rule::label`] with no unwrap.
 ///
-/// [`Anonymizer::with_label`]: elide::redaction::Anonymizer::with_label
+/// [`Rule::label`]: elide::redaction::Rule::label
 pub(in crate::anonymizer) type SharedTextOp<M> = Arc<dyn Operator<M> + Send + Sync + 'static>;
 
 /// Compile `spec` into a boxed operator and attach it to `target`.
@@ -92,17 +93,16 @@ where
     M: Modality + Send + Sync + 'static,
     Erase: Operator<M>,
     Keep: Operator<M>,
-    Mask: Operator<M> + Clone,
-    Replace: Operator<M> + Clone,
-    Sha2Hash: Operator<M> + Clone,
-    HmacHash: Operator<M> + Clone,
-    Truncate: Operator<M> + Clone,
-    Clamp: TryOperator<M> + Clone,
-    GeneralizeDate: TryOperator<M> + Clone,
-    Fake<Replace>: Operator<M> + Clone,
-    Pseudonymize<InMemoryVault<(LabelRef, String), TextReplacement>, RandomToken>:
-        Operator<M> + Clone,
-    AesEncrypt: Operator<M> + Clone,
+    Mask: Operator<M>,
+    Replace: Operator<M>,
+    Sha2Hash: Operator<M>,
+    HmacHash: Operator<M>,
+    Truncate: Operator<M>,
+    Clamp: TryOperator<M>,
+    GeneralizeDate: TryOperator<M>,
+    Fake<Replace>: Operator<M>,
+    Pseudonymize<InMemoryVault<(LabelRef, String), TextReplacement>, RandomToken>: Operator<M>,
+    AesEncrypt: Operator<M>,
 {
     Ok(target.attach_with(build(spec, ctx)?))
 }
@@ -130,17 +130,16 @@ where
     M: Modality + Send + Sync + 'static,
     Erase: Operator<M>,
     Keep: Operator<M>,
-    Mask: Operator<M> + Clone,
-    Replace: Operator<M> + Clone,
-    Sha2Hash: Operator<M> + Clone,
-    HmacHash: Operator<M> + Clone,
-    Truncate: Operator<M> + Clone,
-    Clamp: TryOperator<M> + Clone,
-    GeneralizeDate: TryOperator<M> + Clone,
-    Fake<Replace>: Operator<M> + Clone,
-    Pseudonymize<InMemoryVault<(LabelRef, String), TextReplacement>, RandomToken>:
-        Operator<M> + Clone,
-    AesEncrypt: Operator<M> + Clone,
+    Mask: Operator<M>,
+    Replace: Operator<M>,
+    Sha2Hash: Operator<M>,
+    HmacHash: Operator<M>,
+    Truncate: Operator<M>,
+    Clamp: TryOperator<M>,
+    GeneralizeDate: TryOperator<M>,
+    Fake<Replace>: Operator<M>,
+    Pseudonymize<InMemoryVault<(LabelRef, String), TextReplacement>, RandomToken>: Operator<M>,
+    AesEncrypt: Operator<M>,
 {
     Ok(match spec {
         TextRedaction::Erase => Arc::new(Erase),
@@ -229,11 +228,11 @@ fn box_with_optional_fallback<M, P>(
 ) -> SharedTextOp<M>
 where
     M: Modality + Send + Sync + 'static,
-    P: TryOperator<M> + Clone + Send + Sync + 'static,
+    P: TryOperator<M> + Send + Sync + 'static,
     Erase: Operator<M>,
     Keep: Operator<M>,
-    Replace: Operator<M> + Clone,
-    Mask: Operator<M> + Clone,
+    Replace: Operator<M>,
+    Mask: Operator<M>,
 {
     match fallback {
         None => Arc::new(primary),

--- a/crates/nvisy-engine/src/anonymizer/operator/text.rs
+++ b/crates/nvisy-engine/src/anonymizer/operator/text.rs
@@ -25,7 +25,7 @@ use elide::redaction::Anonymizer;
 use elide::redaction::generator::RandomToken;
 use elide::redaction::operators::{
     AesEncrypt, Clamp, Erase, Fake, GeneralizeDate, HmacHash, Keep, KeyProvider, Mask,
-    Pseudonymize, Replace, Sha2Algorithm, Sha2Hash, Truncate, TryOperator, WithFallback,
+    Pseudonymize, Replace, Sha2Hash, Truncate, TryOperator, WithFallback,
 };
 use elide::redaction::vault::InMemoryVault;
 use elide_core::entity::LabelRef;
@@ -33,9 +33,7 @@ use elide_core::modality::Modality;
 use elide_core::modality::text::TextReplacement;
 use elide_core::operator::Operator;
 use elide_core::{Error, ErrorKind, Result};
-use nvisy_schema::policy::redaction::{
-    ClampBucket, HashAlgorithm, TerminalFallback, TextRedaction,
-};
+use nvisy_schema::policy::redaction::{ClampBucket, TerminalFallback, TextRedaction};
 
 use crate::anonymizer::compile::Target;
 
@@ -154,7 +152,7 @@ where
         } => Arc::new(build_mask(*mask_char, *keep_prefix, *keep_suffix)),
         TextRedaction::Replace { template } => Arc::new(Replace::new(template.clone())),
         TextRedaction::Hash { algorithm, salt } => {
-            let mut op = Sha2Hash::new(to_sha2(*algorithm));
+            let mut op = Sha2Hash::new(*algorithm);
             if let Some(s) = salt {
                 op = op.with_salt(s.as_bytes().to_vec());
             }
@@ -165,7 +163,7 @@ where
                 .key_provider
                 .clone()
                 .ok_or_else(|| missing_infrastructure("hmac_hash", "KeyProvider"))?;
-            Arc::new(HmacHash::new(to_sha2(*algorithm), keys))
+            Arc::new(HmacHash::new(*algorithm, keys))
         }
         TextRedaction::Truncate {
             keep_prefix,
@@ -252,17 +250,6 @@ where
             primary,
             build_mask(*mask_char, *keep_prefix, *keep_suffix),
         )),
-    }
-}
-
-/// Runtime conversion from the wire's [`HashAlgorithm`] to
-/// elide's [`Sha2Algorithm`]. Lives here rather than as a
-/// `From` impl on the wire type so `nvisy-schema` stays free
-/// of the `elide-redaction` dep.
-fn to_sha2(algorithm: HashAlgorithm) -> Sha2Algorithm {
-    match algorithm {
-        HashAlgorithm::Sha256 => Sha2Algorithm::Sha256,
-        HashAlgorithm::Sha512 => Sha2Algorithm::Sha512,
     }
 }
 

--- a/crates/nvisy-engine/src/anonymizer/tabular.rs
+++ b/crates/nvisy-engine/src/anonymizer/tabular.rs
@@ -11,14 +11,14 @@
 
 use elide::redaction::Anonymizer;
 use elide::redaction::operators::{DropColumn, DropRow};
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::tabular::Tabular;
 use nvisy_schema::policy::PolicyDefinition;
 use nvisy_schema::policy::redaction::{ModalityRedactions, TabularRedaction};
 use uuid::Uuid;
 
 use super::compile::{Target, attach_one_override, attach_policies};
-use super::operator::text::TextOp;
+use super::operator::text::{TextOperatorContext, compile_and_attach};
 
 /// Attach every tabular-applicable rule from `policies` onto an
 /// already-constructed anonymizer. Takes an iterator so the
@@ -29,8 +29,11 @@ use super::operator::text::TextOp;
 pub(crate) fn attach_policies_tabular<'a>(
     anonymizer: Anonymizer<Tabular>,
     policies: impl Iterator<Item = &'a PolicyDefinition>,
-) -> Result<Anonymizer<Tabular>, Error> {
-    attach_policies(anonymizer, policies, compile_one)
+    ctx: &TextOperatorContext,
+) -> Result<Anonymizer<Tabular>> {
+    attach_policies(anonymizer, policies, |target, redactions| {
+        compile_one(target, redactions, ctx)
+    })
 }
 
 /// Attach a reviewer override for one entity. A no-op when the
@@ -39,20 +42,22 @@ pub(crate) fn attach_override_tabular(
     anonymizer: Anonymizer<Tabular>,
     entity_id: Uuid,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Tabular>, Error> {
-    attach_one_override(anonymizer, entity_id, redactions, compile_one)
+    ctx: &TextOperatorContext,
+) -> Result<Anonymizer<Tabular>> {
+    attach_one_override(anonymizer, entity_id, redactions, |target, redactions| {
+        compile_one(target, redactions, ctx)
+    })
 }
 
 fn compile_one(
     target: Target<'_, Tabular>,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Tabular>, Error> {
-    let Some(spec) = &redactions.tabular else {
-        return Ok(target.passthrough());
-    };
-    Ok(match spec {
-        TabularRedaction::Cell { spec } => TextOp::try_from(spec)?.attach_to(target),
-        TabularRedaction::DropRow => target.attach_with(DropRow),
-        TabularRedaction::DropColumn => target.attach_with(DropColumn),
-    })
+    ctx: &TextOperatorContext,
+) -> Result<Anonymizer<Tabular>> {
+    match &redactions.tabular {
+        None => Ok(target.passthrough()),
+        Some(TabularRedaction::Cell { spec }) => compile_and_attach(spec, ctx, target),
+        Some(TabularRedaction::DropRow) => Ok(target.attach_with(DropRow)),
+        Some(TabularRedaction::DropColumn) => Ok(target.attach_with(DropColumn)),
+    }
 }

--- a/crates/nvisy-engine/src/anonymizer/text.rs
+++ b/crates/nvisy-engine/src/anonymizer/text.rs
@@ -2,14 +2,14 @@
 //! [`Anonymizer<Text>`].
 
 use elide::redaction::Anonymizer;
-use elide_core::Error;
+use elide_core::Result;
 use elide_core::modality::text::Text;
 use nvisy_schema::policy::PolicyDefinition;
 use nvisy_schema::policy::redaction::ModalityRedactions;
 use uuid::Uuid;
 
 use super::compile::{Target, attach_one_override, attach_policies};
-use super::operator::text::TextOp;
+use super::operator::text::{TextOperatorContext, compile_and_attach};
 
 /// Attach every text-applicable rule from `policies` onto an
 /// already-constructed anonymizer. The apply pipeline calls this
@@ -22,8 +22,11 @@ use super::operator::text::TextOp;
 pub(crate) fn attach_policies_text<'a>(
     anonymizer: Anonymizer<Text>,
     policies: impl Iterator<Item = &'a PolicyDefinition>,
-) -> Result<Anonymizer<Text>, Error> {
-    attach_policies(anonymizer, policies, compile_one)
+    ctx: &TextOperatorContext,
+) -> Result<Anonymizer<Text>> {
+    attach_policies(anonymizer, policies, |target, redactions| {
+        compile_one(target, redactions, ctx)
+    })
 }
 
 /// Attach a reviewer override for one entity. A no-op when the
@@ -32,16 +35,20 @@ pub(crate) fn attach_override_text(
     anonymizer: Anonymizer<Text>,
     entity_id: Uuid,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Text>, Error> {
-    attach_one_override(anonymizer, entity_id, redactions, compile_one)
+    ctx: &TextOperatorContext,
+) -> Result<Anonymizer<Text>> {
+    attach_one_override(anonymizer, entity_id, redactions, |target, redactions| {
+        compile_one(target, redactions, ctx)
+    })
 }
 
 fn compile_one(
     target: Target<'_, Text>,
     redactions: &ModalityRedactions,
-) -> Result<Anonymizer<Text>, Error> {
-    let Some(spec) = &redactions.text else {
-        return Ok(target.passthrough());
-    };
-    Ok(TextOp::try_from(spec)?.attach_to(target))
+    ctx: &TextOperatorContext,
+) -> Result<Anonymizer<Text>> {
+    match &redactions.text {
+        None => Ok(target.passthrough()),
+        Some(spec) => compile_and_attach(spec, ctx, target),
+    }
 }

--- a/crates/nvisy-engine/src/entity/group.rs
+++ b/crates/nvisy-engine/src/entity/group.rs
@@ -139,10 +139,7 @@ pub(crate) fn take_body<M: GroupCarrier>(report: &mut Report) -> Option<EntityGr
 
 /// Drain the part `id`'s entities into an [`EntityGroup`] of
 /// `M`'s variant, or `None` if `M` is not that part's modality.
-pub(crate) fn take_part<M: GroupCarrier>(
-    report: &mut Report,
-    id: &PartId,
-) -> Option<EntityGroup> {
+pub(crate) fn take_part<M: GroupCarrier>(report: &mut Report, id: &PartId) -> Option<EntityGroup> {
     let entities = mem::take(report.part_entities::<M>(id)?);
     Some(M::into_group(entities))
 }
@@ -186,7 +183,8 @@ impl EntityGroup {
     /// Insert this group into `report` as the body under its
     /// modality.
     pub(crate) fn insert_into_body(&self, report: Report) -> Report {
-        dispatch!(self, |M, entities| report.insert_body::<M>(clone_entities(entities)))
+        dispatch!(self, |M, entities| report
+            .insert_body::<M>(clone_entities(entities)))
     }
 
     /// Insert this group into `report` as a container part keyed

--- a/crates/nvisy-engine/src/entity/mod.rs
+++ b/crates/nvisy-engine/src/entity/mod.rs
@@ -32,5 +32,5 @@ pub use nvisy_schema::entity::{
 };
 
 pub use self::group::EntityGroup;
-pub use self::record::EntityRecord;
 pub(crate) use self::group::{take_body, take_part};
+pub use self::record::EntityRecord;

--- a/crates/nvisy-engine/src/entity/mod.rs
+++ b/crates/nvisy-engine/src/entity/mod.rs
@@ -7,7 +7,7 @@
 //! [`EntityGroup`] wraps a whole `Vec` of records, tagged by
 //! modality, as the unit an [`Audit`] holds in `body` and every
 //! `parts` entry. [`Label`] and [`LabelRef`] name the entity
-//! kind; each label carries per-language [`Localization`] entries
+//! kind; each label carries per-language [`LabelLocale`] entries
 //! (name + optional description) so NER and LLM backends render
 //! labels in the analysis language. [`LabelCatalog`] holds the
 //! deployment's label vocabulary and exposes tag-filter helpers
@@ -27,8 +27,8 @@ mod group;
 mod record;
 
 pub use nvisy_schema::entity::{
-    Attribution, Entity, EntityCoRef, EntityRef, Event, EventKind, Label, LabelCatalog, LabelRef,
-    Localization, ModelEvent, PatternEvent, Provenance, RuleMatch,
+    Attribution, Entity, EntityCoRef, EntityRef, Event, EventKind, Label, LabelCatalog,
+    LabelLocale, LabelRef, ModelEvent, PatternEvent, Provenance, RuleMatch,
 };
 
 pub use self::group::EntityGroup;

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -26,13 +26,15 @@ mod analyzer;
 mod anonymizer;
 pub mod entity;
 pub mod modality;
-pub mod plan;
 mod pipeline;
+pub mod plan;
 pub mod primitive;
 pub mod provider;
 
 #[doc(inline)]
 pub use elide::codec::FormatRegistry;
+#[doc(inline)]
+pub use elide::redaction::operators::{KeyProvider, StaticKey};
 #[doc(inline)]
 pub use elide_core::{Error, ErrorKind, Result};
 #[doc(inline)]

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -12,13 +12,19 @@
 //! storage, and multi-tenancy they need on top.
 //!
 //! - [`Engine`]: the entry point. Bundles the codec registry,
-//!   the deployment's NER / LLM lineups, and the per-request
-//!   orchestrator builder.
+//!   the deployment's NER / LLM lineups, the shared
+//!   [`KeyProvider`] for keyed operators (HMAC, AES), and the
+//!   per-request orchestrator builder.
 //! - [`Engine::analyze`] and [`Engine::anonymize`] compile and
 //!   run the full [`elide::Orchestrator`] against one document.
+//!   Both take the request's `policies` and the shared
+//!   `groups` (named [`LabelGroup`]s the policies reference by
+//!   name) alongside the document.
 //! - [`Audit`] carries the analyze → anonymize handoff: the
 //!   modality-tagged entity groups plus an [`AuditContext`] with
 //!   the request's asserted scope and correlation id.
+//!
+//! [`LabelGroup`]: nvisy_schema::policy::LabelGroup
 //!
 //! [`elide`]: elide
 

--- a/crates/nvisy-engine/src/pipeline/audit.rs
+++ b/crates/nvisy-engine/src/pipeline/audit.rs
@@ -28,10 +28,11 @@ use std::collections::HashMap;
 #[cfg(feature = "audit-json")]
 use std::io::Write;
 
-use elide_core::primitive::{CountryCode, Languages};
 use elide::recognition::ScopeMetadata;
+use elide_core::primitive::{CountryCode, Languages};
 #[cfg(feature = "audit-json")]
 use elide_core::{Error, ErrorKind, Result};
+use nvisy_schema::plan::scope_metadata_is_empty;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -136,17 +137,6 @@ pub struct AuditContext {
     ///
     /// [`Document`]: nvisy_schema::file::Document
     pub correlation_id: Uuid,
-}
-
-/// Whether the [`ScopeMetadata`] carries no assertions.
-///
-/// Used by [`AuditContext::metadata`]'s `skip_serializing_if` to
-/// keep the serialized `context` block minimal when the caller
-/// asserts nothing beyond the typed fields. Local to this module
-/// because elide's `ScopeMetadata` doesn't ship an `is_empty` of
-/// its own; a one-line helper is cheaper than a wrapper type.
-fn scope_metadata_is_empty(metadata: &ScopeMetadata) -> bool {
-    metadata.tags.is_empty() && metadata.purpose.is_none() && metadata.audience.is_empty()
 }
 
 #[cfg(feature = "audit-json")]

--- a/crates/nvisy-engine/src/pipeline/audit.rs
+++ b/crates/nvisy-engine/src/pipeline/audit.rs
@@ -29,6 +29,7 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use elide_core::primitive::{CountryCode, Languages};
+use elide::recognition::ScopeMetadata;
 #[cfg(feature = "audit-json")]
 use elide_core::{Error, ErrorKind, Result};
 use schemars::JsonSchema;
@@ -88,18 +89,22 @@ pub struct Audit {
 
 /// Recognition-side facts that travel from analyze to anonymize.
 ///
-/// Everything a policy predicate might key off the request's
-/// caller-asserted scope (languages, jurisdictions, document
-/// tags), plus the analyze-time correlation id so tracing spans
-/// across both phases stay linked. The label catalog is not on
-/// here — labels are policy-owned, and anonymize re-derives them
-/// from the policy set it was handed.
+/// Mirrors elide's [`Scope`] shape one-for-one: direct fields
+/// for `languages` and `countries` (typed, elide-native), a
+/// [`metadata`] sub-struct for free-form classification strings
+/// (`tags`, `purpose`, `audience`), and the analyze-time
+/// [`correlation_id`]. The label catalog is not on here —
+/// labels are policy-owned, and anonymize re-derives them from
+/// the policy set it was handed.
 ///
 /// No [`Default`] — `correlation_id` has no meaningful default
-/// (a nil UUID would silently collapse unrelated audits under one
-/// bucket in downstream trace aggregators), so callers supply one
-/// explicitly. Everything else is optional-on-the-wire and
-/// defaults to empty when missing.
+/// (a nil UUID would silently collapse unrelated audits under
+/// one bucket in downstream trace aggregators), so callers
+/// supply one explicitly. Everything else defaults to empty.
+///
+/// [`Scope`]: elide::recognition::Scope
+/// [`metadata`]: Self::metadata
+/// [`correlation_id`]: Self::correlation_id
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AuditContext {
@@ -114,11 +119,10 @@ pub struct AuditContext {
     /// Recorded from `AnalyzerParams.scope.countries`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub countries: Vec<CountryCode>,
-    /// Document-level classification tags.
-    ///
-    /// Recorded from `AnalyzerParams.scope.tags`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tags: Vec<String>,
+    /// Free-form request context: document tags, request purpose,
+    /// output audience. See elide's [`ScopeMetadata`].
+    #[serde(default, skip_serializing_if = "scope_metadata_is_empty")]
+    pub metadata: ScopeMetadata,
     /// Analyze-time correlation id.
     ///
     /// Threaded into every tracing span on the recognition path;
@@ -132,6 +136,17 @@ pub struct AuditContext {
     ///
     /// [`Document`]: nvisy_schema::file::Document
     pub correlation_id: Uuid,
+}
+
+/// Whether the [`ScopeMetadata`] carries no assertions.
+///
+/// Used by [`AuditContext::metadata`]'s `skip_serializing_if` to
+/// keep the serialized `context` block minimal when the caller
+/// asserts nothing beyond the typed fields. Local to this module
+/// because elide's `ScopeMetadata` doesn't ship an `is_empty` of
+/// its own; a one-line helper is cheaper than a wrapper type.
+fn scope_metadata_is_empty(metadata: &ScopeMetadata) -> bool {
+    metadata.tags.is_empty() && metadata.purpose.is_none() && metadata.audience.is_empty()
 }
 
 #[cfg(feature = "audit-json")]

--- a/crates/nvisy-engine/src/pipeline/audit_csv.rs
+++ b/crates/nvisy-engine/src/pipeline/audit_csv.rs
@@ -386,13 +386,22 @@ fn event_kind_and_payload<M: Modality>(kind: &EventKind<M>) -> (&'static str, Op
 /// object always has a `"kind"` field.
 fn operator_kind_for_modality(review: &ModalityRedactions, modality: &str) -> Option<String> {
     let value = match modality {
-        "text" => review.text.as_ref().and_then(|op| serde_json::to_value(op).ok()),
+        "text" => review
+            .text
+            .as_ref()
+            .and_then(|op| serde_json::to_value(op).ok()),
         "tabular" => review
             .tabular
             .as_ref()
             .and_then(|op| serde_json::to_value(op).ok()),
-        "image" => review.image.as_ref().and_then(|op| serde_json::to_value(op).ok()),
-        "audio" => review.audio.as_ref().and_then(|op| serde_json::to_value(op).ok()),
+        "image" => review
+            .image
+            .as_ref()
+            .and_then(|op| serde_json::to_value(op).ok()),
+        "audio" => review
+            .audio
+            .as_ref()
+            .and_then(|op| serde_json::to_value(op).ok()),
         _ => None,
     }?;
     value

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -84,6 +84,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use elide::codec::{FormatRegistry, PartId, UntypedDocumentHandle};
+use elide::redaction::operators::KeyProvider;
 use elide::{Directives, Report};
 #[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
@@ -108,14 +109,18 @@ use crate::provider::ner::NerConfig;
 /// Cheaply-cloneable pipeline adapter over [`elide`].
 ///
 /// Bundles the codec registry, the deployment's NER / LLM
-/// lineups, the pattern-recognizer guardrails, and the
+/// lineups, the pattern-recognizer guardrails, the shared
+/// [`KeyProvider`] (for `HmacHash` and `Encrypt`), and the
 /// per-request orchestrator constructor.
+///
+/// [`KeyProvider`]: elide::redaction::operators::KeyProvider
 #[derive(Clone, Default)]
 pub struct Engine {
     formats: Arc<FormatRegistry>,
     ner: Arc<NerConfig>,
     llm: Arc<LlmConfig>,
     pattern_guardrails: PatternGuardrails,
+    pub(super) key_provider: Option<Arc<dyn KeyProvider>>,
 }
 
 impl Engine {
@@ -123,16 +128,20 @@ impl Engine {
     ///
     /// Uses [`FormatRegistry::with_builtin`] plus empty NER and
     /// LLM lineups. Callers that want NER or LLM recognition
-    /// must chain [`with_ner`] or [`with_llm`].
+    /// must chain [`with_ner`] or [`with_llm`]. Callers whose
+    /// policies use `HmacHash` or `Encrypt` must wire a key
+    /// provider via [`with_key_provider`].
     ///
     /// [`with_ner`]: Self::with_ner
     /// [`with_llm`]: Self::with_llm
+    /// [`with_key_provider`]: Self::with_key_provider
     pub fn new() -> Self {
         Self {
             formats: Arc::new(FormatRegistry::with_builtin()),
             ner: Arc::new(NerConfig::default()),
             llm: Arc::new(LlmConfig::default()),
             pattern_guardrails: PatternGuardrails::default(),
+            key_provider: None,
         }
     }
 
@@ -155,6 +164,23 @@ impl Engine {
     #[must_use]
     pub fn with_llm(mut self, llm: LlmConfig) -> Self {
         self.llm = Arc::new(llm);
+        self
+    }
+
+    /// Set the shared cryptographic [`KeyProvider`] the
+    /// `HmacHash` and `Encrypt` operators resolve their keys
+    /// through.
+    ///
+    /// One provider backs both operators; per-label keys are the
+    /// provider's own responsibility. A policy that names either
+    /// operator without a provider wired errors at request
+    /// compile time — the audit trail names the operator so a
+    /// misconfiguration surfaces at load, not silently.
+    ///
+    /// [`KeyProvider`]: elide::redaction::operators::KeyProvider
+    #[must_use]
+    pub fn with_key_provider(mut self, provider: Arc<dyn KeyProvider>) -> Self {
+        self.key_provider = Some(provider);
         self
     }
 
@@ -403,11 +429,7 @@ fn build_analyze_directives(spec: &AnalyzerParams) -> Directives {
 /// `TypeId`. Feature-gated per modality; a part whose modality is
 /// disabled in this build falls through to `None`, and the caller
 /// treats it the same as a part the engine doesn't model.
-fn take_part_dispatch(
-    report: &mut Report,
-    id: &PartId,
-    type_id: TypeId,
-) -> Option<EntityGroup> {
+fn take_part_dispatch(report: &mut Report, id: &PartId, type_id: TypeId) -> Option<EntityGroup> {
     if type_id == TypeId::of::<Text>() {
         return take_part::<Text>(report, id);
     }

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -96,8 +96,8 @@ use elide_core::modality::text::Text;
 use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::file::Document;
 use nvisy_schema::plan::AnalyzerParams;
-use nvisy_schema::policy::PolicyDefinition;
 use nvisy_schema::policy::redaction::ModalityRedactions;
+use nvisy_schema::policy::{LabelGroup, PolicyDefinition};
 use uuid::Uuid;
 
 pub use self::audit::{Audit, AuditContext};
@@ -240,26 +240,34 @@ impl Engine {
     ///
     /// `policies` contributes the label catalog (each
     /// [`PolicyDefinition::labels`] unions in) that drives
-    /// recognizer dispatch. The catalog is not persisted onto the
-    /// returned [`Audit`] — the anonymize path re-derives it from
-    /// the policy set it was handed. Pass the same policy set to
+    /// recognizer dispatch. `groups` are the [`LabelGroup`]s the
+    /// policies' `LabelInGroup` predicates reference by name; the
+    /// engine stamps a `group:<name>` synthetic tag on every
+    /// listed label at request-compile time and rejects any
+    /// group reference the request didn't submit.
+    ///
+    /// The catalog is not persisted onto the returned [`Audit`] —
+    /// the anonymize path re-derives it from the policy set it
+    /// was handed. Pass the same policy set + groups to
     /// [`Self::anonymize`] so its rule bodies match against a
     /// catalog they helped define.
     ///
     /// [`Orchestrator::analyze`]: elide::Orchestrator::analyze
     /// [`EntityGroup`]: crate::entity::EntityGroup
+    /// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
     /// [`PolicyDefinition::labels`]: nvisy_schema::policy::PolicyDefinition::labels
     pub async fn analyze(
         &self,
         document: Document,
         policies: &[PolicyDefinition],
+        groups: &[LabelGroup],
         spec: &AnalyzerParams,
     ) -> Result<Audit> {
         let correlation_id = document.correlation_id;
         let extension = document.extension.clone();
         let mut handle = self.decode(document).await?;
         let (orchestrator, context) =
-            self.build_analyze_orchestrator(spec, policies, correlation_id)?;
+            self.build_analyze_orchestrator(spec, policies, groups, correlation_id)?;
         let directives = build_analyze_directives(spec);
         let mut report = orchestrator.analyze(&mut handle, &directives).await?;
 
@@ -327,13 +335,17 @@ impl Engine {
     ///
     /// `policies` is the policy set already filtered by
     /// [`PolicyDefinition::when`] against the per-doc facts; the
-    /// engine does not re-evaluate predicates. The label catalog
-    /// is re-derived from this same policy set on every call —
-    /// policies are the sole source of label vocabulary. The
-    /// asserted scope (languages, jurisdictions, tags) travels on
-    /// [`Audit::context`] from analyze. The document's
-    /// `correlation_id` is threaded into tracing spans on the
-    /// redaction path.
+    /// engine does not re-evaluate predicates. `groups` are the
+    /// [`LabelGroup`]s the policies' `LabelInGroup` predicates
+    /// reference by name — same shape as [`Self::analyze`]. The
+    /// label catalog is re-derived from `policies` + `groups` on
+    /// every call — policies are the sole source of label
+    /// vocabulary. The asserted scope (languages, jurisdictions,
+    /// metadata) travels on [`Audit::context`] from analyze. The
+    /// document's `correlation_id` is threaded into tracing spans
+    /// on the redaction path.
+    ///
+    /// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
     ///
     /// The body's modality (read from `audit.body`'s
     /// [`EntityGroup`] variant) pins which typed handle the
@@ -348,6 +360,7 @@ impl Engine {
         &self,
         document: Document,
         policies: &[PolicyDefinition],
+        groups: &[LabelGroup],
         audit: &mut Audit,
     ) -> Result<Document> {
         let body_group = audit.body.as_ref().ok_or_else(|| {
@@ -372,6 +385,7 @@ impl Engine {
         let orchestrator = self.build_anonymize_orchestrator(
             &audit.context,
             policies,
+            groups,
             &overrides,
             correlation_id,
         )?;

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -34,6 +34,7 @@
 //!
 //! [`Scope`]: elide::recognition::Scope
 
+use std::collections::HashSet;
 use std::slice;
 
 use elide::detection::Analyzer;
@@ -43,6 +44,7 @@ use elide::redaction::vault::InMemoryVault;
 use elide::{Orchestrator, Result};
 use elide_core::entity::LabelCatalog;
 use elide_core::modality::Modality;
+use elide_core::{Error, ErrorKind};
 #[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
 #[cfg(feature = "internal_image")]
@@ -51,8 +53,9 @@ use elide_core::modality::image::Image;
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_schema::plan::AnalyzerParams;
-use nvisy_schema::policy::PolicyDefinition;
+use nvisy_schema::policy::predicate::Predicate;
 use nvisy_schema::policy::redaction::ModalityRedactions;
+use nvisy_schema::policy::{LabelGroup, PolicyDefinition, PolicyRule};
 use uuid::Uuid;
 
 use super::Engine;
@@ -90,9 +93,11 @@ impl Engine {
         &self,
         spec: &AnalyzerParams,
         policies: &[PolicyDefinition],
+        groups: &[LabelGroup],
         correlation_id: Uuid,
     ) -> Result<(Orchestrator<'_>, AuditContext)> {
-        let catalog = compile_catalog(policies);
+        validate_group_references(policies, groups)?;
+        let catalog = compile_catalog(policies, groups);
         let context = AuditContext {
             languages: spec.scope.languages.clone(),
             countries: spec.scope.countries.clone(),
@@ -154,10 +159,12 @@ impl Engine {
         &self,
         context: &AuditContext,
         policies: &[PolicyDefinition],
+        groups: &[LabelGroup],
         overrides: &[(Uuid, ModalityRedactions)],
         correlation_id: Uuid,
     ) -> Result<Orchestrator<'_>> {
-        let catalog = compile_catalog(policies);
+        validate_group_references(policies, groups)?;
+        let catalog = compile_catalog(policies, groups);
         let live_scope = build_scope(context, catalog.clone(), correlation_id);
 
         // Fresh per-request text-operator context. `Pseudonymize`
@@ -218,6 +225,64 @@ impl Engine {
         let orchestrator = orchestrator.with_modality::<Audio>(Analyzer::<Audio>::new(), anon);
 
         Ok(orchestrator)
+    }
+}
+
+/// Reject a request whose policy set references a
+/// [`LabelGroup`] name that no submitted group provides.
+///
+/// Runs before catalog compilation so an authoring typo
+/// (`"gdpr_arcticle_9"`) surfaces as a
+/// [`Configuration`](ErrorKind::Configuration) error at request
+/// validation time, not as a silent underfire at apply time.
+///
+/// Complexity is O(rules × 1) in practice — the lookup uses a
+/// [`HashSet`] over the request's group names.
+///
+/// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
+fn validate_group_references(
+    policies: &[PolicyDefinition],
+    groups: &[LabelGroup],
+) -> Result<()> {
+    let known: HashSet<&str> = groups.iter().map(|g| g.name.as_str()).collect();
+    for policy in policies {
+        for rule in &policy.rules {
+            for (predicate, _) in rule.attachments() {
+                check_predicate_groups(&predicate, &known, policy, rule)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Walk a predicate tree; every [`Predicate::LabelInGroup`] leaf
+/// must name a known group. Returns the first unknown reference
+/// with policy + rule context for the error message.
+fn check_predicate_groups(
+    predicate: &Predicate,
+    known: &HashSet<&str>,
+    policy: &PolicyDefinition,
+    rule: &PolicyRule,
+) -> Result<()> {
+    match predicate {
+        Predicate::LabelInGroup { group } if !known.contains(group.as_str()) => {
+            Err(Error::new(
+                ErrorKind::Configuration,
+                format!(
+                    "policy `{}` rule `{}` references unknown label group `{}` — \
+                     no `LabelGroup` with that name was submitted with the request",
+                    policy.id, rule.id(), group,
+                ),
+            ))
+        }
+        Predicate::All { all } => all
+            .iter()
+            .try_for_each(|p| check_predicate_groups(p, known, policy, rule)),
+        Predicate::Any { any } => any
+            .iter()
+            .try_for_each(|p| check_predicate_groups(p, known, policy, rule)),
+        Predicate::Not { not } => check_predicate_groups(not, known, policy, rule),
+        _ => Ok(()),
     }
 }
 

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -96,7 +96,7 @@ impl Engine {
         let context = AuditContext {
             languages: spec.scope.languages.clone(),
             countries: spec.scope.countries.clone(),
-            tags: spec.scope.tags.clone(),
+            metadata: spec.scope.metadata.clone(),
             correlation_id,
         };
         let live_scope = build_scope(&context, catalog.clone(), correlation_id);
@@ -228,7 +228,7 @@ fn build_scope(context: &AuditContext, catalog: LabelCatalog, correlation_id: Uu
     Scope {
         languages: context.languages.clone(),
         countries: context.countries.clone(),
-        tags: context.tags.clone(),
+        metadata: context.metadata.clone(),
         catalog,
         correlation_id: Some(correlation_id),
     }

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -39,7 +39,8 @@ use std::slice;
 use elide::detection::Analyzer;
 use elide::recognition::Scope;
 use elide::redaction::Anonymizer;
-use elide::{Error, Orchestrator, Result};
+use elide::redaction::vault::InMemoryVault;
+use elide::{Orchestrator, Result};
 use elide_core::entity::LabelCatalog;
 use elide_core::modality::Modality;
 #[cfg(feature = "internal_audio")]
@@ -57,13 +58,13 @@ use uuid::Uuid;
 use super::Engine;
 use super::audit::AuditContext;
 use crate::analyzer::{AnalyzerCompile, compile_catalog};
+use crate::anonymizer::{TextOperatorContext, attach_override_text, attach_policies_text};
 #[cfg(feature = "internal_audio")]
 use crate::anonymizer::{attach_override_audio, attach_policies_audio};
 #[cfg(feature = "internal_image")]
 use crate::anonymizer::{attach_override_image, attach_policies_image};
 #[cfg(feature = "internal_tabular")]
 use crate::anonymizer::{attach_override_tabular, attach_policies_tabular};
-use crate::anonymizer::{attach_override_text, attach_policies_text};
 
 impl Engine {
     /// Build an [`Orchestrator`] for the analyze path: compile
@@ -159,12 +160,22 @@ impl Engine {
         let catalog = compile_catalog(policies);
         let live_scope = build_scope(context, catalog.clone(), correlation_id);
 
+        // Fresh per-request text-operator context. `Pseudonymize`
+        // resolves consistently within one request via a per-request
+        // vault; `HmacHash`/`Encrypt` share the engine-level key
+        // provider. Cross-request pseudonym consistency is a
+        // durable-vault story (see elide #143).
+        let text_ctx = TextOperatorContext {
+            key_provider: self.key_provider.clone(),
+            pseudonym_vault: InMemoryVault::new(),
+        };
+
         let text_anon = assemble::<Text, _, _>(
             &catalog,
             overrides,
             policies,
-            attach_override_text,
-            attach_policies_text,
+            |anon, id, redactions| attach_override_text(anon, id, redactions, &text_ctx),
+            |anon, policies| attach_policies_text(anon, policies, &text_ctx),
         )?;
 
         let orchestrator = Orchestrator::new(&self.formats)
@@ -177,8 +188,8 @@ impl Engine {
                 &catalog,
                 overrides,
                 policies,
-                attach_override_tabular,
-                attach_policies_tabular,
+                |anon, id, redactions| attach_override_tabular(anon, id, redactions, &text_ctx),
+                |anon, policies| attach_policies_tabular(anon, policies, &text_ctx),
             )?;
             orchestrator.with_modality::<Tabular>(Analyzer::<Tabular>::new(), anon)
         };
@@ -196,16 +207,15 @@ impl Engine {
         };
 
         #[cfg(feature = "internal_audio")]
-        let orchestrator = {
-            let anon = assemble::<Audio, _, _>(
-                &catalog,
-                overrides,
-                policies,
-                attach_override_audio,
-                attach_policies_audio,
-            )?;
-            orchestrator.with_modality::<Audio>(Analyzer::<Audio>::new(), anon)
-        };
+        let anon = assemble::<Audio, _, _>(
+            &catalog,
+            overrides,
+            policies,
+            attach_override_audio,
+            attach_policies_audio,
+        )?;
+        #[cfg(feature = "internal_audio")]
+        let orchestrator = orchestrator.with_modality::<Audio>(Analyzer::<Audio>::new(), anon);
 
         Ok(orchestrator)
     }
@@ -253,8 +263,8 @@ fn assemble<'a, M, O, P>(
 ) -> Result<Anonymizer<M>>
 where
     M: Modality + 'static,
-    O: Fn(Anonymizer<M>, Uuid, &ModalityRedactions) -> Result<Anonymizer<M>, Error>,
-    P: FnOnce(Anonymizer<M>, slice::Iter<'a, PolicyDefinition>) -> Result<Anonymizer<M>, Error>,
+    O: Fn(Anonymizer<M>, Uuid, &ModalityRedactions) -> Result<Anonymizer<M>>,
+    P: FnOnce(Anonymizer<M>, slice::Iter<'a, PolicyDefinition>) -> Result<Anonymizer<M>>,
 {
     let mut anonymizer = Anonymizer::<M>::new().with_catalog(catalog.clone());
     for (id, action) in overrides {

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -214,15 +214,16 @@ impl Engine {
         };
 
         #[cfg(feature = "internal_audio")]
-        let anon = assemble::<Audio, _, _>(
-            &catalog,
-            overrides,
-            policies,
-            attach_override_audio,
-            attach_policies_audio,
-        )?;
-        #[cfg(feature = "internal_audio")]
-        let orchestrator = orchestrator.with_modality::<Audio>(Analyzer::<Audio>::new(), anon);
+        let orchestrator = {
+            let anon = assemble::<Audio, _, _>(
+                &catalog,
+                overrides,
+                policies,
+                attach_override_audio,
+                attach_policies_audio,
+            )?;
+            orchestrator.with_modality::<Audio>(Analyzer::<Audio>::new(), anon)
+        };
 
         Ok(orchestrator)
     }

--- a/crates/nvisy-engine/tests/audit.rs
+++ b/crates/nvisy-engine/tests/audit.rs
@@ -115,8 +115,7 @@ async fn write_entities_csv_has_header_and_one_row_per_entity() {
     let mut lines = output.lines();
     let header = lines.next().expect("header line present");
     assert_eq!(
-        header,
-        "part_id,modality,entity_id,label,confidence,coref",
+        header, "part_id,modality,entity_id,label,confidence,coref",
         "column order matches the row struct",
     );
 

--- a/crates/nvisy-engine/tests/audit.rs
+++ b/crates/nvisy-engine/tests/audit.rs
@@ -52,7 +52,7 @@ fn default_spec() -> AnalyzerParams {
 
 async fn analyze() -> Audit {
     engine()
-        .analyze(raw_txt(), &[], &default_spec())
+        .analyze(raw_txt(), &[], &[], &default_spec())
         .await
         .expect("analyze succeeds")
 }

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -153,7 +153,7 @@ async fn audit_context_mirrors_spec_scope_and_carries_correlation_id() {
     let engine = engine();
 
     let mut spec = default_spec();
-    spec.scope.tags = vec!["gdpr-request".to_owned()];
+    spec.scope.metadata.tags = vec!["gdpr-request".into()];
     let doc = raw_docx();
     let correlation_id = doc.correlation_id;
 
@@ -163,7 +163,7 @@ async fn audit_context_mirrors_spec_scope_and_carries_correlation_id() {
         .expect("analyze succeeds");
 
     assert_eq!(
-        audit.context.tags, spec.scope.tags,
+        audit.context.metadata.tags, spec.scope.metadata.tags,
         "audit context must mirror the caller-asserted scope tags",
     );
     assert_eq!(
@@ -231,7 +231,7 @@ async fn empty_analyzed_document_anonymize_fails_validation() {
         context: AuditContext {
             languages: Default::default(),
             countries: Vec::new(),
-            tags: Vec::new(),
+            metadata: Default::default(),
             correlation_id: uuid::Uuid::now_v7(),
         },
     };

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -67,7 +67,7 @@ fn read_zip_entry(buf: &[u8], name: &str) -> Option<Vec<u8>> {
 async fn analyze_captures_text_body_and_image_part() {
     let engine = engine();
     let analyzed = engine
-        .analyze(raw_docx(), &[], &default_spec())
+        .analyze(raw_docx(), &[], &[], &default_spec())
         .await
         .expect("analyze succeeds");
 
@@ -97,7 +97,7 @@ async fn analyze_captures_text_body_and_image_part() {
 async fn anonymize_redacts_targeted_entity_and_preserves_other_parts() {
     let engine = engine();
     let mut analyzed = engine
-        .analyze(raw_docx(), &[], &default_spec())
+        .analyze(raw_docx(), &[], &[], &default_spec())
         .await
         .expect("analyze succeeds");
     let body_group = analyzed.body.as_ref().expect("body group present");
@@ -124,7 +124,7 @@ async fn anonymize_redacts_targeted_entity_and_preserves_other_parts() {
     });
 
     let outcome = engine
-        .anonymize(raw_docx(), &[], &mut analyzed)
+        .anonymize(raw_docx(), &[], &[], &mut analyzed)
         .await
         .expect("anonymize succeeds");
     write_artefact("sample", "out.docx", &outcome.bytes);
@@ -158,7 +158,7 @@ async fn audit_context_mirrors_spec_scope_and_carries_correlation_id() {
     let correlation_id = doc.correlation_id;
 
     let audit = engine
-        .analyze(doc, &[], &spec)
+        .analyze(doc, &[], &[], &spec)
         .await
         .expect("analyze succeeds");
 
@@ -190,12 +190,12 @@ async fn anonymize_succeeds_when_policies_supply_catalog_afresh() {
         retention: Vec::new(),
     };
     let mut analyzed = engine
-        .analyze(raw_docx(), std::slice::from_ref(&policy), &default_spec())
+        .analyze(raw_docx(), std::slice::from_ref(&policy), &[], &default_spec())
         .await
         .expect("analyze succeeds");
 
     engine
-        .anonymize(raw_docx(), std::slice::from_ref(&policy), &mut analyzed)
+        .anonymize(raw_docx(), std::slice::from_ref(&policy), &[], &mut analyzed)
         .await
         .expect("anonymize succeeds when catalog is re-derived from the same policy set");
 }
@@ -204,7 +204,7 @@ async fn anonymize_succeeds_when_policies_supply_catalog_afresh() {
 async fn audit_rejects_missing_context_on_deserialize() {
     let engine = engine();
     let analyzed = engine
-        .analyze(raw_docx(), &[], &default_spec())
+        .analyze(raw_docx(), &[], &[], &default_spec())
         .await
         .expect("analyze succeeds");
     let mut value = serde_json::to_value(&analyzed).expect("serialize");
@@ -223,6 +223,51 @@ async fn audit_rejects_missing_context_on_deserialize() {
 }
 
 #[tokio::test]
+async fn analyze_rejects_policy_that_references_unknown_group() {
+    use nvisy_schema::policy::predicate::Predicate;
+    use nvisy_schema::policy::redaction::TextRedaction;
+    use nvisy_schema::policy::{PolicyRule, PredicatedRule};
+
+    let engine = engine();
+    let rule = PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: uuid::Uuid::now_v7(),
+        name: "sweep".into(),
+        description: None,
+        predicate: Predicate::LabelInGroup {
+            group: "definitely_no_such_group".to_owned(),
+        },
+        action: ModalityRedactions {
+            text: Some(TextRedaction::Erase),
+            ..Default::default()
+        },
+    }));
+    let policy = PolicyDefinition {
+        id: uuid::Uuid::now_v7(),
+        name: "unknown-group".into(),
+        description: None,
+        when: None,
+        labels: Labels::default(),
+        rules: vec![rule],
+        fallback: None,
+        retention: Vec::new(),
+    };
+
+    let err = engine
+        .analyze(
+            raw_docx(),
+            std::slice::from_ref(&policy),
+            &[],
+            &default_spec(),
+        )
+        .await
+        .expect_err("analyze must reject unknown group references");
+    assert!(
+        err.to_string().contains("definitely_no_such_group"),
+        "error must name the unknown group, got: {err}",
+    );
+}
+
+#[tokio::test]
 async fn empty_analyzed_document_anonymize_fails_validation() {
     let engine = engine();
     let mut audit = Audit {
@@ -235,7 +280,7 @@ async fn empty_analyzed_document_anonymize_fails_validation() {
             correlation_id: uuid::Uuid::now_v7(),
         },
     };
-    let outcome = engine.anonymize(raw_docx(), &[], &mut audit).await;
+    let outcome = engine.anonymize(raw_docx(), &[], &[], &mut audit).await;
     let err = outcome.expect_err("anonymize must reject a missing body group");
     assert!(
         err.to_string().contains("body group is missing"),

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -154,6 +154,8 @@ async fn audit_context_mirrors_spec_scope_and_carries_correlation_id() {
 
     let mut spec = default_spec();
     spec.scope.metadata.tags = vec!["gdpr-request".into()];
+    spec.scope.metadata.purpose = Some("dsar-response".into());
+    spec.scope.metadata.audience = vec!["data-subject".into(), "compliance-review".into()];
     let doc = raw_docx();
     let correlation_id = doc.correlation_id;
 
@@ -165,6 +167,14 @@ async fn audit_context_mirrors_spec_scope_and_carries_correlation_id() {
     assert_eq!(
         audit.context.metadata.tags, spec.scope.metadata.tags,
         "audit context must mirror the caller-asserted scope tags",
+    );
+    assert_eq!(
+        audit.context.metadata.purpose, spec.scope.metadata.purpose,
+        "audit context must mirror the caller-asserted scope purpose",
+    );
+    assert_eq!(
+        audit.context.metadata.audience, spec.scope.metadata.audience,
+        "audit context must mirror the caller-asserted scope audience",
     );
     assert_eq!(
         audit.context.correlation_id, correlation_id,

--- a/crates/nvisy-engine/tests/patterns.rs
+++ b/crates/nvisy-engine/tests/patterns.rs
@@ -65,7 +65,7 @@ async fn custom_regex_produces_entity_with_caller_label() {
     });
 
     let analyzed = engine
-        .analyze(raw_docx(), &[], &spec)
+        .analyze(raw_docx(), &[], &[], &spec)
         .await
         .expect("analyze succeeds");
 
@@ -103,7 +103,7 @@ async fn custom_dictionary_produces_entity_with_caller_label() {
     });
 
     let analyzed = engine
-        .analyze(raw_docx(), &[], &spec)
+        .analyze(raw_docx(), &[], &[], &spec)
         .await
         .expect("analyze succeeds");
 
@@ -153,7 +153,7 @@ async fn too_many_custom_rules_rejects_at_analyze() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &spec)
+        .analyze(raw_docx(), &[], &[], &spec)
         .await
         .expect_err("33 rules must exceed the per-request cap");
     let msg = err.to_string();
@@ -183,7 +183,7 @@ async fn tightened_rule_count_guardrail_takes_effect() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &spec)
+        .analyze(raw_docx(), &[], &[], &spec)
         .await
         .expect_err("5 rules must exceed a tightened cap of 4");
     let msg = err.to_string();
@@ -211,7 +211,7 @@ async fn tightened_regex_source_len_guardrail_takes_effect() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &spec)
+        .analyze(raw_docx(), &[], &[], &spec)
         .await
         .expect_err("60-byte source must exceed a tightened cap of 16 bytes");
     let msg = err.to_string();
@@ -246,7 +246,7 @@ async fn regex_source_len_config_above_ceiling_is_clamped() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &spec)
+        .analyze(raw_docx(), &[], &[], &spec)
         .await
         .expect_err("engine must clamp max_regex_source_len to the wire ceiling");
     let msg = err.to_string();

--- a/crates/nvisy-engine/tests/policy_shapes.rs
+++ b/crates/nvisy-engine/tests/policy_shapes.rs
@@ -1,0 +1,236 @@
+//! End-to-end tests for the wire shapes in [`nvisy_schema::policy`]:
+//! per-label table rules, label-group predicates, and any other
+//! policy-side sugar the engine flattens at compile time.
+//!
+//! Runs against the plaintext sample so assertions can inspect the
+//! per-entity provenance chain directly.
+
+use bytes::Bytes;
+use elide_core::entity::LabelRef;
+use elide_core::entity::provenance::EventKind;
+use nvisy_engine::{Audit, Engine, EntityGroup};
+use nvisy_schema::file::Document;
+use nvisy_schema::plan::{
+    AnalyzerParams, EnricherParams, PatternRecognizerParams, ProviderSelection, RecognizerParams,
+    ScopeParams,
+};
+use nvisy_schema::policy::predicate::Predicate;
+use nvisy_schema::policy::redaction::{ModalityRedactions, TextRedaction};
+use nvisy_schema::policy::{
+    LabelEntry, LabelGroup, Labels, PolicyDefinition, PolicyRule, PredicatedRule, TableRule,
+};
+
+const SAMPLE_TXT: &[u8] = include_bytes!("testdata/sample.txt");
+
+fn engine() -> Engine {
+    Engine::new()
+}
+
+fn raw_txt() -> Document {
+    Document::new(Bytes::from_static(SAMPLE_TXT), "txt")
+}
+
+fn default_spec() -> AnalyzerParams {
+    AnalyzerParams {
+        recognizers: RecognizerParams {
+            pattern: Some(PatternRecognizerParams {
+                builtins: true,
+                context_enhanced: true,
+                ..Default::default()
+            }),
+            ner: Some(ProviderSelection::All(false)),
+            llm: Some(ProviderSelection::All(false)),
+        },
+        enrichers: EnricherParams::default(),
+        deduplication: Default::default(),
+        scope: ScopeParams::default(),
+        annotations: Default::default(),
+    }
+}
+
+/// Count redaction events on every text-modality entity of
+/// `audit.body` whose label matches `label`. A redaction event is
+/// stamped once per operator run, so this is the number of
+/// operator hits on the labeled entities.
+fn redaction_hits(audit: &Audit, label: &str) -> usize {
+    let Some(EntityGroup::Text(entities)) = audit.body.as_ref() else {
+        return 0;
+    };
+    entities
+        .iter()
+        .filter(|r| r.entity.label.as_str() == label)
+        .flat_map(|r| r.entity.provenance.events.iter())
+        .filter(|e| matches!(e.kind, EventKind::Redaction { .. }))
+        .count()
+}
+
+/// Assert that a `TableRule` routes each label to its paired
+/// operator: both email and phone entities in the sample get a
+/// redaction event, driven by the table under one shared UUID.
+#[tokio::test]
+async fn table_rule_dispatches_per_label_under_one_identity() {
+    let engine = engine();
+    let rule_id = uuid::Uuid::now_v7();
+    let table = PolicyRule::Table(TableRule {
+        id: rule_id,
+        name: "contact-sweep".into(),
+        description: None,
+        operators: vec![
+            LabelEntry {
+                label: LabelRef::new("email_address"),
+                action: ModalityRedactions {
+                    text: Some(TextRedaction::Erase),
+                    ..Default::default()
+                },
+            },
+            LabelEntry {
+                label: LabelRef::new("phone_number"),
+                action: ModalityRedactions {
+                    text: Some(TextRedaction::Replace {
+                        template: "[phone]".to_owned(),
+                    }),
+                    ..Default::default()
+                },
+            },
+        ],
+    });
+    let policy = PolicyDefinition {
+        id: uuid::Uuid::now_v7(),
+        name: "contact-info".into(),
+        description: None,
+        when: None,
+        labels: Labels {
+            builtins: vec![LabelRef::new("email_address"), LabelRef::new("phone_number")],
+            custom: Vec::new(),
+        },
+        rules: vec![table],
+        fallback: None,
+        retention: Vec::new(),
+    };
+
+    let mut analyzed = engine
+        .analyze(
+            raw_txt(),
+            std::slice::from_ref(&policy),
+            &[],
+            &default_spec(),
+        )
+        .await
+        .expect("analyze succeeds");
+    engine
+        .anonymize(
+            raw_txt(),
+            std::slice::from_ref(&policy),
+            &[],
+            &mut analyzed,
+        )
+        .await
+        .expect("anonymize succeeds");
+
+    assert!(
+        redaction_hits(&analyzed, "email_address") >= 1,
+        "email entries in the sample should each get a redaction event",
+    );
+    assert!(
+        redaction_hits(&analyzed, "phone_number") >= 1,
+        "phone entries in the sample should each get a redaction event",
+    );
+    // Both branches share the same rule UUID via elide's Attribution.
+    // Cross-verify one entity's attribution names the table rule.
+    let Some(EntityGroup::Text(entities)) = analyzed.body.as_ref() else {
+        panic!("expected text body");
+    };
+    let sample_event = entities
+        .iter()
+        .find(|r| r.entity.label.as_str() == "email_address")
+        .and_then(|r| {
+            r.entity
+                .provenance
+                .events
+                .iter()
+                .find_map(|e| match &e.kind {
+                    EventKind::Redaction { attribution, .. } => attribution.as_ref(),
+                    _ => None,
+                })
+        })
+        .expect("email entity must have a redaction event with an attribution");
+    assert_eq!(
+        sample_event.description.as_deref(),
+        Some(rule_id.to_string().as_str()),
+        "attribution.description must carry the shared rule UUID",
+    );
+}
+
+/// A `Predicate::LabelInGroup` predicate drives the same redaction
+/// path as a `TagOneOf` over the synthetic `group:<name>` tag —
+/// asserts the group compilation and predicate rewrite are wired
+/// end-to-end.
+#[tokio::test]
+async fn label_in_group_predicate_fires_on_grouped_labels() {
+    let engine = engine();
+    let policy = PolicyDefinition {
+        id: uuid::Uuid::now_v7(),
+        name: "sweep".into(),
+        description: None,
+        when: None,
+        labels: Labels {
+            builtins: vec![LabelRef::new("email_address"), LabelRef::new("phone_number")],
+            custom: Vec::new(),
+        },
+        rules: vec![PolicyRule::Predicated(Box::new(PredicatedRule {
+            id: uuid::Uuid::now_v7(),
+            name: "erase-contacts".into(),
+            description: None,
+            predicate: Predicate::LabelInGroup {
+                group: "contact_info".to_owned(),
+            },
+            action: ModalityRedactions {
+                text: Some(TextRedaction::Erase),
+                ..Default::default()
+            },
+        }))],
+        fallback: None,
+        retention: Vec::new(),
+    };
+    let group = LabelGroup {
+        name: "contact_info".into(),
+        description: None,
+        labels: vec![LabelRef::new("email_address"), LabelRef::new("phone_number")],
+    };
+
+    let mut analyzed = engine
+        .analyze(
+            raw_txt(),
+            std::slice::from_ref(&policy),
+            std::slice::from_ref(&group),
+            &default_spec(),
+        )
+        .await
+        .expect("analyze succeeds");
+    engine
+        .anonymize(
+            raw_txt(),
+            std::slice::from_ref(&policy),
+            std::slice::from_ref(&group),
+            &mut analyzed,
+        )
+        .await
+        .expect("anonymize succeeds");
+
+    assert!(
+        redaction_hits(&analyzed, "email_address") >= 1,
+        "email entries fall in the group and must be redacted",
+    );
+    assert!(
+        redaction_hits(&analyzed, "phone_number") >= 1,
+        "phone entries fall in the group and must be redacted",
+    );
+    // Not asserting "non-group labels untouched" here: elide
+    // clusters overlapping detections and stamps the winner's
+    // redaction event on every cluster member, so a non-group
+    // label overlapping a group-label detection can carry a
+    // redaction event without being *matched* by the group rule.
+    // The positive checks above are sufficient to prove the
+    // group predicate wired through the compile path.
+}
+

--- a/crates/nvisy-engine/tests/policy_shapes.rs
+++ b/crates/nvisy-engine/tests/policy_shapes.rs
@@ -117,7 +117,7 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
         )
         .await
         .expect("analyze succeeds");
-    engine
+    let redacted = engine
         .anonymize(
             raw_txt(),
             std::slice::from_ref(&policy),
@@ -135,12 +135,27 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
         redaction_hits(&analyzed, "phone_number") >= 1,
         "phone entries in the sample should each get a redaction event",
     );
-    // Both branches share the same rule UUID via elide's Attribution.
-    // Cross-verify one entity's attribution names the table rule.
+
+    // The interesting invariant: each label routes to *its own*
+    // operator. Inspect the redacted body — the phone entries must
+    // read `[phone]` (Replace template), and the raw email address
+    // must be gone (Erase). Both are strong enough that a bug
+    // routing everything through one operator would trip them.
+    let body = std::str::from_utf8(&redacted.bytes).expect("body is utf-8");
+    assert!(
+        body.contains("[phone]"),
+        "phone entries must render as the Replace template `[phone]`; body was:\n{body}",
+    );
+    assert!(
+        !body.contains("jane.doe@example.com"),
+        "email entries must be erased, not replaced; body was:\n{body}",
+    );
+
+    // Attribution: both branches share the shared rule UUID.
     let Some(EntityGroup::Text(entities)) = analyzed.body.as_ref() else {
         panic!("expected text body");
     };
-    let sample_event = entities
+    let attribution = entities
         .iter()
         .find(|r| r.entity.label.as_str() == "email_address")
         .and_then(|r| {
@@ -155,7 +170,7 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
         })
         .expect("email entity must have a redaction event with an attribution");
     assert_eq!(
-        sample_event.description.as_deref(),
+        attribution.description.as_deref(),
         Some(rule_id.to_string().as_str()),
         "attribution.description must carry the shared rule UUID",
     );

--- a/crates/nvisy-policy/Cargo.toml
+++ b/crates/nvisy-policy/Cargo.toml
@@ -25,6 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 # Elide crates
 elide-core = { workspace = true, features = ["serde", "schema", "audio"] }
+elide-redaction = { workspace = true, features = ["serde", "schema", "datetime"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nvisy-policy/Cargo.toml
+++ b/crates/nvisy-policy/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 # Elide crates
 elide-core = { workspace = true, features = ["serde", "schema", "audio"] }
-elide-redaction = { workspace = true, features = ["serde", "schema", "datetime"] }
+elide-redaction = { workspace = true, features = ["serde", "schema", "datetime", "sha2"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nvisy-policy/src/label.rs
+++ b/crates/nvisy-policy/src/label.rs
@@ -1,26 +1,29 @@
-//! Per-policy label catalog: the vocabulary the policy's rules
-//! and predicates operate over.
+//! Per-policy label catalog vocabulary and per-request named
+//! label groups.
 //!
-//! Two distinct sources the engine unions into one
-//! `elide_core::entity::LabelCatalog` at request-compile time:
+//! Two shapes:
 //!
-//! - [`builtins`]: names of labels from `elide-core`'s shipped
-//!   builtin set (`LabelCatalog::with_builtins`). Engine looks
-//!   each name up against the full builtin catalog and copies
-//!   the matching [`Label`] across; unknown names log a warning
-//!   and are skipped (typos don't fail the request).
-//! - [`custom`]: schemas the caller defined inline, beyond the
-//!   builtin set. Names that collide with a builtin replace it
-//!   (last write wins, matching `LabelCatalog::insert` semantics).
+//! - [`Labels`] — carried on each [`PolicyDefinition`]. Selects
+//!   builtins from elide-core's shipped set and adds inline
+//!   custom schemas. The engine unions every submitted policy's
+//!   `labels` into one `elide_core::entity::LabelCatalog` at
+//!   request-compile time.
+//! - [`LabelGroup`] — a named cluster of [`LabelRef`]s shared
+//!   across a request. Templates ship groups (`"hipaa_18"`,
+//!   `"gdpr_article_9"`, `"pci_chd"`); rules reference groups by
+//!   name via [`Predicate::LabelInGroup`]. Engine synthesises a
+//!   `group:<name>` tag on every listed label at request time
+//!   and rewrites [`LabelInGroup`] to
+//!   [`TagOneOf`]`{ tags: ["group:<name>"] }` — same fast path
+//!   as any tag-based rule.
 //!
-//! Empty default. Every submitted [`PolicyDefinition`]'s labels
-//! union at request time to form the analyzer's per-run catalog.
-//!
-//! [`builtins`]: Labels::builtins
-//! [`custom`]: Labels::custom
 //! [`PolicyDefinition`]: super::PolicyDefinition
+//! [`Predicate::LabelInGroup`]: super::predicate::Predicate::LabelInGroup
+//! [`LabelInGroup`]: super::predicate::Predicate::LabelInGroup
+//! [`TagOneOf`]: super::predicate::Predicate::TagOneOf
 
 use elide_core::entity::{Label, LabelRef};
+use hipstr::HipStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -47,4 +50,63 @@ impl Labels {
     pub fn is_empty(&self) -> bool {
         self.builtins.is_empty() && self.custom.is_empty()
     }
+}
+
+/// Named cluster of [`LabelRef`]s a policy predicate can reference
+/// by name via [`Predicate::LabelInGroup`].
+///
+/// Groups are the primitive regulatory templates compose on top
+/// of: a template ships one group per canonical label list
+/// (`"hipaa_18"`, `"gdpr_article_9"`, `"pci_chd"`, `"pci_sad"`),
+/// and every rule that targets that list references the group by
+/// name instead of respelling the labels. When elide adds a new
+/// label to a category, extending the group covers every rule
+/// that referenced it — no policy edit.
+///
+/// **Compilation**: at request time the engine synthesises a
+/// `group:<name>` tag on every label listed in the group, then
+/// rewrites [`Predicate::LabelInGroup { group }`] into
+/// [`Predicate::TagOneOf { tags: ["group:<name>"] }`]. That
+/// routes through the same `Anonymizer::with_tag` fast path as
+/// any authored tag — no new engine machinery, no per-request
+/// walk over group membership.
+///
+/// **Unknown group names error at request validation**, not at
+/// apply time. A typo doesn't silently underfire.
+///
+/// Groups are per-request, not per-policy: the caller (or a
+/// template loader) submits a `Vec<LabelGroup>` alongside the
+/// policy set. This keeps groups reusable across policies within
+/// one request and keeps them out of individual `PolicyDefinition`
+/// wire payloads.
+///
+/// [`Predicate::LabelInGroup`]: super::predicate::Predicate::LabelInGroup
+/// [`Predicate::LabelInGroup { group }`]: super::predicate::Predicate::LabelInGroup
+/// [`Predicate::TagOneOf { tags: ["group:<name>"] }`]: super::predicate::Predicate::TagOneOf
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelGroup {
+    /// Stable name a [`Predicate::LabelInGroup`] references.
+    ///
+    /// Free-form; a policy layer picks the vocabulary. Recommend
+    /// snake_case identifiers (`hipaa_18`, `gdpr_article_9`) —
+    /// they compile to `group:hipaa_18` tags on the catalog and
+    /// read cleanly in audit provenance.
+    ///
+    /// [`Predicate::LabelInGroup`]: super::predicate::Predicate::LabelInGroup
+    #[schemars(with = "String")]
+    pub name: HipStr<'static>,
+    /// Optional description for reviewers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Labels this group covers, by ref.
+    ///
+    /// A label that doesn't appear in the request's compiled
+    /// [`LabelCatalog`] is silently skipped at tag-synthesis time
+    /// — a group can safely list labels the current build
+    /// doesn't emit (e.g. modality-gated ones); rules keyed off
+    /// the group still fire on whatever labels *are* present.
+    ///
+    /// [`LabelCatalog`]: elide_core::entity::LabelCatalog
+    pub labels: Vec<LabelRef>,
 }

--- a/crates/nvisy-policy/src/lib.rs
+++ b/crates/nvisy-policy/src/lib.rs
@@ -6,22 +6,45 @@
 //!
 //! Authored vocabulary for redaction governance.
 //!
-//! A request submits `Vec<PolicyDefinition>` in precedence order. Engine
-//! walks them; for each policy whose [`PolicyDefinition::when`]
-//! holds against the document, it walks [`PolicyDefinition::rules`] in
-//! order and runs the first matching rule's redaction operators. If
-//! no rule in a policy matches, the policy's [`PolicyDefinition::fallback`]
-//! runs (and the chain halts) if set; otherwise the engine moves
-//! to the next policy. If no policy matches and no policy
-//! carries a fallback, the entity is skipped.
+//! A request submits `Vec<PolicyDefinition>` in precedence order,
+//! plus a `Vec<LabelGroup>` shared across every policy. Engine
+//! walks the policies; for each policy whose
+//! [`PolicyDefinition::when`] holds against the document, it walks
+//! [`PolicyDefinition::rules`] in order and runs the first matching
+//! rule's redaction operators. If no rule in a policy matches, the
+//! policy's [`PolicyDefinition::fallback`] runs (and the chain
+//! halts) if set; otherwise the engine moves to the next policy.
+//! If no policy matches and no policy carries a fallback, the
+//! entity is skipped.
 //!
-//! Identity is UUID-keyed: every [`PolicyDefinition`] and every [`PolicyRule`]
-//! carries a stable [`Uuid`]. Engine stamps `policy.id` and
-//! `rule.id` into the redaction event's [`Attribution`] so
-//! reviewers can trace any redaction back to the exact rule that
-//! fired.
+//! Rules have two shapes ([`PolicyRule`]):
+//! - [`Predicated`]: one composable [`Predicate`] gates a single
+//!   [`ModalityRedactions`] action.
+//! - [`Table`]: a list of per-label [`LabelEntry`] entries — the
+//!   compile-time sugar for "route each label to its own operator
+//!   under one shared rule identity" (e.g. HIPAA Safe Harbor
+//!   fan-out).
+//!
+//! [`LabelGroup`]s are named clusters of [`LabelRef`]s a
+//! [`Predicate::LabelInGroup`] references by name. Templates ship
+//! groups (`"hipaa_18"`, `"gdpr_article_9"`); rules reference
+//! them without respelling the label list. At request-compile
+//! time the engine stamps `group:<name>` tags on the listed
+//! labels; unknown group names error at validation.
+//!
+//! Identity is UUID-keyed: every [`PolicyDefinition`] and every
+//! [`PolicyRule`] carries a stable [`Uuid`]. Engine stamps
+//! `policy.id` and `rule.id` into the redaction event's
+//! [`Attribution`] so reviewers can trace any redaction back to
+//! the exact rule that fired.
 //!
 //! [`Attribution`]: elide_core::entity::provenance::Attribution
+//! [`LabelRef`]: elide_core::entity::LabelRef
+//! [`ModalityRedactions`]: redaction::ModalityRedactions
+//! [`Predicate`]: predicate::Predicate
+//! [`Predicate::LabelInGroup`]: predicate::Predicate::LabelInGroup
+//! [`Predicated`]: PolicyRule::Predicated
+//! [`Table`]: PolicyRule::Table
 
 mod label;
 pub mod predicate;
@@ -34,7 +57,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub use self::label::Labels;
+pub use self::label::{LabelGroup, Labels};
 use self::predicate::DocumentPredicate;
 use self::redaction::ModalityRedactions;
 use self::retention::RetentionPolicy;

--- a/crates/nvisy-policy/src/lib.rs
+++ b/crates/nvisy-policy/src/lib.rs
@@ -38,7 +38,7 @@ pub use self::label::Labels;
 use self::predicate::DocumentPredicate;
 use self::redaction::ModalityRedactions;
 use self::retention::RetentionPolicy;
-pub use self::rule::PolicyRule;
+pub use self::rule::{LabelEntry, PolicyRule, PredicatedRule, TableRule};
 
 /// A named governance policy.
 ///
@@ -49,10 +49,10 @@ pub struct PolicyDefinition {
     /// Stable identifier. UUIDv7 recommended (time-ordered);
     /// customer-supplied so re-submissions carry the same id.
     /// Engine stamps this into the redaction event's
-    /// [`Attribution::policy_id`] so reviewers can find this
-    /// policy from any redaction it drove.
+    /// [`Attribution::name`] so reviewers can find this policy
+    /// from any redaction it drove.
     ///
-    /// [`Attribution::policy_id`]: elide_core::entity::provenance::Attribution::policy_id
+    /// [`Attribution::name`]: elide_core::entity::provenance::Attribution::name
     pub id: Uuid,
     /// Human-readable name. Display-only. Does not key anything.
     #[schemars(with = "String")]

--- a/crates/nvisy-policy/src/predicate/mod.rs
+++ b/crates/nvisy-policy/src/predicate/mod.rs
@@ -10,17 +10,20 @@
 //!   against the document-level facts (labels, metadata,
 //!   language, etc.).
 //!
-//! Both are serialisable. Engine compiles a `Predicate` into a
-//! closure passed to
-//! `elide::redaction::Anonymizer::with_catalog_predicate` (or
-//! routed to [`with_label`] / [`with_tag`] fast paths for the
-//! degenerate single-label / single-tag shapes). Leaf variants
-//! inspect entity facts; the composing variants
-//! ([`Predicate::All`], [`Predicate::Any`], [`Predicate::Not`])
-//! wire boolean algebra over them.
+//! Both are serialisable. Engine compiles a `Predicate` into an
+//! elide [`Rule`]: single-label predicates route through
+//! [`Rule::label`], single-tag through [`Rule::tag`], and
+//! everything else through [`Rule::predicate`] with a closure
+//! over the [`MatchContext`]. Leaf variants inspect entity
+//! facts; the composing variants ([`Predicate::All`],
+//! [`Predicate::Any`], [`Predicate::Not`]) wire boolean algebra
+//! over them.
 //!
-//! [`with_label`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_label
-//! [`with_tag`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_tag
+//! [`Rule`]: https://docs.rs/elide/latest/elide/redaction/struct.Rule.html
+//! [`Rule::label`]: https://docs.rs/elide/latest/elide/redaction/struct.Rule.html#method.label
+//! [`Rule::tag`]: https://docs.rs/elide/latest/elide/redaction/struct.Rule.html#method.tag
+//! [`Rule::predicate`]: https://docs.rs/elide/latest/elide/redaction/struct.Rule.html#method.predicate
+//! [`MatchContext`]: https://docs.rs/elide/latest/elide/redaction/struct.MatchContext.html
 
 mod document;
 
@@ -52,6 +55,28 @@ pub enum Predicate {
     TagOneOf {
         /// Allowed tags.
         tags: Vec<String>,
+    },
+    /// Entity label is in the named [`LabelGroup`] submitted
+    /// alongside this request.
+    ///
+    /// Sugar over [`TagOneOf`]`{ tags: ["group:<name>"] }`: the
+    /// engine synthesises a `group:<name>` tag on every label
+    /// listed in the matching group at request-compile time, then
+    /// rewrites `LabelInGroup { group }` to that `TagOneOf` form.
+    /// Same fast path as any authored tag; the group indirection
+    /// keeps the wire compact when templates target a canonical
+    /// label cluster (e.g. `hipaa_18`, `gdpr_article_9`).
+    ///
+    /// An unknown group name is a request-validation error, not a
+    /// silent no-op.
+    ///
+    /// [`LabelGroup`]: super::LabelGroup
+    /// [`TagOneOf`]: Predicate::TagOneOf
+    LabelInGroup {
+        /// Name of the [`LabelGroup`] to match against.
+        ///
+        /// [`LabelGroup`]: super::LabelGroup
+        group: String,
     },
     /// Entity carries the given coreference cluster id.
     CoRef {

--- a/crates/nvisy-policy/src/redaction/audio.rs
+++ b/crates/nvisy-policy/src/redaction/audio.rs
@@ -20,8 +20,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Operator spec a `redact` audio rule carries.
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AudioRedaction {
     /// Cut the matched interval out, shortening the clip.

--- a/crates/nvisy-policy/src/redaction/image.rs
+++ b/crates/nvisy-policy/src/redaction/image.rs
@@ -17,8 +17,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Operator spec a `redact` image rule carries.
-#[derive(Debug, Clone, PartialEq)]
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ImageRedaction {
     /// Clear the matched region.

--- a/crates/nvisy-policy/src/redaction/mod.rs
+++ b/crates/nvisy-policy/src/redaction/mod.rs
@@ -6,11 +6,13 @@
 //! override boundary.
 //!
 //! Each modality has its own enum because the operator catalogue
-//! differs by modality. Text gets the full elide built-in set
-//! ([`Replace`], [`Mask`], [`Hash`], [`Erase`], [`Keep`]) plus a
-//! `Custom` escape hatch. Image / Audio / Tabular currently expose
-//! only `Custom`; elide ships no built-in operators wired into the
-//! policy wire format for those modalities.
+//! differs by modality. Text carries the full elide built-in set
+//! ([`Erase`], [`Keep`], [`Mask`], [`Replace`], [`Hash`], [`Fake`],
+//! [`Pseudonymize`], [`Encrypt`], [`HmacHash`], [`Truncate`],
+//! [`Clamp`], [`GeneralizeDate`], and the [`WithFallback`] wrapper).
+//! Image, audio, and tabular each carry their own operator sets
+//! (blur/pixelate/blackbox for image, silence/beep for audio,
+//! drop-row/drop-column plus cell-level text ops for tabular).
 //!
 //! The split between these enums (the spec) and elide's
 //! [`Operator<M>`] trait is intentional: the spec is the
@@ -18,11 +20,19 @@
 //! variant into the matching runtime operator instance at apply
 //! time.
 //!
-//! [`Replace`]: https://docs.rs/elide/latest/elide/redaction/operators/Replace
-//! [`Mask`]: https://docs.rs/elide/latest/elide/redaction/operators/Mask
-//! [`Hash`]: https://docs.rs/elide/latest/elide/redaction/operators/Sha2Hash
-//! [`Erase`]: https://docs.rs/elide/latest/elide/redaction/operators/Erase
-//! [`Keep`]: https://docs.rs/elide/latest/elide/redaction/operators/Keep
+//! [`Erase`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Erase.html
+//! [`Keep`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Keep.html
+//! [`Mask`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Mask.html
+//! [`Replace`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Replace.html
+//! [`Hash`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Sha2Hash.html
+//! [`Fake`]: https://docs.rs/elide_fake/latest/elide_fake/struct.Fake.html
+//! [`Pseudonymize`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Pseudonymize.html
+//! [`Encrypt`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.AesEncrypt.html
+//! [`HmacHash`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.HmacHash.html
+//! [`Truncate`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Truncate.html
+//! [`Clamp`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.Clamp.html
+//! [`GeneralizeDate`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.GeneralizeDate.html
+//! [`WithFallback`]: https://docs.rs/elide/latest/elide/redaction/operators/struct.WithFallback.html
 //! [`Operator<M>`]: elide_core::operator::Operator
 
 mod any;
@@ -38,7 +48,9 @@ pub use self::any::{AnyRedaction, RedactionModality};
 pub use self::audio::AudioRedaction;
 pub use self::image::ImageRedaction;
 pub use self::tabular::TabularRedaction;
-pub use self::text::{HashAlgorithm, TextRedaction};
+pub use self::text::{
+    ClampBucket, DateGranularity, DateStyle, HashAlgorithm, TerminalFallback, TextRedaction,
+};
 
 /// Per-modality operator specs carried by a `redact` rule.
 ///
@@ -76,25 +88,5 @@ impl ModalityRedactions {
             && self.tabular.is_none()
             && self.image.is_none()
             && self.audio.is_none()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn empty_when_no_modality_set() {
-        let r = ModalityRedactions::default();
-        assert!(r.is_empty());
-    }
-
-    #[test]
-    fn non_empty_when_any_modality_set() {
-        let r = ModalityRedactions {
-            text: Some(TextRedaction::Erase),
-            ..Default::default()
-        };
-        assert!(!r.is_empty());
     }
 }

--- a/crates/nvisy-policy/src/redaction/mod.rs
+++ b/crates/nvisy-policy/src/redaction/mod.rs
@@ -49,7 +49,7 @@ pub use self::audio::AudioRedaction;
 pub use self::image::ImageRedaction;
 pub use self::tabular::TabularRedaction;
 pub use self::text::{
-    ClampBucket, DateGranularity, DateStyle, HashAlgorithm, TerminalFallback, TextRedaction,
+    ClampBucket, DateGranularity, DateStyle, Sha2Algorithm, TerminalFallback, TextRedaction,
 };
 
 /// Per-modality operator specs carried by a `redact` rule.

--- a/crates/nvisy-policy/src/redaction/tabular.rs
+++ b/crates/nvisy-policy/src/redaction/tabular.rs
@@ -22,8 +22,7 @@ use serde::{Deserialize, Serialize};
 use super::text::TextRedaction;
 
 /// Operator spec a `redact` tabular rule carries.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TabularRedaction {
     /// Run a text-modality operator on the matched cell's

--- a/crates/nvisy-policy/src/redaction/text.rs
+++ b/crates/nvisy-policy/src/redaction/text.rs
@@ -65,26 +65,10 @@ use std::collections::HashMap;
 
 use elide_core::primitive::{LanguageTag, LocalizedText};
 use elide_redaction::operators::Clamp;
-pub use elide_redaction::operators::{DateGranularity, DateStyle};
+pub use elide_redaction::operators::{DateGranularity, DateStyle, Sha2Algorithm};
 use hipstr::HipStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-/// SHA-2 variant for the [`TextRedaction::Hash`] operator.
-///
-/// Wire mirror of elide's `Sha2Algorithm`; the runtime `From`
-/// conversion is on the engine side so this crate stays free
-/// of the elide-redaction dep.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-#[derive(Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum HashAlgorithm {
-    /// SHA-256, 32-byte digest, 64-char hex.
-    #[default]
-    Sha256,
-    /// SHA-512, 64-byte digest, 128-char hex.
-    Sha512,
-}
 
 /// Text a [`TextRedaction::Clamp`] emits for out-of-range values.
 ///
@@ -229,7 +213,7 @@ pub enum TextRedaction {
     Hash {
         /// SHA-256 (default) or SHA-512.
         #[serde(default)]
-        algorithm: HashAlgorithm,
+        algorithm: Sha2Algorithm,
         /// Salt prepended to the value before hashing.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         salt: Option<String>,
@@ -284,7 +268,7 @@ pub enum TextRedaction {
     HmacHash {
         /// HMAC-SHA-256 (default) or HMAC-SHA-512.
         #[serde(default)]
-        algorithm: HashAlgorithm,
+        algorithm: Sha2Algorithm,
     },
     /// Physically remove the middle of the value, keeping a
     /// leading and/or trailing run of characters. Unlike [`Mask`]

--- a/crates/nvisy-policy/src/redaction/text.rs
+++ b/crates/nvisy-policy/src/redaction/text.rs
@@ -109,7 +109,7 @@ impl ClampBucket {
         match self {
             Self::Plain(text) => clamp.with_ceiling(threshold, text.clone()),
             Self::Format { format } => clamp.with_ceiling_fmt(threshold, format.clone()),
-            Self::Localized(map) => clamp.with_ceiling(threshold, to_localized(map)),
+            Self::Localized(map) => clamp.with_ceiling(threshold, localized(map)),
         }
     }
 
@@ -120,17 +120,14 @@ impl ClampBucket {
         match self {
             Self::Plain(text) => clamp.with_floor(threshold, text.clone()),
             Self::Format { format } => clamp.with_floor_fmt(threshold, format.clone()),
-            Self::Localized(map) => clamp.with_floor(threshold, to_localized(map)),
+            Self::Localized(map) => clamp.with_floor(threshold, localized(map)),
         }
     }
 }
 
-/// Convert a per-language string map into elide's [`LocalizedText`]
-/// carrier. `String` moves into `HipStr` without a re-allocation
-/// (`HipStr` reuses the owned buffer).
-fn to_localized(map: &HashMap<LanguageTag, String>) -> LocalizedText<HipStr<'static>> {
+fn localized(map: &HashMap<LanguageTag, String>) -> LocalizedText<HipStr<'static>> {
     map.iter()
-        .map(|(lang, value)| (lang.clone(), value.clone().into()))
+        .map(|(lang, value)| (lang.clone(), HipStr::from(value.as_str())))
         .collect()
 }
 
@@ -275,7 +272,9 @@ pub enum TextRedaction {
     /// this *shortens* the string — the dropped characters leave
     /// no placeholder. The PCI DSS §3.5.1 truncation posture for
     /// stored PAN: `Truncate { keep_prefix: 6, keep_suffix: 4 }`
-    /// yields `"41111111234"` (not `"411111********1234"`).
+    /// on `"4111111111111234"` yields `"4111111234"` (10 chars),
+    /// where the analogous [`Mask`] would yield `"411111******1234"`
+    /// (16 chars, length preserved).
     ///
     /// A configuration whose kept regions cover (or overlap) the
     /// whole value is rejected at apply time; the operator errors

--- a/crates/nvisy-policy/src/redaction/text.rs
+++ b/crates/nvisy-policy/src/redaction/text.rs
@@ -13,16 +13,60 @@
 //!   surrogate values; the engine wires a `Replace`-with-default-
 //!   template fallback for labels outside the core PII catalogue)
 //! - [`TextRedaction::Pseudonymize`] →
-//!   `elide::redaction::operators::Pseudonymize`
+//!   `elide::redaction::operators::Pseudonymize` (engine wires a
+//!   per-request in-memory [`Vault`] and the default [`RandomToken`]
+//!   [`Generator`])
 //! - [`TextRedaction::Encrypt`] →
 //!   `elide::redaction::operators::AesEncrypt` (engine wires the
-//!   per-tenant key provider)
+//!   per-tenant AES [`KeyProvider`])
+//! - [`TextRedaction::HmacHash`] →
+//!   `elide::redaction::operators::HmacHash` (engine wires the
+//!   per-tenant [`KeyProvider`]; distinct from [`Hash`] because the
+//!   HMAC key stays secret, blocking offline dictionary attacks a
+//!   public salt does not — the PCI DSS v4.0.1 §3.5.1 "keyed hash"
+//!   posture)
+//! - [`TextRedaction::Truncate`] →
+//!   `elide::redaction::operators::Truncate` (physically drop the
+//!   middle of the value; distinct from [`Mask`] which preserves
+//!   length — the PCI DSS §3.5.1 truncation posture for stored PAN)
+//! - [`TextRedaction::Clamp`] →
+//!   `elide::redaction::operators::Clamp` (numeric ceiling/floor →
+//!   bucket label; the HIPAA §164.514(b)(2)(i)(C) age-cap posture)
+//! - [`TextRedaction::GeneralizeDate`] →
+//!   `elide::redaction::operators::GeneralizeDate` (reduce date
+//!   granularity; the HIPAA §164.514(b)(2)(i)(C) date-generalization
+//!   posture)
+//!
+//! [`Clamp`] and [`GeneralizeDate`] each carry an optional
+//! `fallback` field that runs when the entity value isn't the
+//! operator's shape (a non-numeric age, a free-text date). The
+//! fallback is one of the four terminal operators — [`Erase`],
+//! [`Keep`], [`Replace`], [`Mask`] — so the engine builds a
+//! concrete `elide::WithFallback<primary, fallback>` without
+//! type erasure. `None` erases (elide's baked-in default).
 //!
 //! No `Custom` escape hatch: every operator the wire format admits
 //! is predefined. New built-ins land in elide first, then surface
 //! here as new variants.
+//!
+//! [`Clamp`]: TextRedaction::Clamp
+//! [`Erase`]: TextRedaction::Erase
+//! [`GeneralizeDate`]: TextRedaction::GeneralizeDate
+//! [`Hash`]: TextRedaction::Hash
+//! [`Keep`]: TextRedaction::Keep
+//! [`Mask`]: TextRedaction::Mask
+//! [`Replace`]: TextRedaction::Replace
+//! [`Generator`]: https://docs.rs/elide/latest/elide/redaction/generator/trait.Generator.html
+//! [`KeyProvider`]: https://docs.rs/elide/latest/elide/redaction/operators/trait.KeyProvider.html
+//! [`RandomToken`]: https://docs.rs/elide/latest/elide/redaction/generator/struct.RandomToken.html
+//! [`Vault`]: https://docs.rs/elide/latest/elide/redaction/vault/trait.Vault.html
 
-use elide_core::primitive::LanguageTag;
+use std::collections::HashMap;
+
+use elide_core::primitive::{LanguageTag, LocalizedText};
+use elide_redaction::operators::Clamp;
+pub use elide_redaction::operators::{DateGranularity, DateStyle};
+use hipstr::HipStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -42,8 +86,115 @@ pub enum HashAlgorithm {
     Sha512,
 }
 
+/// Text a [`TextRedaction::Clamp`] emits for out-of-range values.
+///
+/// Three forms, deserialized untagged so callers can pick the
+/// terser one for the case at hand:
+///
+/// - **Plain string** (`"90 or older"`) — English-only shorthand.
+/// - **Localized map** (`{"en": "90 or older", "fr": "90 ou plus"}`)
+///   — one entry per language the deployment ships; missing
+///   locales fall back to English at render time.
+/// - **Format template** (`{"format": "{n} or older"}`) — the
+///   engine substitutes `{n}` for the threshold, so a ceiling of
+///   `90` renders `"90 or older"` without the caller repeating the
+///   number. Same rendering in every language.
+///
+/// Round-trips through serde as whichever form the caller wrote.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ClampBucket {
+    /// Plain English-only string.
+    Plain(String),
+    /// Format template — the engine substitutes `{n}` for the
+    /// threshold. Same rendering in every language.
+    Format {
+        /// The template string. `{n}` is substituted; other text
+        /// is literal.
+        format: String,
+    },
+    /// Localized map, keyed by BCP-47 language tag.
+    Localized(HashMap<LanguageTag, String>),
+}
+
+impl ClampBucket {
+    /// Attach this bucket as the ceiling of `clamp` at `threshold`,
+    /// returning the extended [`Clamp`].
+    #[must_use]
+    pub fn attach_ceiling(&self, clamp: Clamp, threshold: f64) -> Clamp {
+        match self {
+            Self::Plain(text) => clamp.with_ceiling(threshold, text.clone()),
+            Self::Format { format } => clamp.with_ceiling_fmt(threshold, format.clone()),
+            Self::Localized(map) => clamp.with_ceiling(threshold, to_localized(map)),
+        }
+    }
+
+    /// Attach this bucket as the floor of `clamp` at `threshold`,
+    /// returning the extended [`Clamp`].
+    #[must_use]
+    pub fn attach_floor(&self, clamp: Clamp, threshold: f64) -> Clamp {
+        match self {
+            Self::Plain(text) => clamp.with_floor(threshold, text.clone()),
+            Self::Format { format } => clamp.with_floor_fmt(threshold, format.clone()),
+            Self::Localized(map) => clamp.with_floor(threshold, to_localized(map)),
+        }
+    }
+}
+
+/// Convert a per-language string map into elide's [`LocalizedText`]
+/// carrier. `String` moves into `HipStr` without a re-allocation
+/// (`HipStr` reuses the owned buffer).
+fn to_localized(map: &HashMap<LanguageTag, String>) -> LocalizedText<HipStr<'static>> {
+    map.iter()
+        .map(|(lang, value)| (lang.clone(), value.clone().into()))
+        .collect()
+}
+
+/// Fallback operator that runs when a declinable primary
+/// ([`TextRedaction::Clamp`], [`TextRedaction::GeneralizeDate`])
+/// doesn't apply to the entity value.
+///
+/// The four operators that always apply and produce a deterministic
+/// output without needing engine-side infrastructure (no key
+/// provider, no vault). Enough to satisfy every regulatory
+/// pattern I know: `Clamp/GeneralizeDate → Erase` (the safe
+/// default), `→ Replace { template }` (an explicit placeholder),
+/// or `→ Mask` / `→ Keep` on the rare occasion those fit.
+///
+/// Absent from the primary's spec, elide's baked-in default is
+/// [`Erase`] — a bare [`TextRedaction::Clamp`] without a `fallback`
+/// erases values that aren't numeric.
+///
+/// [`Erase`]: TerminalFallback::Erase
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TerminalFallback {
+    /// See [`TextRedaction::Erase`].
+    Erase,
+    /// See [`TextRedaction::Keep`].
+    Keep,
+    /// See [`TextRedaction::Replace`].
+    Replace {
+        /// Template string. Default `[{label}]`.
+        #[serde(default = "default_replace_template")]
+        template: String,
+    },
+    /// See [`TextRedaction::Mask`].
+    Mask {
+        /// The character that replaces masked positions.
+        #[serde(default = "default_mask_char")]
+        mask_char: char,
+        /// Characters to leave unmasked at the start of the value.
+        #[serde(default, skip_serializing_if = "is_zero")]
+        keep_prefix: usize,
+        /// Characters to leave unmasked at the end of the value.
+        #[serde(default, skip_serializing_if = "is_zero")]
+        keep_suffix: usize,
+    },
+}
+
 /// Operator spec a `redact` text rule carries.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TextRedaction {
@@ -115,12 +266,102 @@ pub enum TextRedaction {
     /// reads the same surrogate. The engine wires a per-request
     /// vault + the default [`RandomToken`] generator.
     ///
-    /// [`RandomToken`]: https://docs.rs/elide/latest/elide/redaction/generator/RandomToken
+    /// [`RandomToken`]: https://docs.rs/elide/latest/elide/redaction/generator/struct.RandomToken.html
     Pseudonymize,
     /// Reversible AES-256-GCM ciphertext. The engine supplies the
     /// per-tenant AES key at construction so raw key material never
-    /// lives in serialised policy.
+    /// lives in serialised policy. Requires the engine to have a
+    /// key provider wired via `Engine::with_key_provider`.
     Encrypt,
+    /// Keyed HMAC-SHA-2 digest. The key stays secret, so an
+    /// attacker who obtains the redacted output cannot enumerate
+    /// a small input space without the key — the PCI DSS v4.0.1
+    /// §3.5.1 "keyed hash" posture. Distinct from [`Hash`], whose
+    /// salt is public. Requires the engine to have a key provider
+    /// wired via `Engine::with_key_provider`.
+    ///
+    /// [`Hash`]: TextRedaction::Hash
+    HmacHash {
+        /// HMAC-SHA-256 (default) or HMAC-SHA-512.
+        #[serde(default)]
+        algorithm: HashAlgorithm,
+    },
+    /// Physically remove the middle of the value, keeping a
+    /// leading and/or trailing run of characters. Unlike [`Mask`]
+    /// this *shortens* the string — the dropped characters leave
+    /// no placeholder. The PCI DSS §3.5.1 truncation posture for
+    /// stored PAN: `Truncate { keep_prefix: 6, keep_suffix: 4 }`
+    /// yields `"41111111234"` (not `"411111********1234"`).
+    ///
+    /// A configuration whose kept regions cover (or overlap) the
+    /// whole value is rejected at apply time; the operator errors
+    /// rather than silently pass through.
+    ///
+    /// [`Mask`]: TextRedaction::Mask
+    Truncate {
+        /// Characters to keep at the start of the value.
+        #[serde(default, skip_serializing_if = "is_zero")]
+        keep_prefix: usize,
+        /// Characters to keep at the end of the value.
+        #[serde(default, skip_serializing_if = "is_zero")]
+        keep_suffix: usize,
+    },
+    /// Collapse a numeric value at or above `ceiling` (or at or
+    /// below `floor`) into a bucket label; values in the middle
+    /// pass through unchanged. The HIPAA §164.514(b)(2)(i)(C) age
+    /// posture: everyone ≥90 aggregates into `"90 or older"`,
+    /// while a 73-year-old stays `"73"`.
+    ///
+    /// Values that don't parse as finite numbers are *declined*.
+    /// `fallback` names what runs on a declined value; when
+    /// absent, elide's baked-in default is [`Erase`] (the safe
+    /// posture — a non-numeric age never survives redaction).
+    ///
+    /// [`Erase`]: TextRedaction::Erase
+    Clamp {
+        /// Threshold at or above which values collapse to
+        /// `ceiling_bucket`. `None` disables the ceiling.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ceiling: Option<f64>,
+        /// Bucket label for values at or above `ceiling`. Required
+        /// when `ceiling` is set; ignored otherwise.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ceiling_bucket: Option<ClampBucket>,
+        /// Threshold at or below which values collapse to
+        /// `floor_bucket`. `None` disables the floor.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        floor: Option<f64>,
+        /// Bucket label for values at or below `floor`. Required
+        /// when `floor` is set; ignored otherwise.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        floor_bucket: Option<ClampBucket>,
+        /// Operator that runs when the entity value isn't a
+        /// finite number. `None` erases (elide's default).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fallback: Option<TerminalFallback>,
+    },
+    /// Reduce a date/timestamp to a coarser granularity. The
+    /// HIPAA §164.514(b)(2)(i)(C) date-generalization posture:
+    /// dates directly related to an individual reduced to the
+    /// year, preserving cohort-level analytics.
+    ///
+    /// Values that don't parse as dates are *declined*. `fallback`
+    /// names what runs on a declined value; when absent, elide's
+    /// baked-in default is [`Erase`].
+    ///
+    /// [`Erase`]: TextRedaction::Erase
+    GeneralizeDate {
+        /// Coarseness of the output. Default `Year`.
+        #[serde(default)]
+        granularity: DateGranularity,
+        /// Which input convention to accept. Default `Iso`.
+        #[serde(default)]
+        style: DateStyle,
+        /// Operator that runs when the entity value isn't a
+        /// parseable date. `None` erases (elide's default).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fallback: Option<TerminalFallback>,
+    },
 }
 
 fn default_replace_template() -> String {

--- a/crates/nvisy-policy/src/rule.rs
+++ b/crates/nvisy-policy/src/rule.rs
@@ -1,29 +1,43 @@
-//! One rule inside a [`PolicyDefinition`]: shared identity/description
-//! fields, the match predicate, and the redaction operators
-//! ([`ModalityRedactions`]) to apply on match.
+//! One rule inside a [`PolicyDefinition`]: either predicate-gated
+//! (one predicate, one action) or per-label table (a map of label
+//! → action for compact fan-out).
 //!
-//! The engine compiles a rule's [`predicate`] into an elide
-//! anonymizer rule at request time. Three shapes are recognised
-//! as fast paths and route to the matching [`Anonymizer`] builder
-//! method; everything else compiles to a catalog-aware closure:
+//! Both variants carry the same identity/description fields; the
+//! shape differs only in how targets are selected. The engine
+//! compiles either shape down through the same
+//! [`Anonymizer`] entry points:
 //!
-//! - [`Predicate::LabelOneOf`] with a single label → [`Anonymizer::with_label`]
-//! - [`Predicate::TagOneOf`] with a single tag → [`Anonymizer::with_tag`]
-//! - any composite (or multi-label / multi-tag) → [`Anonymizer::with_catalog_predicate`]
+//! - **Predicated** rule → the `predicate` compiles into an elide
+//!   selector. Fast paths:
+//!   - [`Predicate::LabelOneOf`] with a single label →
+//!     [`Anonymizer::with_label`]
+//!   - [`Predicate::TagOneOf`] with a single tag →
+//!     [`Anonymizer::with_tag`]
+//!   - anything else → [`Anonymizer::with_catalog_predicate`]
+//! - **Table** rule → each `(label, action)` entry attaches as
+//!   [`Anonymizer::with_label`] directly; the table is sugar over
+//!   N predicated rules with identical id/name/description.
 //!
-//! Author-facing wire format: rules carry one composable
-//! `predicate` field. No need for separate label/tag/predicate
-//! kinds: `Predicate::LabelOneOf { labels: ["email"] }` is the
-//! same rule as the old `RuleKind::Label { label: "email" }` and
-//! compiles down to the same fast path.
+//! Table rules keep templates that need per-label operator
+//! dispatch (HIPAA Safe Harbor identifier fan-out: date →
+//! generalize-year, age → clamp-≥90, name → erase, …) from
+//! ballooning to one predicated rule per label with the same
+//! identity boilerplate repeated.
+//!
+//! Wire format is an untagged serde enum: existing JSON with
+//! `predicate` and `action` fields parses as [`PolicyRule::Predicated`];
+//! JSON with an `operators` field parses as [`PolicyRule::Table`].
 //!
 //! [`PolicyDefinition`]: super::PolicyDefinition
-//! [`predicate`]: PolicyRule::predicate
+//! [`Predicate`]: super::predicate::Predicate
+//! [`Predicate::LabelOneOf`]: super::predicate::Predicate::LabelOneOf
+//! [`Predicate::TagOneOf`]: super::predicate::Predicate::TagOneOf
 //! [`Anonymizer`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer
 //! [`Anonymizer::with_label`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_label
 //! [`Anonymizer::with_tag`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_tag
 //! [`Anonymizer::with_catalog_predicate`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_catalog_predicate
 
+use elide_core::entity::LabelRef;
 use hipstr::HipStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -32,22 +46,95 @@ use uuid::Uuid;
 use super::predicate::Predicate;
 use super::redaction::ModalityRedactions;
 
-/// One rule inside a [`PolicyDefinition`]. Identity is the UUID; `name` /
-/// `description` are display-only.
+/// One rule inside a [`PolicyDefinition`]. Identity is the UUID;
+/// `name` / `description` are display-only.
+///
+/// Untagged on the wire: distinguished by the presence of
+/// `predicate` (predicated) vs. `operators` (table). Existing
+/// JSON keeps working.
 ///
 /// [`PolicyDefinition`]: super::PolicyDefinition
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct PolicyRule {
-    /// Stable identifier. UUIDv7 recommended (time-ordered);
-    /// customer-supplied so re-submissions carry the same id.
-    /// Engine stamps this into the redaction event's
-    /// [`Attribution::reason`] so reviewers can trace back which
+#[serde(untagged)]
+pub enum PolicyRule {
+    /// Predicate-gated: one predicate, one action, fires when the
+    /// predicate holds on the candidate entity.
+    ///
+    /// Boxed because [`PredicatedRule`] carries a recursive
+    /// [`Predicate`] tree; without indirection the enum's
+    /// stack footprint balloons to the largest variant.
+    Predicated(Box<PredicatedRule>),
+    /// Per-label table: one action per label, sugar over N
+    /// predicated rules with identical id/name/description.
+    Table(TableRule),
+}
+
+impl PolicyRule {
+    /// Stable identifier — display-independent, shared by both
+    /// variants. Engine stamps it into the redaction event's
+    /// [`Attribution::description`] so reviewers can trace which
     /// rule fired.
     ///
-    /// [`Attribution::reason`]: elide_core::entity::provenance::Attribution::reason
+    /// [`Attribution::description`]: elide_core::entity::provenance::Attribution::description
+    #[must_use]
+    pub fn id(&self) -> Uuid {
+        match self {
+            Self::Predicated(r) => r.id,
+            Self::Table(r) => r.id,
+        }
+    }
+
+    /// Human-readable name — display only.
+    #[must_use]
+    pub fn name(&self) -> &HipStr<'static> {
+        match self {
+            Self::Predicated(r) => &r.name,
+            Self::Table(r) => &r.name,
+        }
+    }
+
+    /// Optional reviewer description.
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Self::Predicated(r) => r.description.as_deref(),
+            Self::Table(r) => r.description.as_deref(),
+        }
+    }
+
+    /// Flatten this rule into one or more `(predicate, action)`
+    /// pairs. Predicated yields one pair verbatim; Table yields
+    /// one pair per [`LabelEntry`] with a synthetic
+    /// [`Predicate::LabelOneOf`] holding that single label. The
+    /// engine attaches every yielded pair under this rule's
+    /// shared UUID.
+    ///
+    /// Iteration order is stable — `Predicated` yields once;
+    /// `Table` yields in the entries' declared order.
+    ///
+    /// [`Predicate::LabelOneOf`]: super::predicate::Predicate::LabelOneOf
+    pub fn attachments(&self) -> Box<dyn Iterator<Item = (Predicate, &ModalityRedactions)> + '_> {
+        match self {
+            Self::Predicated(r) => Box::new(std::iter::once((r.predicate.clone(), &r.action))),
+            Self::Table(r) => Box::new(r.operators.iter().map(|entry| {
+                (
+                    Predicate::LabelOneOf {
+                        labels: vec![entry.label.clone()],
+                    },
+                    &entry.action,
+                )
+            })),
+        }
+    }
+}
+
+/// Predicate-gated rule: one predicate, one action.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PredicatedRule {
+    /// Stable identifier. UUIDv7 recommended.
     pub id: Uuid,
-    /// Human-readable name. Display-only. Does not key anything.
+    /// Human-readable name. Display-only.
     #[schemars(with = "String")]
     pub name: HipStr<'static>,
     /// Optional description for reviewers.
@@ -61,5 +148,58 @@ pub struct PolicyRule {
     /// predicate matches. Modalities the rule doesn't cover fall
     /// through to the policy fallback (or the next policy in the
     /// chain).
+    pub action: ModalityRedactions,
+}
+
+/// Per-label table rule: N labels, N actions, one shared identity.
+///
+/// Each entry compiles to an [`Anonymizer::with_label`] attachment
+/// under this rule's shared UUID / name / description — so the
+/// audit trail records "rule X fired" without exposing the fan-out
+/// to the reviewer. Meant for templates where a single policy
+/// intent (e.g. "HIPAA Safe Harbor identifiers") routes different
+/// labels to different operators.
+///
+/// [`Anonymizer::with_label`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_label
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TableRule {
+    /// Stable identifier — shared by every entry the table
+    /// expands into. UUIDv7 recommended.
+    pub id: Uuid,
+    /// Human-readable name. Display-only.
+    #[schemars(with = "String")]
+    pub name: HipStr<'static>,
+    /// Optional description for reviewers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Per-label operator dispatch. Every entity whose label
+    /// matches a listed [`LabelRef`] attaches the paired
+    /// [`ModalityRedactions`]. Labels absent from the list are not
+    /// affected by this rule and fall through to the next rule or
+    /// the policy fallback.
+    ///
+    /// A [`Vec`] rather than a map keeps the author-supplied
+    /// order — elide's anonymizer treats attach order as a
+    /// tie-break, so the wire keeping the caller's order buys
+    /// deterministic audits. Duplicate labels are the caller's
+    /// bug; the engine attaches every entry, and elide's
+    /// `Anonymizer` overwrites earlier attachments with later
+    /// ones for the same label.
+    pub operators: Vec<LabelEntry>,
+}
+
+/// One entry inside a [`TableRule`]: the label to match plus the
+/// per-modality operators to run.
+///
+/// Kept as a named struct rather than a `(LabelRef, ModalityRedactions)`
+/// tuple so the wire JSON reads `{"label": "email", "action": {…}}`
+/// instead of a positional pair.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelEntry {
+    /// Label the entry matches on.
+    pub label: LabelRef,
+    /// Per-modality operators to run for matching entities.
     pub action: ModalityRedactions,
 }

--- a/crates/nvisy-policy/src/rule.rs
+++ b/crates/nvisy-policy/src/rule.rs
@@ -4,19 +4,17 @@
 //!
 //! Both variants carry the same identity/description fields; the
 //! shape differs only in how targets are selected. The engine
-//! compiles either shape down through the same
-//! [`Anonymizer`] entry points:
+//! compiles either shape into elide [`Rule`]s attached via
+//! [`Anonymizer::with`]:
 //!
 //! - **Predicated** rule → the `predicate` compiles into an elide
 //!   selector. Fast paths:
-//!   - [`Predicate::LabelOneOf`] with a single label →
-//!     [`Anonymizer::with_label`]
-//!   - [`Predicate::TagOneOf`] with a single tag →
-//!     [`Anonymizer::with_tag`]
-//!   - anything else → [`Anonymizer::with_catalog_predicate`]
+//!   - [`Predicate::LabelOneOf`] with a single label → [`Rule::label`]
+//!   - [`Predicate::TagOneOf`] with a single tag → [`Rule::tag`]
+//!   - anything else → [`Rule::predicate`]
 //! - **Table** rule → each `(label, action)` entry attaches as
-//!   [`Anonymizer::with_label`] directly; the table is sugar over
-//!   N predicated rules with identical id/name/description.
+//!   [`Rule::label`] directly; the table is sugar over N
+//!   predicated rules with identical id/name/description.
 //!
 //! Table rules keep templates that need per-label operator
 //! dispatch (HIPAA Safe Harbor identifier fan-out: date →
@@ -32,10 +30,11 @@
 //! [`Predicate`]: super::predicate::Predicate
 //! [`Predicate::LabelOneOf`]: super::predicate::Predicate::LabelOneOf
 //! [`Predicate::TagOneOf`]: super::predicate::Predicate::TagOneOf
-//! [`Anonymizer`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer
-//! [`Anonymizer::with_label`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_label
-//! [`Anonymizer::with_tag`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_tag
-//! [`Anonymizer::with_catalog_predicate`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_catalog_predicate
+//! [`Anonymizer::with`]: elide_redaction::Anonymizer::with
+//! [`Rule`]: elide_redaction::Rule
+//! [`Rule::label`]: elide_redaction::Rule::label
+//! [`Rule::tag`]: elide_redaction::Rule::tag
+//! [`Rule::predicate`]: elide_redaction::Rule::predicate
 
 use elide_core::entity::LabelRef;
 use hipstr::HipStr;
@@ -153,14 +152,14 @@ pub struct PredicatedRule {
 
 /// Per-label table rule: N labels, N actions, one shared identity.
 ///
-/// Each entry compiles to an [`Anonymizer::with_label`] attachment
-/// under this rule's shared UUID / name / description — so the
-/// audit trail records "rule X fired" without exposing the fan-out
-/// to the reviewer. Meant for templates where a single policy
-/// intent (e.g. "HIPAA Safe Harbor identifiers") routes different
-/// labels to different operators.
+/// Each entry compiles to a [`Rule::label`] attachment under this
+/// rule's shared UUID / name / description — so the audit trail
+/// records "rule X fired" without exposing the fan-out to the
+/// reviewer. Meant for templates where a single policy intent
+/// (e.g. "HIPAA Safe Harbor identifiers") routes different labels
+/// to different operators.
 ///
-/// [`Anonymizer::with_label`]: https://docs.rs/elide/latest/elide/redaction/Anonymizer::with_label
+/// [`Rule::label`]: elide_redaction::Rule::label
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TableRule {
@@ -180,12 +179,10 @@ pub struct TableRule {
     /// the policy fallback.
     ///
     /// A [`Vec`] rather than a map keeps the author-supplied
-    /// order — elide's anonymizer treats attach order as a
-    /// tie-break, so the wire keeping the caller's order buys
-    /// deterministic audits. Duplicate labels are the caller's
-    /// bug; the engine attaches every entry, and elide's
-    /// `Anonymizer` overwrites earlier attachments with later
-    /// ones for the same label.
+    /// order — elide's anonymizer is first-match-wins, so wire
+    /// order determines which entry fires when two match the
+    /// same entity. Duplicate labels are the caller's bug; the
+    /// engine attaches every entry, and the first one wins.
     pub operators: Vec<LabelEntry>,
 }
 

--- a/crates/nvisy-schema/src/entity.rs
+++ b/crates/nvisy-schema/src/entity.rs
@@ -4,7 +4,7 @@
 //! by the analyzer and consumed by the anonymizer. [`Label`] and
 //! [`LabelRef`] name the entity kind; [`LabelCatalog`] holds the
 //! deployment's label vocabulary. Each label carries per-language
-//! [`Localization`] entries (name + optional description); NER
+//! [`LabelLocale`] entries (name + optional description); NER
 //! and LLM backends render these in the analysis language.
 //! [`Provenance`] carries the audit trail (which rule / model /
 //! pattern produced each detection).
@@ -13,5 +13,5 @@ pub use elide_core::entity::provenance::{
     Attribution, Event, EventKind, ModelEvent, PatternEvent, Provenance, RuleMatch,
 };
 pub use elide_core::entity::{
-    Entity, EntityCoRef, EntityRef, Label, LabelCatalog, LabelRef, Localization,
+    Entity, EntityCoRef, EntityRef, Label, LabelCatalog, LabelLocale, LabelRef,
 };

--- a/crates/nvisy-schema/src/plan/analyzer.rs
+++ b/crates/nvisy-schema/src/plan/analyzer.rs
@@ -94,13 +94,15 @@ pub struct ScopeParams {
     pub metadata: ScopeMetadata,
 }
 
-/// Whether the [`ScopeMetadata`] carries no assertions.
+/// Whether a [`ScopeMetadata`] carries no assertions — all three
+/// fields (`tags`, `purpose`, `audience`) empty.
 ///
-/// Used by [`ScopeParams::metadata`]'s `skip_serializing_if` to
-/// keep the serialized `scope` block minimal when the caller
-/// asserts nothing beyond the typed fields. Local to this module
-/// because elide's `ScopeMetadata` doesn't ship an `is_empty` of
-/// its own; a one-line helper is cheaper than a wrapper type.
-fn scope_metadata_is_empty(metadata: &ScopeMetadata) -> bool {
+/// Used as the `skip_serializing_if` for every wire type that
+/// carries a `ScopeMetadata` (both [`ScopeParams::metadata`] here
+/// and the engine-side `AuditContext::metadata`) so a serialized
+/// block stays minimal when the caller asserts nothing beyond
+/// the typed fields. Exposed because elide's `ScopeMetadata`
+/// doesn't ship an `is_empty` of its own.
+pub fn scope_metadata_is_empty(metadata: &ScopeMetadata) -> bool {
     metadata.tags.is_empty() && metadata.purpose.is_none() && metadata.audience.is_empty()
 }

--- a/crates/nvisy-schema/src/plan/analyzer.rs
+++ b/crates/nvisy-schema/src/plan/analyzer.rs
@@ -1,6 +1,7 @@
 //! Top-level analyzer params.
 
 use elide_core::primitive::{CountryCode, Languages};
+use elide_core::recognition::ScopeMetadata;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,19 +19,15 @@ use super::recognizer::RecognizerParams;
 /// params. Text picks up the text-applicable recognizers,
 /// image picks up the image ones, etc.
 ///
-/// The caller-asserted scope lives under [`scope`], a single
-/// nested object grouping the three knobs the engine assembles
-/// into an `elide::recognition::Scope` at compile time
-/// ([`languages`], [`countries`], [`tags`]). `Scope`'s two other
-/// knobs are engine-side: `correlation_id` is server-minted per
-/// request, and `catalog` is derived from the request's policy
-/// set (each [`PolicyDefinition::labels`] contributes).
+/// The caller-asserted scope lives under [`scope`], a narrower
+/// wire projection of `elide::recognition::Scope`: `languages`,
+/// `countries`, and elide's own [`ScopeMetadata`] block for
+/// free-form classification strings. `Scope`'s other two fields
+/// are server-owned — `correlation_id` is minted per request,
+/// and `catalog` is derived from the request's policy set — so
+/// they don't appear on the wire.
 ///
 /// [`scope`]: AnalyzerParams::scope
-/// [`languages`]: ScopeParams::languages
-/// [`countries`]: ScopeParams::countries
-/// [`tags`]: ScopeParams::tags
-/// [`PolicyDefinition::labels`]: crate::policy::PolicyDefinition::labels
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyzerParams {
@@ -51,12 +48,7 @@ pub struct AnalyzerParams {
     /// Calibrate → reconcile → filter.
     #[serde(default)]
     pub deduplication: DeduplicationParams,
-    /// Caller-asserted scope.
-    ///
-    /// Languages, jurisdictions, document tags. Engine assembles
-    /// this (plus a server-minted correlation id and the
-    /// policy-derived label catalog) into an
-    /// `elide::recognition::Scope` at compile time.
+    /// Caller-asserted scope. See [`ScopeParams`].
     #[serde(default)]
     pub scope: ScopeParams,
     /// Per-modality region annotations.
@@ -72,10 +64,12 @@ pub struct AnalyzerParams {
 
 /// Caller-asserted scope for one request.
 ///
-/// Mirrors the wire-visible knobs of `elide::recognition::Scope`.
-/// The engine assembles this plus a server-minted
-/// `correlation_id` into the orchestrator's `Scope` at compile
-/// time.
+/// A narrower wire projection of `elide::recognition::Scope`:
+/// `languages` and `countries` (typed, elide-native), plus
+/// elide's [`ScopeMetadata`] block for free-form classification
+/// strings (`tags`, `purpose`, `audience`). The engine assembles
+/// this plus a server-minted `correlation_id` and a policy-derived
+/// label catalog into the orchestrator's `Scope` at compile time.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ScopeParams {
@@ -94,18 +88,19 @@ pub struct ScopeParams {
     /// jurisdiction don't lose detections.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub countries: Vec<CountryCode>,
-    /// Document-level classification tags.
-    ///
-    /// E.g. `"medical"`, `"gdpr-request"`. Recognizers may use
-    /// these to bias their behaviour for domain-specific terms;
-    /// those that don't ignore the field.
-    ///
-    /// Distinct from the entity-label catalog: tags classify the
-    /// *document*, whereas labels name the entity *types* to
-    /// emit. Labels are authored on each [`PolicyDefinition`],
-    /// not here.
-    ///
-    /// [`PolicyDefinition`]: crate::policy::PolicyDefinition
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tags: Vec<String>,
+    /// Free-form request context: document tags, request purpose,
+    /// output audience. See elide's [`ScopeMetadata`].
+    #[serde(default, skip_serializing_if = "scope_metadata_is_empty")]
+    pub metadata: ScopeMetadata,
+}
+
+/// Whether the [`ScopeMetadata`] carries no assertions.
+///
+/// Used by [`ScopeParams::metadata`]'s `skip_serializing_if` to
+/// keep the serialized `scope` block minimal when the caller
+/// asserts nothing beyond the typed fields. Local to this module
+/// because elide's `ScopeMetadata` doesn't ship an `is_empty` of
+/// its own; a one-line helper is cheaper than a wrapper type.
+fn scope_metadata_is_empty(metadata: &ScopeMetadata) -> bool {
+    metadata.tags.is_empty() && metadata.purpose.is_none() && metadata.audience.is_empty()
 }

--- a/crates/nvisy-schema/src/plan/mod.rs
+++ b/crates/nvisy-schema/src/plan/mod.rs
@@ -36,7 +36,7 @@ mod enricher;
 mod pattern;
 mod recognizer;
 
-pub use self::analyzer::{AnalyzerParams, ScopeParams};
+pub use self::analyzer::{AnalyzerParams, ScopeParams, scope_metadata_is_empty};
 pub use self::annotation::AnyAnnotations;
 pub use self::deduplication::{DeduplicationParams, MergingStrategyParams, TiebreakerParams};
 pub use self::enricher::{

--- a/crates/nvisy-schema/src/plan/mod.rs
+++ b/crates/nvisy-schema/src/plan/mod.rs
@@ -21,11 +21,11 @@
 //!   (inclusions / exclusions).
 //!
 //! Caller-asserted scope lives under [`AnalyzerParams::scope`],
-//! a single [`ScopeParams`] grouping `languages`, `countries`,
-//! and `tags`. The engine assembles these (plus a server-minted
-//! correlation id, plus the label catalog derived from the
-//! request's policy set) into an `elide::recognition::Scope` at
-//! compile time.
+//! a [`ScopeParams`] carrying `languages`, `countries`, and
+//! elide's own `ScopeMetadata` block (tags, purpose, audience).
+//! The engine assembles these (plus a server-minted correlation
+//! id and the policy-derived label catalog) into an
+//! `elide::recognition::Scope` at compile time.
 //!
 //! [`policy`]: crate::policy
 


### PR DESCRIPTION
## Summary

Phase 1 of regulatory-template foundations. Lays the schema and engine primitives HIPAA/GDPR/PCI-DSS/CCPA templates will lean on: expressive per-label operators, a table rule shape, and named label groups.

Four commits, each independently reviewable:

1. **Bump elide, rename `Localization` → `LabelLocale`** — pick up the upstream renames so the rest of the stack compiles clean.
2. **Wire elide's new operators into `TextRedaction`** — `Clamp`, `GeneralizeDate`, `Truncate`, `HmacHash`, `WithFallback` reach the wire; feature-gates `sha2` on `elide-redaction`.
3. **Bump elide, adapt to new APIs, add `PolicyRule::Table`** — `MatchContext`, `ScopeMetadata`, blanket `Operator` impls on `Box`/`Arc`, and the untagged `Predicated | Table` split under `PolicyRule`. `Attribution { name, description }` replaces `{ policy_id, reason }`.
4. **Add `LabelGroup` primitive and `LabelInGroup` predicate** — per-request named label clusters, fast-pathed to a synthetic `group:<name>` tag on the catalog. Unknown-group references fail at request compile with a named-group error.

## Wire changes

- `Engine::analyze` and `Engine::anonymize` grew a `groups: &[LabelGroup]` param between `policies` and the spec/audit.
- `PolicyRule` is now an untagged enum. Existing `Predicated` rules deserialise unchanged; `Table` is additive.
- `Attribution.name` carries `policy.id`; `Attribution.description` carries `rule.id`.

## Verification

- \`cargo check --workspace --all-features --all-targets\`
- \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- \`cargo test --workspace --all-features\` — 32 tests green (unit + integration; policy_shapes tests exercise Table dispatch and LabelInGroup end-to-end)
- \`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps\`

## Closes

- nvisycom/runtime#357 (LabelGroup)
- nvisycom/runtime#358 (elide operator wiring)
- nvisycom/runtime#359 (PolicyRule::Table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)