### PR TITLE
Phase 2: nvisy-template crate — HIPAA, GDPR, PCI DSS, CCPA templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -72,18 +72,18 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -108,14 +108,14 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-any"
@@ -151,14 +151,14 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -250,14 +250,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -268,9 +269,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bentoml"
@@ -304,9 +305,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitstream-io"
@@ -359,9 +360,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -386,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -414,9 +415,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -597,9 +598,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -616,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -667,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -730,7 +731,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -741,7 +742,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -760,15 +761,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -776,15 +777,14 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -814,7 +814,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -824,7 +824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -846,7 +846,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -880,13 +880,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -924,14 +924,14 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -943,6 +943,7 @@ dependencies = [
  "elide-llm",
  "elide-ner",
  "elide-ocr",
+ "elide-operator",
  "elide-pattern",
  "elide-redaction",
  "elide-stt",
@@ -953,7 +954,7 @@ name = "elide-bento"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bentoml",
  "elide-core",
  "elide-ner",
@@ -967,7 +968,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "bytes",
@@ -993,7 +994,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1004,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1022,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1035,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "elide-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1050,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1061,7 +1062,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1072,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1094,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1108,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1116,9 +1117,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "elide-operator"
+version = "0.1.0"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
+dependencies = [
+ "aes-gcm",
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
+ "elide-core",
+ "elide-fake",
+ "hex",
+ "hipstr",
+ "hmac",
+ "jiff",
+ "schemars",
+ "serde",
+ "sha2 0.11.0",
+ "tracing",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1138,30 +1162,21 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
- "aes-gcm",
  "async-trait",
- "base64 0.23.0",
- "bytes",
  "elide-core",
- "elide-fake",
- "hex",
  "hipstr",
- "hmac",
- "jiff",
  "schemars",
  "serde",
- "sha2 0.11.0",
  "tracing",
  "uuid",
- "zeroize",
 ]
 
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#d79cb5ed43e7ee64d1a188e3dc1d3e8b400ea2bb"
+source = "git+https://github.com/nvisycom/elide?branch=main#231766e0b4d2863b1f20af5f6211a7f129aeaa67"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1206,7 +1221,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1239,14 +1254,16 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.74.0"
+version = "1.74.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
 dependencies = [
  "bit_field",
  "half",
  "lebe",
  "miniz_oxide",
+ "num-complex",
+ "pulp",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -1266,16 +1283,16 @@ checksum = "ea6be833b323a56361118a747470a45a1bcd5c52a2ec9b1e40c83dafe687e453"
 dependencies = [
  "deunicode",
  "either",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -1295,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -1393,7 +1410,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1489,11 +1506,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1539,15 +1554,15 @@ checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
 name = "glam"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
+checksum = "7360bd2cd76e0cd9032d42cf2922155cecea2685b0cfa4630c3246df030bcfd6"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -1675,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1685,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1695,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1714,18 +1729,18 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1950,10 +1965,10 @@ dependencies = [
  "approx",
  "getrandom 0.4.3",
  "image",
- "itertools",
+ "itertools 0.14.0",
  "nalgebra",
  "num",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_distr",
  "rayon",
 ]
@@ -2010,20 +2025,29 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2069,14 +2093,14 @@ dependencies = [
  "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -2114,7 +2138,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2133,24 +2157,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2171,9 +2195,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2212,7 +2236,7 @@ dependencies = [
  "fastrand",
  "fst",
  "include_dir",
- "itertools",
+ "itertools 0.14.0",
  "lingua-english-language-model",
  "maplit",
  "rayon",
@@ -2325,15 +2349,15 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -2357,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memo-map"
@@ -2385,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.21.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+checksum = "42d74234349a775546a83af0f0c0c0e3a73227dee4950a542cda81a47240b3e6"
 dependencies = [
  "memo-map",
  "serde",
@@ -2411,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2460,7 +2484,7 @@ dependencies = [
  "glam 0.30.10",
  "glam 0.31.1",
  "glam 0.32.1",
- "glam 0.33.2",
+ "glam 0.33.3",
  "matrixmultiply",
  "num-complex",
  "num-rational",
@@ -2533,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2547,6 +2571,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2558,7 +2583,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2572,11 +2597,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2616,6 +2640,7 @@ dependencies = [
  "hipstr",
  "nvisy-engine",
  "nvisy-schema",
+ "nvisy-template",
  "schemars",
  "serde",
  "serde_json",
@@ -2633,7 +2658,7 @@ version = "0.1.0"
 dependencies = [
  "derive_more",
  "elide-core",
- "elide-redaction",
+ "elide-operator",
  "hipstr",
  "schemars",
  "serde",
@@ -2653,6 +2678,18 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "nvisy-template"
+version = "0.1.0"
+dependencies = [
+ "elide-core",
+ "hipstr",
+ "jiff",
+ "nvisy-policy",
+ "semver",
  "uuid",
 ]
 
@@ -2733,14 +2770,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826f8f64bc88cb15381cbb5aa245c1500632cd8a453b244bc2b0cbaff7098077"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "bytes",
  "chrono",
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools",
+ "itertools 0.15.0",
  "js-sys",
  "libloading",
  "log",
@@ -2800,7 +2837,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2849,7 +2886,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2871,12 +2908,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2896,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2956,32 +2999,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3002,14 +3023,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.29"
+name = "pulp"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -3048,15 +3092,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3070,23 +3115,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3105,9 +3150,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3115,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3156,7 +3201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3175,7 +3229,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -3186,7 +3240,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha",
  "simd_helpers",
  "thiserror",
@@ -3207,6 +3261,15 @@ dependencies = [
  "rav1e",
  "rayon",
  "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3236,39 +3299,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3278,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3419,7 +3488,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -3506,7 +3575,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3525,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3540,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3566,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3615,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -3627,9 +3696,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
 dependencies = [
  "bytemuck",
 ]
@@ -3712,7 +3781,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3735,7 +3804,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -3753,6 +3822,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -3845,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3893,9 +3966,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simba"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
+checksum = "f1a7200d82ff1c7b4235efd12f11e2537a402c91cf83a5cb97ce80eef787fde7"
 dependencies = [
  "approx",
  "num-complex",
@@ -3905,15 +3978,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -3954,9 +4027,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4034,7 +4107,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4046,7 +4119,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4096,7 +4169,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "lazy_static",
  "log",
@@ -4131,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4168,33 +4241,32 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4203,9 +4275,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -4236,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4266,13 +4338,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4317,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4341,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4353,18 +4425,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -4387,7 +4459,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -4430,7 +4502,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4501,7 +4573,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -4704,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4717,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4727,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4737,22 +4809,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4786,9 +4858,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4818,9 +4890,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4831,14 +4903,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4851,9 +4923,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wide"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -4889,7 +4961,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4900,7 +4972,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5011,9 +5083,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -5055,28 +5127,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5096,7 +5168,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5136,7 +5208,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5155,15 +5227,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"
@@ -5179,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "./crates/nvisy-engine",
     "./crates/nvisy-policy",
     "./crates/nvisy-schema",
+    "./crates/nvisy-template",
 ]
 # Python (uv) workspace lives in `packages/`. Excluded so cargo
 # doesn't glob-scan it or complain about missing Cargo.toml files.
@@ -32,12 +33,17 @@ documentation = "https://docs.rs/nvisy-runtime"
 
 # Elide crates
 elide = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
+elide-codec = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
+elide-context = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-core = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-detection = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-redaction = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
+elide-engine = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-llm = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-ner = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-ocr = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
+elide-operator = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
+elide-pattern = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
+elide-redaction = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-stt = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 
 # Elide extensions
@@ -47,6 +53,7 @@ elide-bento = { path = "./crates/elide-bento", version = "0.1.0" }
 nvisy-engine = { path = "./crates/nvisy-engine", version = "0.1.0" }
 nvisy-policy = { path = "./crates/nvisy-policy", version = "0.1.0" }
 nvisy-schema = { path = "./crates/nvisy-schema", version = "0.1.0" }
+nvisy-template = { path = "./crates/nvisy-template", version = "0.1.0" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
@@ -65,6 +72,7 @@ uuid = { version = "1.23", features = ["serde", "v4", "v7"] }
 bytes = { version = "1.0", features = ["serde"] }
 hipstr = { version = "0.8", features = ["serde"] }
 jiff = { version = "0.2", features = ["serde"] }
+semver = { version = "1.0", features = ["serde"] }
 
 # Encoding and hashing
 base64 = { version = "0.23", features = [] }

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -122,6 +122,7 @@ tracing = { workspace = true, features = [] }
 [dev-dependencies]
 # Internal crates
 nvisy-engine = { path = ".", features = ["test-utils", "audit-json", "audit-csv"] }
+nvisy-template = { workspace = true }
 
 # Primitive datatypes
 uuid = { workspace = true, features = ["v7"] }

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -24,6 +24,12 @@
 //!   modality-tagged entity groups plus an [`AuditContext`] with
 //!   the request's asserted scope and correlation id.
 //!
+//! Ready-to-run policy sets for common regulatory postures
+//! (HIPAA Safe Harbor, GDPR Article 9, PCI DSS §3.5.1, CCPA)
+//! live in the sibling `nvisy-template` crate. Each template
+//! returns a `Template` whose `policies` and `groups` fields feed
+//! straight into [`Engine::analyze`] / [`Engine::anonymize`].
+//!
 //! [`LabelGroup`]: nvisy_schema::policy::LabelGroup
 //!
 //! [`elide`]: elide

--- a/crates/nvisy-engine/tests/templates.rs
+++ b/crates/nvisy-engine/tests/templates.rs
@@ -1,0 +1,216 @@
+//! End-to-end tests for the templates shipped in [`nvisy_template`].
+//!
+//! Each test submits a template through the full analyze →
+//! anonymize pipeline against the plaintext sample and asserts
+//! on the redacted output bytes. That's the strongest form of
+//! coverage: proves the template's rule dispatch, the group
+//! synthesis, and the operator wiring all agree end-to-end,
+//! rather than any one layer in isolation.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use nvisy_engine::{Engine, KeyProvider, StaticKey};
+use nvisy_schema::file::Document;
+use nvisy_schema::plan::{
+    AnalyzerParams, EnricherParams, PatternRecognizerParams, ProviderSelection, RecognizerParams,
+    ScopeParams,
+};
+use nvisy_template::Template;
+
+const SAMPLE_TXT: &[u8] = include_bytes!("testdata/sample.txt");
+
+fn engine() -> Engine {
+    Engine::new()
+}
+
+fn engine_with_key() -> Engine {
+    let provider: Arc<dyn KeyProvider> = Arc::new(StaticKey::new(*b"nvisy-template-test-key-32bytes"));
+    Engine::new().with_key_provider(provider)
+}
+
+fn raw_txt() -> Document {
+    Document::new(Bytes::from_static(SAMPLE_TXT), "txt")
+}
+
+fn default_spec() -> AnalyzerParams {
+    AnalyzerParams {
+        recognizers: RecognizerParams {
+            pattern: Some(PatternRecognizerParams {
+                builtins: true,
+                context_enhanced: true,
+                ..Default::default()
+            }),
+            ner: Some(ProviderSelection::All(false)),
+            llm: Some(ProviderSelection::All(false)),
+        },
+        enrichers: EnricherParams::default(),
+        deduplication: Default::default(),
+        scope: ScopeParams::default(),
+        annotations: Default::default(),
+    }
+}
+
+/// Run `template` through analyze + anonymize against the sample
+/// and return the redacted body as a UTF-8 string.
+async fn apply(engine: &Engine, template: Template) -> String {
+    let mut analyzed = engine
+        .analyze(raw_txt(), &template.policies, &template.groups, &default_spec())
+        .await
+        .expect("analyze succeeds");
+    let redacted = engine
+        .anonymize(
+            raw_txt(),
+            &template.policies,
+            &template.groups,
+            &mut analyzed,
+        )
+        .await
+        .expect("anonymize succeeds");
+    String::from_utf8(redacted.bytes.to_vec()).expect("body is utf-8")
+}
+
+#[tokio::test]
+async fn hipaa_safe_harbor_erases_contact_info_from_sample() {
+    let body = apply(&engine(), nvisy_template::hipaa_safe_harbor()).await;
+    // The sample carries an email, a phone, and an SSN — every
+    // one falls in a HIPAA identifier category and should be
+    // gone from the output. (Address is present too but the
+    // spec runs NER off, so it isn't detected here.)
+    assert!(
+        !body.contains("jane.doe@example.com"),
+        "email must be erased under HIPAA Safe Harbor; body was:\n{body}",
+    );
+    assert!(
+        !body.contains("office@example.com"),
+        "email must be erased under HIPAA Safe Harbor; body was:\n{body}",
+    );
+    assert!(
+        !body.contains("415-555-0142"),
+        "phone must be erased under HIPAA Safe Harbor; body was:\n{body}",
+    );
+    assert!(
+        !body.contains("123-45-6789"),
+        "SSN must be erased under HIPAA Safe Harbor; body was:\n{body}",
+    );
+}
+
+#[tokio::test]
+async fn gdpr_article_9_leaves_non_special_categories_alone() {
+    // The sample contains contact info + an SSN but nothing from
+    // the Article 9 special categories (no religion, ethnicity,
+    // health data, biometric, sexual orientation, etc.). So the
+    // GDPR template should redact nothing — the output equals
+    // the input.
+    let body = apply(&engine(), nvisy_template::gdpr_article_9()).await;
+    assert!(
+        body.contains("jane.doe@example.com"),
+        "GDPR Article 9 doesn't cover email; must survive. Body:\n{body}",
+    );
+    assert!(
+        body.contains("123-45-6789"),
+        "GDPR Article 9 doesn't cover SSN; must survive. Body:\n{body}",
+    );
+}
+
+#[tokio::test]
+async fn pci_dss_pan_truncate_leaves_non_pan_labels_alone() {
+    // The sample has no `payment_card` entity — the PCI truncate
+    // template targets exactly one label, so the sample should
+    // round-trip unchanged.
+    let body = apply(&engine(), nvisy_template::pci_dss_pan_truncate()).await;
+    assert!(
+        body.contains("jane.doe@example.com"),
+        "PCI PAN template doesn't cover email; must survive. Body:\n{body}",
+    );
+    assert!(
+        body.contains("123-45-6789"),
+        "PCI PAN template doesn't cover SSN; must survive. Body:\n{body}",
+    );
+}
+
+#[tokio::test]
+async fn pci_dss_pan_hmac_requires_key_provider() {
+    // Without a key provider on the engine, compiling the HMAC
+    // template's HmacHash operator fails at anonymize-time with
+    // a Configuration error. Proves the template wires the right
+    // capability requirement into place.
+    let template = nvisy_template::pci_dss_pan_hmac();
+    let mut analyzed = engine()
+        .analyze(raw_txt(), &template.policies, &template.groups, &default_spec())
+        .await
+        .expect("analyze succeeds without a key provider");
+    let err = engine()
+        .anonymize(
+            raw_txt(),
+            &template.policies,
+            &template.groups,
+            &mut analyzed,
+        )
+        .await
+        .expect_err("anonymize must fail without a key provider");
+    assert!(
+        err.to_string().contains("KeyProvider"),
+        "expected error naming the missing KeyProvider; got: {err}",
+    );
+}
+
+#[tokio::test]
+async fn pci_dss_pan_hmac_runs_with_a_key_provider() {
+    // Sample has no PAN, so the redacted body still matches the
+    // input verbatim — the test is that anonymize succeeds when
+    // the engine carries a KeyProvider, which is the only PCI-
+    // template-specific setup the operator needs.
+    let body = apply(&engine_with_key(), nvisy_template::pci_dss_pan_hmac()).await;
+    assert!(
+        body.contains("jane.doe@example.com"),
+        "sample carries no PAN; contact info must survive verbatim. Body:\n{body}",
+    );
+}
+
+#[tokio::test]
+async fn ccpa_erases_contact_info_and_identifiers_from_sample() {
+    // CCPA §(A) identifiers include email, phone, and SSN —
+    // every one shows up in the sample and should be redacted
+    // under the shipped template. (Address is present too but
+    // the spec runs NER off, so it isn't detected here.)
+    let body = apply(&engine(), nvisy_template::ccpa()).await;
+    assert!(
+        !body.contains("jane.doe@example.com"),
+        "email is a CCPA §(A) identifier; must be erased. Body:\n{body}",
+    );
+    assert!(
+        !body.contains("415-555-0142"),
+        "phone is a CCPA §(A) identifier; must be erased. Body:\n{body}",
+    );
+    assert!(
+        !body.contains("123-45-6789"),
+        "SSN is a CCPA §(A) identifier; must be erased. Body:\n{body}",
+    );
+}
+
+#[tokio::test]
+async fn every_shipped_template_analyzes_and_anonymizes_the_sample() {
+    // Smoke test: every template listed in `ALL` produces a
+    // valid analyze/anonymize round-trip against the sample.
+    // Catches wiring regressions (unknown group refs, unbuildable
+    // operators) that unit tests inside nvisy-template can't
+    // catch without an engine.
+    let engine = engine_with_key();
+    for (name, build) in nvisy_template::ALL {
+        let template = build();
+        let mut analyzed = engine
+            .analyze(raw_txt(), &template.policies, &template.groups, &default_spec())
+            .await
+            .unwrap_or_else(|e| panic!("template `{name}` failed to analyze: {e}"));
+        engine
+            .anonymize(
+                raw_txt(),
+                &template.policies,
+                &template.groups,
+                &mut analyzed,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("template `{name}` failed to anonymize: {e}"));
+    }
+}

--- a/crates/nvisy-policy/Cargo.toml
+++ b/crates/nvisy-policy/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 # Elide crates
 elide-core = { workspace = true, features = ["serde", "schema", "audio"] }
-elide-redaction = { workspace = true, features = ["serde", "schema", "datetime", "sha2"] }
+elide-operator = { workspace = true, features = ["serde", "schema", "datetime", "sha2"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nvisy-policy/src/redaction/text.rs
+++ b/crates/nvisy-policy/src/redaction/text.rs
@@ -64,8 +64,8 @@
 use std::collections::HashMap;
 
 use elide_core::primitive::{LanguageTag, LocalizedText};
-use elide_redaction::operators::Clamp;
-pub use elide_redaction::operators::{DateGranularity, DateStyle, Sha2Algorithm};
+use elide_operator::operators::Clamp;
+pub use elide_operator::operators::{DateGranularity, DateStyle, Sha2Algorithm};
 use hipstr::HipStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/nvisy-policy/src/rule.rs
+++ b/crates/nvisy-policy/src/rule.rs
@@ -4,17 +4,17 @@
 //!
 //! Both variants carry the same identity/description fields; the
 //! shape differs only in how targets are selected. The engine
-//! compiles either shape into elide [`Rule`]s attached via
-//! [`Anonymizer::with`]:
+//! compiles either shape into elide `Rule` values attached via
+//! `Anonymizer::with`:
 //!
 //! - **Predicated** rule → the `predicate` compiles into an elide
 //!   selector. Fast paths:
-//!   - [`Predicate::LabelOneOf`] with a single label → [`Rule::label`]
-//!   - [`Predicate::TagOneOf`] with a single tag → [`Rule::tag`]
-//!   - anything else → [`Rule::predicate`]
+//!   - [`Predicate::LabelOneOf`] with a single label → `Rule::label`
+//!   - [`Predicate::TagOneOf`] with a single tag → `Rule::tag`
+//!   - anything else → `Rule::predicate`
 //! - **Table** rule → each `(label, action)` entry attaches as
-//!   [`Rule::label`] directly; the table is sugar over N
-//!   predicated rules with identical id/name/description.
+//!   `Rule::label` directly; the table is sugar over N predicated
+//!   rules with identical id/name/description.
 //!
 //! Table rules keep templates that need per-label operator
 //! dispatch (HIPAA Safe Harbor identifier fan-out: date →
@@ -30,11 +30,6 @@
 //! [`Predicate`]: super::predicate::Predicate
 //! [`Predicate::LabelOneOf`]: super::predicate::Predicate::LabelOneOf
 //! [`Predicate::TagOneOf`]: super::predicate::Predicate::TagOneOf
-//! [`Anonymizer::with`]: elide_redaction::Anonymizer::with
-//! [`Rule`]: elide_redaction::Rule
-//! [`Rule::label`]: elide_redaction::Rule::label
-//! [`Rule::tag`]: elide_redaction::Rule::tag
-//! [`Rule::predicate`]: elide_redaction::Rule::predicate
 
 use elide_core::entity::LabelRef;
 use hipstr::HipStr;
@@ -152,14 +147,12 @@ pub struct PredicatedRule {
 
 /// Per-label table rule: N labels, N actions, one shared identity.
 ///
-/// Each entry compiles to a [`Rule::label`] attachment under this
-/// rule's shared UUID / name / description — so the audit trail
-/// records "rule X fired" without exposing the fan-out to the
-/// reviewer. Meant for templates where a single policy intent
+/// Each entry compiles to an elide `Rule::label` attachment under
+/// this rule's shared UUID / name / description — so the audit
+/// trail records "rule X fired" without exposing the fan-out to
+/// the reviewer. Meant for templates where a single policy intent
 /// (e.g. "HIPAA Safe Harbor identifiers") routes different labels
 /// to different operators.
-///
-/// [`Rule::label`]: elide_redaction::Rule::label
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TableRule {

--- a/crates/nvisy-template/Cargo.toml
+++ b/crates/nvisy-template/Cargo.toml
@@ -1,0 +1,36 @@
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[package]
+name = "nvisy-template"
+description = "Ready-to-run Nvisy policy templates for common regulatory postures (HIPAA, GDPR, PCI DSS, CCPA)"
+keywords = ["nvisy", "policy", "template", "hipaa", "gdpr"]
+categories = ["data-structures"]
+readme = "README.md"
+
+version = { workspace = true }
+rust-version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+# Internal crates
+nvisy-policy = { workspace = true }
+
+# Elide crates — for LabelRef in template bodies
+elide-core = { workspace = true, features = ["serde"] }
+
+# Primitive datatypes
+hipstr = { workspace = true, features = ["serde"] }
+jiff = { workspace = true, features = ["serde"] }
+semver = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["v7"] }

--- a/crates/nvisy-template/README.md
+++ b/crates/nvisy-template/README.md
@@ -1,0 +1,33 @@
+# nvisy-template
+
+[![Build](https://img.shields.io/github/actions/workflow/status/nvisycom/runtime/runtime-build.yml?branch=main&label=build%20%26%20test&style=flat-square)](https://github.com/nvisycom/runtime/actions/workflows/runtime-build.yml)
+
+Ready-to-run Nvisy policy templates for common regulatory postures.
+
+## Overview
+
+Each template returns a self-contained `Template` value: a set of
+`PolicyDefinition`s plus the `LabelGroup`s those policies reference,
+matched to how the engine consumes them. Callers hand the template
+straight to `Engine::analyze` / `Engine::anonymize`; no assembly
+required.
+
+Templates ship with their own semver-tracked `version` and the
+`effective_date` of the regulatory text they encode, so customers
+can pin to a snapshot when compliance requires it and audit which
+version drove a given run.
+
+## What's covered
+
+- **HIPAA Safe Harbor** — 18-identifier de-identification per
+  §164.514(b)(2).
+- **GDPR Article 9** — special-category personal data.
+- **PCI DSS §3.5.1** — Primary Account Number (PAN) render posture.
+  Ships two variants (truncate / keyed hash) so callers pick per
+  their control choice.
+- **CCPA** — Cal. Civ. Code §1798.140 personal-information
+  categories.
+
+Every template is a starting point. Customers override the
+per-label operator or fallback where their internal posture
+diverges — the returned `PolicyDefinition` is plain data.

--- a/crates/nvisy-template/src/lib.rs
+++ b/crates/nvisy-template/src/lib.rs
@@ -1,0 +1,138 @@
+#![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
+
+//! ## Architecture
+//!
+//! One function per regulatory posture, each returning a
+//! self-contained [`Template`] — the [`PolicyDefinition`]s plus
+//! the [`LabelGroup`]s those policies reference by name — matched
+//! to how the engine consumes them. Callers hand the [`Template`]
+//! straight to `Engine::analyze` / `Engine::anonymize` via
+//! [`Template::policies`] and [`Template::groups`].
+//!
+//! Templates are plain data. Nothing is registered globally, and
+//! no template constructor talks to the engine or hits I/O. A
+//! caller wanting to diverge from the shipped operator (say,
+//! swap the default [`TextRedaction::Erase`] for a
+//! [`TextRedaction::Pseudonymize`] for retained analytics use)
+//! mutates the returned [`PolicyDefinition`] before submitting.
+//!
+//! Each [`Template`] carries its own [`Version`] and the
+//! [`Date`] the regulatory text became effective, distinct from
+//! the crate's release version. A customer that must pin to a
+//! snapshot for compliance reasons pins the [`Template::version`]
+//! field, not the crate version; the two update on independent
+//! cadences.
+//!
+//! [`Date`]: jiff::civil::Date
+//! [`LabelGroup`]: nvisy_policy::LabelGroup
+//! [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+//! [`TextRedaction::Erase`]: nvisy_policy::redaction::TextRedaction::Erase
+//! [`TextRedaction::Pseudonymize`]: nvisy_policy::redaction::TextRedaction::Pseudonymize
+//! [`Version`]: semver::Version
+
+mod template;
+
+pub use self::template::Template;
+use self::template::{ccpa, gdpr, hipaa, pci};
+
+/// HIPAA Safe Harbor de-identification per 45 CFR §164.514(b)(2).
+///
+/// Ships a `hipaa_18` [`LabelGroup`] naming the 18 identifier
+/// categories the rule enumerates, plus one [`PolicyDefinition`]
+/// whose [`TableRule`] dispatches each identifier to the
+/// operator called for by the safe-harbor posture (ages ≥90
+/// [`Clamp`]ed, dates [`GeneralizeDate`]d to the year, the
+/// remainder [`TextRedaction::Erase`]d).
+///
+/// [`Clamp`]: nvisy_policy::redaction::TextRedaction::Clamp
+/// [`GeneralizeDate`]: nvisy_policy::redaction::TextRedaction::GeneralizeDate
+/// [`LabelGroup`]: nvisy_policy::LabelGroup
+/// [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+/// [`TableRule`]: nvisy_policy::TableRule
+/// [`TextRedaction::Erase`]: nvisy_policy::redaction::TextRedaction::Erase
+#[must_use]
+pub fn hipaa_safe_harbor() -> Template {
+    hipaa::template()
+}
+
+/// GDPR Article 9 special categories of personal data.
+///
+/// Ships a `gdpr_article_9` [`LabelGroup`] naming the nine
+/// special categories the article enumerates, plus one
+/// [`PolicyDefinition`] with a [`Predicated`] rule using
+/// [`Predicate::LabelInGroup`] to erase every match.
+///
+/// [`LabelGroup`]: nvisy_policy::LabelGroup
+/// [`Predicate::LabelInGroup`]: nvisy_policy::predicate::Predicate::LabelInGroup
+/// [`Predicated`]: nvisy_policy::PolicyRule::Predicated
+/// [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+#[must_use]
+pub fn gdpr_article_9() -> Template {
+    gdpr::template()
+}
+
+/// PCI DSS §3.5.1 — render stored Primary Account Numbers (PAN)
+/// unreadable via truncation to the first-six / last-four digits.
+///
+/// Ships one [`PolicyDefinition`] whose sole rule dispatches
+/// the elide-builtin `payment_card` label through
+/// [`TextRedaction::Truncate`] with `keep_prefix: 6, keep_suffix: 4`.
+/// No [`LabelGroup`] — one label, one operator.
+///
+/// [`LabelGroup`]: nvisy_policy::LabelGroup
+/// [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+/// [`TextRedaction::Truncate`]: nvisy_policy::redaction::TextRedaction::Truncate
+#[must_use]
+pub fn pci_dss_pan_truncate() -> Template {
+    pci::truncate_template()
+}
+
+/// PCI DSS §3.5.1 — render stored PAN unreadable via a keyed
+/// HMAC hash. Requires the engine to have a `KeyProvider` wired.
+///
+/// Same shape as [`pci_dss_pan_truncate`] with
+/// [`TextRedaction::HmacHash`] in the operator slot.
+///
+/// [`TextRedaction::HmacHash`]: nvisy_policy::redaction::TextRedaction::HmacHash
+#[must_use]
+pub fn pci_dss_pan_hmac() -> Template {
+    pci::hmac_template()
+}
+
+/// CCPA "personal information" categories per Cal. Civ. Code
+/// §1798.140(v).
+///
+/// Ships a `ccpa_personal_information` [`LabelGroup`] naming the
+/// enumerated categories, plus one [`PolicyDefinition`] using
+/// [`Predicate::LabelInGroup`] to erase every match. Customers
+/// commonly override the operator to [`TextRedaction::Pseudonymize`]
+/// where the retained data drives analytics.
+///
+/// [`LabelGroup`]: nvisy_policy::LabelGroup
+/// [`Predicate::LabelInGroup`]: nvisy_policy::predicate::Predicate::LabelInGroup
+/// [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+/// [`TextRedaction::Pseudonymize`]: nvisy_policy::redaction::TextRedaction::Pseudonymize
+#[must_use]
+pub fn ccpa() -> Template {
+    ccpa::template()
+}
+
+/// A [`Template`] constructor keyed by machine name. One entry
+/// per shipped template in [`ALL`].
+pub type Registered = (&'static str, fn() -> Template);
+
+/// Every template this crate ships, keyed by [`Template::name`].
+///
+/// Constructors, not values — the caller pays for whichever
+/// templates they use and no more. Iterate for coverage tests or
+/// discovery UIs; index by name for a caller-configurable
+/// registry.
+pub const ALL: &[Registered] = &[
+    ("hipaa_safe_harbor", hipaa_safe_harbor),
+    ("gdpr_article_9", gdpr_article_9),
+    ("pci_dss_pan_truncate", pci_dss_pan_truncate),
+    ("pci_dss_pan_hmac", pci_dss_pan_hmac),
+    ("ccpa", ccpa),
+];

--- a/crates/nvisy-template/src/template/ccpa.rs
+++ b/crates/nvisy-template/src/template/ccpa.rs
@@ -1,0 +1,221 @@
+//! CCPA / CPRA — "personal information" categories per
+//! Cal. Civ. Code §1798.140(v)(1).
+//!
+//! The statute enumerates eleven categories of personal
+//! information (subsections (A)–(K)). The shipped template
+//! rolls the elide-builtin labels that map onto those categories
+//! into a `ccpa_personal_information` [`LabelGroup`], and ships
+//! a single [`Predicated`] rule that erases every match.
+//!
+//! Consumer requests under CCPA fall into two large buckets:
+//! disclosure (right to know) and deletion (right to delete). The
+//! shipped template targets the deletion posture — a workflow
+//! that surfaces PI and hands the caller a redacted copy on
+//! request. Callers whose posture retains PI under a
+//! §1798.145 exception (fraud detection, security incident,
+//! transactional necessity, ...) override the operator on the
+//! returned [`PolicyDefinition`] — commonly to [`Pseudonymize`]
+//! for retained analytics that keep coreference without exposing
+//! the underlying identifier.
+//!
+//! [`LabelGroup`]: nvisy_policy::LabelGroup
+//! [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+//! [`Predicated`]: nvisy_policy::PolicyRule::Predicated
+//! [`Pseudonymize`]: nvisy_policy::redaction::TextRedaction::Pseudonymize
+
+use elide_core::entity::LabelRef;
+use jiff::civil::Date;
+use nvisy_policy::predicate::Predicate;
+use nvisy_policy::redaction::TextRedaction;
+use nvisy_policy::{LabelGroup, Labels, PolicyDefinition, PolicyRule, PredicatedRule};
+use semver::Version;
+use uuid::{Uuid, uuid};
+
+use super::{Template, text_action};
+
+/// Group name every CCPA rule references.
+pub(crate) const GROUP_NAME: &str = "ccpa_personal_information";
+
+/// Elide-builtin labels the group covers, mapped from
+/// §1798.140(v)(1) categories. See the caveats issue for two
+/// known coverage gaps ((J) non-public education info, (K)
+/// inferences — neither has a dedicated label today).
+const CCPA_LABELS: &[LabelRef] = &[
+    // (A) Identifiers
+    LabelRef::from_static("person_name"),
+    LabelRef::from_static("address"),
+    LabelRef::from_static("postal_code"),
+    LabelRef::from_static("email_address"),
+    LabelRef::from_static("phone_number"),
+    LabelRef::from_static("ip_address"),
+    LabelRef::from_static("mac_address"),
+    LabelRef::from_static("device_id"),
+    LabelRef::from_static("username"),
+    LabelRef::from_static("government_id"),
+    LabelRef::from_static("national_insurance_number"),
+    LabelRef::from_static("drivers_license"),
+    LabelRef::from_static("passport_number"),
+    // (B) §1798.80 categories overlap with (A) + adds signature,
+    // physical description, education/employment, financial /
+    // medical / insurance.
+    LabelRef::from_static("signature"),
+    LabelRef::from_static("handwriting"),
+    LabelRef::from_static("occupation"),
+    LabelRef::from_static("medical_id"),
+    LabelRef::from_static("insurance_id"),
+    LabelRef::from_static("bank_account"),
+    // (C) Protected classifications (CA/federal)
+    LabelRef::from_static("ethnicity"),
+    LabelRef::from_static("nationality"),
+    LabelRef::from_static("religion"),
+    LabelRef::from_static("gender"),
+    LabelRef::from_static("sexual_orientation"),
+    LabelRef::from_static("age"),
+    LabelRef::from_static("date_of_birth"),
+    // (D) Commercial information
+    LabelRef::from_static("payment_card"),
+    LabelRef::from_static("amount"),
+    // (E) Biometric information
+    LabelRef::from_static("fingerprint"),
+    LabelRef::from_static("voiceprint"),
+    LabelRef::from_static("retina_scan"),
+    LabelRef::from_static("facial_geometry"),
+    LabelRef::from_static("genetic_data"),
+    // (F) Internet / network activity
+    LabelRef::from_static("url"),
+    // (G) Geolocation data
+    LabelRef::from_static("coordinates"),
+    LabelRef::from_static("geolocation_metadata"),
+    // (H) Sensory (audio, visual, thermal, olfactory)
+    LabelRef::from_static("face"),
+    // (I) Professional / employment information
+    LabelRef::from_static("certificate_number"),
+    LabelRef::from_static("company_id"),
+    LabelRef::from_static("department_name"),
+];
+
+const POLICY_ID: Uuid = uuid!("016806b5-bc00-7000-8000-000000000001");
+const RULE_ID: Uuid = uuid!("016806b5-bc00-7000-8000-000000000002");
+
+/// Build the CCPA template.
+pub(crate) fn template() -> Template {
+    Template {
+        name: "ccpa".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: Date::constant(2020, 1, 1),
+        description: "CCPA / CPRA — Cal. Civ. Code §1798.140(v)(1) personal information".into(),
+        groups: vec![group()],
+        policies: vec![policy()],
+    }
+}
+
+fn group() -> LabelGroup {
+    LabelGroup {
+        name: GROUP_NAME.into(),
+        description: Some(
+            "The eleven personal-information categories enumerated in \
+             Cal. Civ. Code §1798.140(v)(1) (identifiers, §1798.80 categories, \
+             protected classifications, commercial information, biometric data, \
+             internet/network activity, geolocation, sensory data, professional/\
+             employment information, non-public education info, inferences)."
+                .to_owned(),
+        ),
+        labels: CCPA_LABELS.to_vec(),
+    }
+}
+
+fn policy() -> PolicyDefinition {
+    PolicyDefinition {
+        id: POLICY_ID,
+        name: "ccpa-personal-information".into(),
+        description: Some(
+            "Erase every §1798.140(v)(1) personal-information entity by default. \
+             Callers under a §1798.145 retention exception override the operator \
+             to Pseudonymize on the returned rule."
+                .to_owned(),
+        ),
+        when: None,
+        labels: Labels {
+            builtins: CCPA_LABELS.to_vec(),
+            custom: Vec::new(),
+        },
+        rules: vec![erase_rule()],
+        fallback: None,
+        retention: Vec::new(),
+    }
+}
+
+fn erase_rule() -> PolicyRule {
+    PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: RULE_ID,
+        name: "ccpa-personal-information-erase".into(),
+        description: Some(
+            "Erase any entity whose label falls in the ccpa_personal_information \
+             group."
+                .to_owned(),
+        ),
+        predicate: Predicate::LabelInGroup {
+            group: GROUP_NAME.to_owned(),
+        },
+        action: text_action(TextRedaction::Erase),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_carries_group_and_single_policy() {
+        let t = template();
+        assert_eq!(t.name, "ccpa");
+        assert_eq!(t.version, Version::new(1, 0, 0));
+        assert_eq!(t.groups.len(), 1);
+        assert_eq!(t.groups[0].name, GROUP_NAME);
+        assert_eq!(t.policies.len(), 1);
+    }
+
+    #[test]
+    fn every_shipped_ccpa_category_has_at_least_one_anchor_label() {
+        // Spot-check one label per shipped category so a future
+        // edit dropping a whole category trips this rather than
+        // silently regressing coverage. Categories (J) and (K)
+        // aren't covered — see caveats issue.
+        for anchor in [
+            "person_name",        // (A) identifiers
+            "signature",          // (B) §1798.80
+            "ethnicity",          // (C) protected classifications
+            "payment_card",       // (D) commercial info
+            "fingerprint",        // (E) biometric
+            "url",                // (F) internet/network activity
+            "coordinates",        // (G) geolocation
+            "face",               // (H) sensory
+            "occupation",         // (I) professional/employment
+        ] {
+            assert!(
+                CCPA_LABELS.iter().any(|l| l.as_str() == anchor),
+                "expected anchor label `{anchor}` in ccpa_personal_information group",
+            );
+        }
+    }
+
+    #[test]
+    fn rule_matches_the_group_and_erases() {
+        let PolicyRule::Predicated(rule) = &template().policies[0].rules[0] else {
+            panic!("expected Predicated rule");
+        };
+        assert!(matches!(
+            &rule.predicate,
+            Predicate::LabelInGroup { group } if group == GROUP_NAME,
+        ));
+        assert!(matches!(rule.action.text, Some(TextRedaction::Erase)));
+    }
+
+    #[test]
+    fn template_ids_are_stable_across_calls() {
+        let a = template();
+        let b = template();
+        assert_eq!(a.policies[0].id, b.policies[0].id);
+        assert_eq!(a.policies[0].rules[0].id(), b.policies[0].rules[0].id());
+    }
+}

--- a/crates/nvisy-template/src/template/gdpr.rs
+++ b/crates/nvisy-template/src/template/gdpr.rs
@@ -1,0 +1,182 @@
+//! GDPR Article 9 — special categories of personal data.
+//!
+//! Article 9(1) prohibits processing of nine categories of
+//! personal data by default (racial/ethnic origin, political
+//! opinions, religious/philosophical beliefs, trade-union
+//! membership, genetic data, biometric data used to uniquely
+//! identify a person, health data, sex life, sexual orientation).
+//! The shipped template ships a single [`Predicated`] rule that
+//! erases any entity whose label falls in the
+//! `gdpr_article_9` [`LabelGroup`], leaving the caller to
+//! override with [`Pseudonymize`] where a lawful-basis carve-out
+//! (Article 9(2)) allows retention.
+//!
+//! [`LabelGroup`]: nvisy_policy::LabelGroup
+//! [`Predicated`]: nvisy_policy::PolicyRule::Predicated
+//! [`Pseudonymize`]: nvisy_policy::redaction::TextRedaction::Pseudonymize
+
+use elide_core::entity::LabelRef;
+use jiff::civil::Date;
+use nvisy_policy::predicate::Predicate;
+use nvisy_policy::redaction::TextRedaction;
+use nvisy_policy::{LabelGroup, Labels, PolicyDefinition, PolicyRule, PredicatedRule};
+use semver::Version;
+use uuid::{Uuid, uuid};
+
+use super::{Template, text_action};
+
+/// Group name every Article 9 rule references.
+pub(crate) const GROUP_NAME: &str = "gdpr_article_9";
+
+/// Elide-builtin labels the group covers, mapped from Article
+/// 9(1) categories. See the caveats issue for two known
+/// coverage gaps (`nationality` conflated with racial/ethnic
+/// origin; no dedicated `sex_life` label).
+const GDPR_LABELS: &[LabelRef] = &[
+    // Racial or ethnic origin
+    LabelRef::from_static("ethnicity"),
+    LabelRef::from_static("nationality"),
+    // Political opinions
+    LabelRef::from_static("political_opinion"),
+    // Religious or philosophical beliefs
+    LabelRef::from_static("religion"),
+    // Trade-union membership
+    LabelRef::from_static("trade_union_membership"),
+    // Genetic data
+    LabelRef::from_static("genetic_data"),
+    // Biometric data (used for unique identification)
+    LabelRef::from_static("fingerprint"),
+    LabelRef::from_static("voiceprint"),
+    LabelRef::from_static("retina_scan"),
+    LabelRef::from_static("facial_geometry"),
+    // Health data
+    LabelRef::from_static("medical_id"),
+    LabelRef::from_static("insurance_id"),
+    LabelRef::from_static("prescription_id"),
+    LabelRef::from_static("diagnosis"),
+    LabelRef::from_static("medication"),
+    // Sexual orientation (sex life has no dedicated label — see caveats)
+    LabelRef::from_static("sexual_orientation"),
+];
+
+const POLICY_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000001");
+const RULE_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000002");
+
+/// Build the GDPR Article 9 template.
+pub(crate) fn template() -> Template {
+    Template {
+        name: "gdpr_article_9".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: Date::constant(2018, 5, 25),
+        description: "GDPR Article 9 — special categories of personal data".into(),
+        groups: vec![group()],
+        policies: vec![policy()],
+    }
+}
+
+fn group() -> LabelGroup {
+    LabelGroup {
+        name: GROUP_NAME.into(),
+        description: Some(
+            "The nine special categories of personal data enumerated in \
+             GDPR Article 9(1) (racial/ethnic origin, political opinions, \
+             religious/philosophical beliefs, trade-union membership, genetic \
+             data, biometric data for unique identification, health data, sex \
+             life, sexual orientation)."
+                .to_owned(),
+        ),
+        labels: GDPR_LABELS.to_vec(),
+    }
+}
+
+fn policy() -> PolicyDefinition {
+    PolicyDefinition {
+        id: POLICY_ID,
+        name: "gdpr-article-9".into(),
+        description: Some(
+            "Erase every Article 9(1) special-category entity by default. \
+             Callers with an Article 9(2) lawful-basis carve-out override \
+             the operator to Pseudonymize or HmacHash on the returned rule."
+                .to_owned(),
+        ),
+        when: None,
+        labels: Labels {
+            builtins: GDPR_LABELS.to_vec(),
+            custom: Vec::new(),
+        },
+        rules: vec![erase_rule()],
+        fallback: None,
+        retention: Vec::new(),
+    }
+}
+
+fn erase_rule() -> PolicyRule {
+    PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: RULE_ID,
+        name: "gdpr-article-9-erase".into(),
+        description: Some(
+            "Erase any entity whose label falls in the gdpr_article_9 group.".to_owned(),
+        ),
+        predicate: Predicate::LabelInGroup {
+            group: GROUP_NAME.to_owned(),
+        },
+        action: text_action(TextRedaction::Erase),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_carries_group_and_single_policy() {
+        let t = template();
+        assert_eq!(t.name, "gdpr_article_9");
+        assert_eq!(t.version, Version::new(1, 0, 0));
+        assert_eq!(t.groups.len(), 1);
+        assert_eq!(t.groups[0].name, GROUP_NAME);
+        assert_eq!(t.policies.len(), 1);
+    }
+
+    #[test]
+    fn every_article_9_category_has_at_least_one_label() {
+        // Spot-check one label per category so a future edit that
+        // drops a whole category (say, deletes every biometric)
+        // trips this rather than silently regressing coverage.
+        for anchor in [
+            "ethnicity",
+            "political_opinion",
+            "religion",
+            "trade_union_membership",
+            "genetic_data",
+            "fingerprint",
+            "medical_id",
+            "sexual_orientation",
+        ] {
+            assert!(
+                GDPR_LABELS.iter().any(|l| l.as_str() == anchor),
+                "expected anchor label `{anchor}` in gdpr_article_9 group",
+            );
+        }
+    }
+
+    #[test]
+    fn rule_matches_the_group_and_erases() {
+        let PolicyRule::Predicated(rule) = &template().policies[0].rules[0] else {
+            panic!("expected Predicated rule");
+        };
+        assert!(matches!(
+            &rule.predicate,
+            Predicate::LabelInGroup { group } if group == GROUP_NAME,
+        ));
+        assert!(matches!(rule.action.text, Some(TextRedaction::Erase)));
+    }
+
+    #[test]
+    fn template_ids_are_stable_across_calls() {
+        let a = template();
+        let b = template();
+        assert_eq!(a.policies[0].id, b.policies[0].id);
+        assert_eq!(a.policies[0].rules[0].id(), b.policies[0].rules[0].id());
+    }
+}

--- a/crates/nvisy-template/src/template/hipaa.rs
+++ b/crates/nvisy-template/src/template/hipaa.rs
@@ -1,0 +1,297 @@
+//! HIPAA Safe Harbor de-identification per 45 CFR §164.514(b)(2).
+//!
+//! Two rules under one policy, first-match-wins:
+//!
+//! 1. [`TableRule`] for the identifiers that need per-label
+//!    dispatch — ages ≥ 90 [`Clamp`]ed to `"90 or older"`,
+//!    dates related to an individual [`GeneralizeDate`]d to
+//!    the year.
+//! 2. [`Predicated`] rule keyed off the `hipaa_18`
+//!    [`LabelGroup`] with plain [`Erase`] — catches every other
+//!    identifier listed by the rule (names, contact info, IDs,
+//!    biometrics, etc.).
+//!
+//! The [`TableRule`] fires first so `age` and date labels reach
+//! their generalization operators; anything not in the table but
+//! covered by the group falls through to rule 2. A caller who
+//! wants a different terminal — [`Pseudonymize`] to keep
+//! coreference across mentions, [`HmacHash`] with a per-tenant
+//! key for a linkage-preserving audit — mutates the returned
+//! [`PolicyDefinition`] before submitting.
+//!
+//! [`Clamp`]: nvisy_policy::redaction::TextRedaction::Clamp
+//! [`Erase`]: nvisy_policy::redaction::TextRedaction::Erase
+//! [`GeneralizeDate`]: nvisy_policy::redaction::TextRedaction::GeneralizeDate
+//! [`HmacHash`]: nvisy_policy::redaction::TextRedaction::HmacHash
+//! [`LabelGroup`]: nvisy_policy::LabelGroup
+//! [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+//! [`Predicated`]: nvisy_policy::PolicyRule::Predicated
+//! [`Pseudonymize`]: nvisy_policy::redaction::TextRedaction::Pseudonymize
+//! [`TableRule`]: nvisy_policy::TableRule
+
+use elide_core::entity::LabelRef;
+use jiff::civil::Date;
+use nvisy_policy::predicate::Predicate;
+use nvisy_policy::redaction::{ClampBucket, DateGranularity, DateStyle, TextRedaction};
+use nvisy_policy::{
+    LabelEntry, LabelGroup, Labels, PolicyDefinition, PolicyRule, PredicatedRule, TableRule,
+};
+use semver::Version;
+use uuid::{Uuid, uuid};
+
+use super::{Template, text_action};
+
+/// Group name every HIPAA rule references.
+pub(crate) const GROUP_NAME: &str = "hipaa_18";
+
+/// Elide-builtin labels the group covers, one per HIPAA identifier
+/// category. `date_of_birth` / `date_time` / `age` are
+/// deliberately absent — they get per-label operators
+/// ([`GeneralizeDate`] / [`Clamp`]) via the table rule, not the
+/// bulk erase. Adding them here would collide with the table's
+/// intent: first-match-wins currently protects the intent, but
+/// leaving them out makes the split explicit and prevents a
+/// future rule reorder from silently converting `age`→`Clamp`
+/// into `age`→`Erase`.
+///
+/// [`Clamp`]: nvisy_policy::redaction::TextRedaction::Clamp
+/// [`GeneralizeDate`]: nvisy_policy::redaction::TextRedaction::GeneralizeDate
+const HIPAA_LABELS: &[LabelRef] = &[
+    LabelRef::from_static("person_name"),
+    LabelRef::from_static("address"),
+    LabelRef::from_static("postal_code"),
+    LabelRef::from_static("phone_number"),
+    LabelRef::from_static("fax_number"),
+    LabelRef::from_static("email_address"),
+    LabelRef::from_static("government_id"),
+    LabelRef::from_static("national_insurance_number"),
+    LabelRef::from_static("medical_id"),
+    LabelRef::from_static("insurance_id"),
+    LabelRef::from_static("bank_account"),
+    LabelRef::from_static("certificate_number"),
+    LabelRef::from_static("drivers_license"),
+    LabelRef::from_static("vehicle_id"),
+    LabelRef::from_static("license_plate"),
+    LabelRef::from_static("device_id"),
+    LabelRef::from_static("url"),
+    LabelRef::from_static("ip_address"),
+    LabelRef::from_static("fingerprint"),
+    LabelRef::from_static("voiceprint"),
+    LabelRef::from_static("retina_scan"),
+    LabelRef::from_static("facial_geometry"),
+    LabelRef::from_static("genetic_data"),
+    LabelRef::from_static("face"),
+    LabelRef::from_static("internal_id"),
+    LabelRef::from_static("case_number"),
+];
+
+/// Labels the table rule dispatches per-operator. Kept separate
+/// from [`HIPAA_LABELS`] so the group's bulk-erase rule never
+/// matches them — the table rule owns their operator dispatch.
+const TABLE_LABELS: &[LabelRef] = &[
+    LabelRef::from_static("age"),
+    LabelRef::from_static("date_of_birth"),
+    LabelRef::from_static("date_time"),
+];
+
+const POLICY_ID: Uuid = uuid!("0197c348-8800-7000-8000-000000000001");
+const RULE_SPECIAL_ID: Uuid = uuid!("0197c348-8800-7000-8000-000000000002");
+const RULE_BULK_ID: Uuid = uuid!("0197c348-8800-7000-8000-000000000003");
+
+/// Build the HIPAA Safe Harbor template.
+pub(crate) fn template() -> Template {
+    Template {
+        name: "hipaa_safe_harbor".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: Date::constant(2003, 4, 14),
+        description: "HIPAA Safe Harbor de-identification — 45 CFR §164.514(b)(2)".into(),
+        groups: vec![group()],
+        policies: vec![policy()],
+    }
+}
+
+fn group() -> LabelGroup {
+    LabelGroup {
+        name: GROUP_NAME.into(),
+        description: Some(
+            "The 18 identifier categories the HIPAA Safe Harbor rule enumerates \
+             (names, geographic subdivisions smaller than state, dates related to \
+             an individual, contact info, government/medical/account/certificate \
+             identifiers, vehicle and device ids, URLs, IPs, biometrics, faces, \
+             and other unique identifiers)."
+                .to_owned(),
+        ),
+        labels: HIPAA_LABELS.to_vec(),
+    }
+}
+
+fn policy() -> PolicyDefinition {
+    PolicyDefinition {
+        id: POLICY_ID,
+        name: "hipaa-safe-harbor".into(),
+        description: Some(
+            "HIPAA Safe Harbor de-identification. Ages ≥ 90 collapse to a bucket, \
+             dates reduce to the year, every other identifier is erased."
+                .to_owned(),
+        ),
+        when: None,
+        labels: Labels {
+            builtins: HIPAA_LABELS
+                .iter()
+                .chain(TABLE_LABELS.iter())
+                .cloned()
+                .collect(),
+            custom: Vec::new(),
+        },
+        rules: vec![special_dispatch_rule(), bulk_erase_rule()],
+        fallback: None,
+        retention: Vec::new(),
+    }
+}
+
+/// §(C) ages > 89 collapse to `"90 or older"`; dates directly
+/// related to an individual reduce to the year. Anything the
+/// rule doesn't match falls through to the bulk erase.
+fn special_dispatch_rule() -> PolicyRule {
+    PolicyRule::Table(TableRule {
+        id: RULE_SPECIAL_ID,
+        name: "hipaa-age-and-dates".into(),
+        description: Some(
+            "§164.514(b)(2)(i)(C) — ages over 89 aggregate into a `90 or older` \
+             bucket; dates related to the individual reduce to the year."
+                .to_owned(),
+        ),
+        operators: vec![
+            LabelEntry {
+                label: LabelRef::from_static("age"),
+                action: text_action(TextRedaction::Clamp {
+                    ceiling: Some(90.0),
+                    ceiling_bucket: Some(ClampBucket::Plain("90 or older".to_owned())),
+                    floor: None,
+                    floor_bucket: None,
+                    fallback: None,
+                }),
+            },
+            LabelEntry {
+                label: LabelRef::from_static("date_of_birth"),
+                action: text_action(TextRedaction::GeneralizeDate {
+                    granularity: DateGranularity::Year,
+                    style: DateStyle::Iso,
+                    fallback: None,
+                }),
+            },
+            LabelEntry {
+                label: LabelRef::from_static("date_time"),
+                action: text_action(TextRedaction::GeneralizeDate {
+                    granularity: DateGranularity::Year,
+                    style: DateStyle::Iso,
+                    fallback: None,
+                }),
+            },
+        ],
+    })
+}
+
+/// Everything else the group covers → [`Erase`].
+///
+/// [`Erase`]: nvisy_policy::redaction::TextRedaction::Erase
+fn bulk_erase_rule() -> PolicyRule {
+    PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: RULE_BULK_ID,
+        name: "hipaa-bulk-erase".into(),
+        description: Some(
+            "Every remaining §164.514(b)(2) identifier is erased.".to_owned(),
+        ),
+        predicate: Predicate::LabelInGroup {
+            group: GROUP_NAME.to_owned(),
+        },
+        action: text_action(TextRedaction::Erase),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_carries_hipaa_18_group_and_a_single_policy() {
+        let t = template();
+        assert_eq!(t.name, "hipaa_safe_harbor");
+        assert_eq!(t.version, Version::new(1, 0, 0));
+        assert_eq!(t.groups.len(), 1);
+        assert_eq!(t.groups[0].name, GROUP_NAME);
+        assert_eq!(t.policies.len(), 1);
+    }
+
+    #[test]
+    fn table_labels_are_excluded_from_bulk_erase_group() {
+        // Table-dispatched labels (age, dates) must not appear in
+        // the bulk-erase group, else a rule reorder could silently
+        // convert Clamp / GeneralizeDate into Erase.
+        for label in TABLE_LABELS {
+            assert!(
+                !HIPAA_LABELS.contains(label),
+                "table label `{}` must not appear in HIPAA_LABELS bulk-erase set",
+                label.as_str(),
+            );
+        }
+    }
+
+    #[test]
+    fn special_dispatch_rule_precedes_bulk_erase() {
+        let policy = &template().policies[0];
+        assert!(
+            matches!(&policy.rules[0], PolicyRule::Table(_)),
+            "table rule must fire first so `age` and dates reach their generalizers",
+        );
+        assert!(matches!(&policy.rules[1], PolicyRule::Predicated(_)));
+    }
+
+    #[test]
+    fn table_rule_dispatches_age_to_clamp_and_dates_to_generalize() {
+        let PolicyRule::Table(table) = &template().policies[0].rules[0] else {
+            panic!("first rule must be Table");
+        };
+        let age = table
+            .operators
+            .iter()
+            .find(|e| e.label.as_str() == "age")
+            .expect("age entry present");
+        assert!(matches!(
+            age.action.text,
+            Some(TextRedaction::Clamp { ceiling: Some(c), .. }) if (c - 90.0).abs() < f64::EPSILON,
+        ));
+        for date_label in ["date_of_birth", "date_time"] {
+            let entry = table
+                .operators
+                .iter()
+                .find(|e| e.label.as_str() == date_label)
+                .unwrap_or_else(|| panic!("{date_label} entry present"));
+            assert!(matches!(
+                entry.action.text,
+                Some(TextRedaction::GeneralizeDate { .. }),
+            ));
+        }
+    }
+
+    #[test]
+    fn bulk_rule_matches_the_group() {
+        let PolicyRule::Predicated(rule) = &template().policies[0].rules[1] else {
+            panic!("second rule must be Predicated");
+        };
+        assert!(matches!(
+            &rule.predicate,
+            Predicate::LabelInGroup { group } if group == GROUP_NAME,
+        ));
+        assert!(matches!(rule.action.text, Some(TextRedaction::Erase)));
+    }
+
+    #[test]
+    fn template_ids_are_stable_across_calls() {
+        let a = template();
+        let b = template();
+        assert_eq!(a.policies[0].id, b.policies[0].id);
+        assert_eq!(a.policies[0].rules[0].id(), b.policies[0].rules[0].id());
+        assert_eq!(a.policies[0].rules[1].id(), b.policies[0].rules[1].id());
+    }
+}

--- a/crates/nvisy-template/src/template/mod.rs
+++ b/crates/nvisy-template/src/template/mod.rs
@@ -1,0 +1,86 @@
+//! The [`Template`] value every template constructor returns:
+//! the [`PolicyDefinition`]s + [`LabelGroup`]s a caller submits
+//! together, plus identity metadata the engine records on every
+//! run driven by this template.
+
+pub(crate) mod ccpa;
+pub(crate) mod gdpr;
+pub(crate) mod hipaa;
+pub(crate) mod pci;
+
+use hipstr::HipStr;
+use jiff::civil::Date;
+use nvisy_policy::redaction::{ModalityRedactions, TextRedaction};
+use nvisy_policy::{LabelGroup, PolicyDefinition};
+use semver::Version;
+
+/// A regulatory posture packaged as engine-ready data.
+///
+/// Templates are plain data; a caller wanting to diverge from
+/// the shipped defaults mutates the returned [`policies`] /
+/// [`groups`] before submitting. The engine never sees the
+/// [`Template`] itself — only its [`policies`] and [`groups`]
+/// via `Engine::analyze` / `Engine::anonymize`.
+///
+/// # Identity
+///
+/// Templates carry their own [`version`] and [`effective_date`],
+/// distinct from the crate's release version and the individual
+/// [`PolicyDefinition::id`]s inside. That separation matters
+/// because regulatory text updates on its own cadence: a
+/// customer pinned to `hipaa_safe_harbor` v1 doesn't want a
+/// point-release of `nvisy-template` shifting the labelset out
+/// from under them.
+///
+/// [`effective_date`]: Self::effective_date
+/// [`groups`]: Self::groups
+/// [`policies`]: Self::policies
+/// [`version`]: Self::version
+/// [`PolicyDefinition::id`]: nvisy_policy::PolicyDefinition::id
+#[derive(Debug, Clone)]
+pub struct Template {
+    /// Stable identifier for the template, matched to the
+    /// constructor that produced it (`"hipaa_safe_harbor"`,
+    /// `"gdpr_article_9"`, ...). Not a display string —
+    /// snake_case, ASCII, kebab-safe. Used to key registries and
+    /// to name the template in audit annotations.
+    pub name: HipStr<'static>,
+    /// Semver-tracked version of *this* template, distinct from
+    /// the crate version. A change to the shipped labelset or
+    /// operator dispatch bumps this field. See [`semver::Version`]
+    /// for the parse / comparison semantics.
+    pub version: Version,
+    /// The date the regulatory text this template encodes became
+    /// effective. Not the date the template was authored — the
+    /// date the *rule* took force. Reviewers reading an audit
+    /// trail check this against the run date to confirm the
+    /// template that fired was the one in force at the time.
+    pub effective_date: Date,
+    /// Human-readable name for reviewers. `name` is the machine
+    /// identifier; this is the string a customer sees.
+    pub description: HipStr<'static>,
+    /// [`LabelGroup`]s the template's [`policies`] reference by
+    /// name. Passed as-is to `Engine::analyze` / `anonymize`.
+    /// May be empty for templates whose rules address labels
+    /// directly (e.g. PAN-only templates).
+    ///
+    /// [`policies`]: Self::policies
+    /// [`LabelGroup`]: nvisy_policy::LabelGroup
+    pub groups: Vec<LabelGroup>,
+    /// The [`PolicyDefinition`]s a caller submits in precedence
+    /// order. Every template ships at least one.
+    ///
+    /// [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+    pub policies: Vec<PolicyDefinition>,
+}
+
+/// Wrap a text-modality [`TextRedaction`] in a
+/// [`ModalityRedactions`] with every other modality slot left
+/// empty. The common case across every shipped template — text
+/// is where the regulatory action lives.
+pub(crate) fn text_action(spec: TextRedaction) -> ModalityRedactions {
+    ModalityRedactions {
+        text: Some(spec),
+        ..Default::default()
+    }
+}

--- a/crates/nvisy-template/src/template/pci.rs
+++ b/crates/nvisy-template/src/template/pci.rs
@@ -1,0 +1,233 @@
+//! PCI DSS §3.5.1 — render stored Primary Account Numbers (PAN)
+//! unreadable.
+//!
+//! §3.5.1 lists four acceptable render approaches: one-way hashes
+//! based on strong cryptography, truncation, index tokens with
+//! securely stored pads, and strong cryptography with associated
+//! key-management processes. This module ships the two the runtime
+//! covers today:
+//!
+//! - [`truncate_template`] → `Truncate { keep_prefix: 6, keep_suffix: 4 }`
+//!   — the historical PCI truncation posture. No key material
+//!   involved.
+//! - [`hmac_template`] → `HmacHash { algorithm: Sha256 }` — the
+//!   "keyed cryptographic hash" posture PCI DSS v4.0.1
+//!   introduces. Requires the engine to have a `KeyProvider`
+//!   wired.
+//!
+//! Both target the elide-builtin `payment_card` label. No
+//! [`LabelGroup`] — one label, one rule per template. Callers
+//! wanting both dispatched from one policy compose the two
+//! [`PolicyDefinition`]s themselves.
+//!
+//! [`LabelGroup`]: nvisy_policy::LabelGroup
+//! [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
+
+use elide_core::entity::LabelRef;
+use jiff::civil::Date;
+use nvisy_policy::predicate::Predicate;
+use nvisy_policy::redaction::{Sha2Algorithm, TextRedaction};
+use nvisy_policy::{Labels, PolicyDefinition, PolicyRule, PredicatedRule};
+use semver::Version;
+use uuid::{Uuid, uuid};
+
+use super::{Template, text_action};
+
+/// The elide-builtin label PCI PAN templates dispatch on.
+const PAN_LABEL: LabelRef = LabelRef::from_static("payment_card");
+
+/// PCI DSS §3.5.1 effective date (v4.0.1 mandatory compliance).
+const EFFECTIVE_DATE: Date = Date::constant(2025, 3, 31);
+
+const TRUNCATE_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000001");
+const TRUNCATE_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000002");
+const HMAC_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000003");
+const HMAC_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000004");
+
+/// PCI DSS §3.5.1 — truncation posture: keep the first six and
+/// last four digits, drop the middle.
+pub(crate) fn truncate_template() -> Template {
+    Template {
+        name: "pci_dss_pan_truncate".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: EFFECTIVE_DATE,
+        description: "PCI DSS §3.5.1 — PAN render via truncation (keep first-six / last-four)"
+            .into(),
+        groups: Vec::new(),
+        policies: vec![PolicyDefinition {
+            id: TRUNCATE_POLICY_ID,
+            name: "pci-dss-pan-truncate".into(),
+            description: Some(
+                "Truncate stored PAN to the first six digits and last four, dropping \
+                 the middle. Keeps BIN and last-four for downstream lookups without \
+                 leaving a reversible ciphertext or a key surface to protect."
+                    .to_owned(),
+            ),
+            when: None,
+            labels: Labels {
+                builtins: vec![PAN_LABEL.clone()],
+                custom: Vec::new(),
+            },
+            rules: vec![truncate_rule()],
+            fallback: None,
+            retention: Vec::new(),
+        }],
+    }
+}
+
+/// PCI DSS §3.5.1 — keyed cryptographic hash posture: HMAC-SHA-256
+/// with a per-tenant key.
+pub(crate) fn hmac_template() -> Template {
+    Template {
+        name: "pci_dss_pan_hmac".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: EFFECTIVE_DATE,
+        description: "PCI DSS §3.5.1 — PAN render via keyed cryptographic hash (HMAC-SHA-256)"
+            .into(),
+        groups: Vec::new(),
+        policies: vec![PolicyDefinition {
+            id: HMAC_POLICY_ID,
+            name: "pci-dss-pan-hmac".into(),
+            description: Some(
+                "Replace stored PAN with a keyed HMAC-SHA-256 digest. Requires the \
+                 engine to have a KeyProvider wired via `Engine::with_key_provider`. \
+                 The key must stay secret; a leaked key permits offline PAN enumeration \
+                 against the shipped hash."
+                    .to_owned(),
+            ),
+            when: None,
+            labels: Labels {
+                builtins: vec![PAN_LABEL.clone()],
+                custom: Vec::new(),
+            },
+            rules: vec![hmac_rule()],
+            fallback: None,
+            retention: Vec::new(),
+        }],
+    }
+}
+
+fn truncate_rule() -> PolicyRule {
+    PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: TRUNCATE_RULE_ID,
+        name: "pci-truncate-pan".into(),
+        description: Some(
+            "Drop the middle of every payment_card value, keeping the first six \
+             (BIN) and last four digits."
+                .to_owned(),
+        ),
+        predicate: single_label(PAN_LABEL.clone()),
+        action: text_action(TextRedaction::Truncate {
+            keep_prefix: 6,
+            keep_suffix: 4,
+        }),
+    }))
+}
+
+fn hmac_rule() -> PolicyRule {
+    PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: HMAC_RULE_ID,
+        name: "pci-hmac-pan".into(),
+        description: Some(
+            "Replace every payment_card value with an HMAC-SHA-256 digest keyed on \
+             the engine's KeyProvider."
+                .to_owned(),
+        ),
+        predicate: single_label(PAN_LABEL.clone()),
+        action: text_action(TextRedaction::HmacHash {
+            algorithm: Sha2Algorithm::Sha256,
+        }),
+    }))
+}
+
+fn single_label(label: LabelRef) -> Predicate {
+    Predicate::LabelOneOf {
+        labels: vec![label],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_template_shape() {
+        let t = truncate_template();
+        assert_eq!(t.name, "pci_dss_pan_truncate");
+        assert_eq!(t.version, Version::new(1, 0, 0));
+        assert!(t.groups.is_empty(), "PCI templates ship no LabelGroup");
+        assert_eq!(t.policies.len(), 1);
+    }
+
+    #[test]
+    fn hmac_template_shape() {
+        let t = hmac_template();
+        assert_eq!(t.name, "pci_dss_pan_hmac");
+        assert_eq!(t.version, Version::new(1, 0, 0));
+        assert!(t.groups.is_empty());
+        assert_eq!(t.policies.len(), 1);
+    }
+
+    #[test]
+    fn truncate_rule_keeps_bin_and_last_four() {
+        let PolicyRule::Predicated(rule) = &truncate_template().policies[0].rules[0] else {
+            panic!("expected Predicated rule");
+        };
+        assert!(matches!(
+            rule.action.text,
+            Some(TextRedaction::Truncate {
+                keep_prefix: 6,
+                keep_suffix: 4,
+            })
+        ));
+    }
+
+    #[test]
+    fn hmac_rule_uses_sha256_by_default() {
+        let PolicyRule::Predicated(rule) = &hmac_template().policies[0].rules[0] else {
+            panic!("expected Predicated rule");
+        };
+        assert!(matches!(
+            rule.action.text,
+            Some(TextRedaction::HmacHash {
+                algorithm: Sha2Algorithm::Sha256,
+            })
+        ));
+    }
+
+    #[test]
+    fn both_templates_target_payment_card_label() {
+        for template in [truncate_template(), hmac_template()] {
+            let PolicyRule::Predicated(rule) = &template.policies[0].rules[0] else {
+                panic!("expected Predicated rule");
+            };
+            let Predicate::LabelOneOf { labels } = &rule.predicate else {
+                panic!("expected LabelOneOf predicate");
+            };
+            assert_eq!(labels.len(), 1);
+            assert_eq!(labels[0], PAN_LABEL);
+        }
+    }
+
+    #[test]
+    fn template_ids_are_stable_across_calls() {
+        let trunc_a = truncate_template();
+        let trunc_b = truncate_template();
+        assert_eq!(trunc_a.policies[0].id, trunc_b.policies[0].id);
+        assert_eq!(
+            trunc_a.policies[0].rules[0].id(),
+            trunc_b.policies[0].rules[0].id(),
+        );
+        let hmac_a = hmac_template();
+        let hmac_b = hmac_template();
+        assert_eq!(hmac_a.policies[0].id, hmac_b.policies[0].id);
+        assert_eq!(
+            hmac_a.policies[0].rules[0].id(),
+            hmac_b.policies[0].rules[0].id(),
+        );
+        assert_ne!(
+            trunc_a.policies[0].id, hmac_a.policies[0].id,
+            "the two PCI templates must ship distinct policy identities",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the regulatory-templates rollout: a new \`nvisy-template\` crate ships ready-to-run policy sets for HIPAA Safe Harbor, GDPR Article 9, PCI DSS §3.5.1 (two variants), and CCPA. Built on top of the Phase 1 primitives (LabelGroup, TableRule, elide operators, LabelInGroup predicate).

Two commits:

1. **Bump elide to catch operator crate split** — elide reorganized alongside \`LabelRef::from_static\` (nvisycom/elide#171): \`elide-operator\` (owns the shipped operators), \`elide-context\`, \`elide-engine\`, \`elide-codec\`. All \`elide::...\` facade paths still resolve through re-exports; the only direct-dep case is \`nvisy-policy\` (swapped \`elide-redaction\` → \`elide-operator\` for \`DateGranularity\` / \`Sha2Algorithm\` / \`Clamp\`).

2. **Add nvisy-template crate with four regulatory templates** — the crate + engine-side integration tests.

## What ships

| Template | Group | Rule shape | Notes |
|---|---|---|---|
| \`hipaa_safe_harbor()\` | \`hipaa_18\` (26 labels) | \`Table\` (age→Clamp≥90, dates→GeneralizeDate) + \`Predicated\` (bulk Erase) | Table labels excluded from group so rule reorder can't silently drop Clamp |
| \`gdpr_article_9()\` | \`gdpr_article_9\` (16 labels) | \`Predicated\` \`LabelInGroup → Erase\` | |
| \`pci_dss_pan_truncate()\` | — | \`Predicated\` \`Truncate { keep_prefix: 6, keep_suffix: 4 }\` | Single \`payment_card\` label |
| \`pci_dss_pan_hmac()\` | — | \`Predicated\` \`HmacHash { Sha256 }\` | Requires \`Engine::with_key_provider\` |
| \`ccpa()\` | \`ccpa_personal_information\` (37 labels) | \`Predicated\` \`LabelInGroup → Erase\` | |

Each template carries stable UUIDv7 constants (audit-trail continuity), its own \`semver::Version\`, and the regulatory text's \`effective_date\`. Label constants are \`&[LabelRef]\` via elide#171's new const \`LabelRef::from_static\`. Templates are plain data — customers override the returned \`PolicyDefinition\` at import time to swap \`Erase\` for \`Pseudonymize\` / \`HmacHash\` when their posture requires retention.

## Follow-up work already tracked

Per-template deviation issues filed as part of the rollout:

- HIPAA — nvisycom/runtime#362
- GDPR — nvisycom/runtime#363
- PCI — nvisycom/runtime#364
- CCPA — nvisycom/runtime#365

Test-fixture gap (sample.txt has no PAN, age ≥ 90, or DOB, so \`Truncate\` / \`HmacHash\` / \`Clamp\` / \`GeneralizeDate\` operator branches never fire in integration tests) — nvisycom/runtime#366.

## Test plan

- [x] \`cargo test --workspace --all-features\` — 27 tests green (20 template unit + 7 engine integration)
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps\`
- [ ] Manual verification that HIPAA / CCPA integration tests really remove contact info from a fresh sample
- [ ] Confirm the PCI HMAC template errors cleanly when no \`KeyProvider\` is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)