### PR TITLE
chore: prune unused deps and align Cargo.toml headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,8 +2632,6 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "csv",
- "derive_builder",
- "derive_more",
  "elide",
  "elide-bento",
  "elide-core",
@@ -2644,8 +2642,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "strum 0.28.0",
- "thiserror",
  "tokio",
  "tracing",
  "uuid",
@@ -2656,7 +2652,6 @@ dependencies = [
 name = "nvisy-policy"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "elide-core",
  "elide-operator",
  "hipstr",
@@ -2677,7 +2672,6 @@ dependencies = [
  "nvisy-policy",
  "schemars",
  "serde",
- "serde_json",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,18 +33,10 @@ documentation = "https://docs.rs/nvisy-runtime"
 
 # Elide crates
 elide = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-codec = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-context = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-core = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-detection = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-engine = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-llm = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-ner = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-ocr = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 elide-operator = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-pattern = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-redaction = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
-elide-stt = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 
 # Elide extensions
 elide-bento = { path = "./crates/elide-bento", version = "0.1.0" }

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -118,13 +118,13 @@ tracing = { workspace = true, features = [] }
 nvisy-engine = { path = ".", features = ["test-utils", "audit-json", "audit-csv"] }
 nvisy-template = { workspace = true }
 
-# Primitive datatypes
-uuid = { workspace = true, features = ["v7"] }
-bytes = { workspace = true, features = [] }
-hipstr = { workspace = true, features = [] }
-
 # Serialization
 serde_json = { workspace = true, features = [] }
+
+# Primitive datatypes
+bytes = { workspace = true, features = [] }
+hipstr = { workspace = true, features = [] }
+uuid = { workspace = true, features = ["v7"] }
 
 # Test utilities
 zip = { workspace = true }

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -106,12 +106,6 @@ serde_json = { workspace = true, features = [], optional = true }
 schemars = { workspace = true, features = [] }
 csv = { workspace = true, features = [], optional = true }
 
-# Derive macros and error handling
-thiserror = { workspace = true, features = [] }
-derive_more = { workspace = true, features = ["display"] }
-derive_builder = { workspace = true, features = [] }
-strum = { workspace = true, features = ["derive"] }
-
 # Primitive datatypes
 uuid = { workspace = true, features = [] }
 bytes = { workspace = true, features = [] }

--- a/crates/nvisy-policy/Cargo.toml
+++ b/crates/nvisy-policy/Cargo.toml
@@ -31,8 +31,7 @@ elide-operator = { workspace = true, features = ["serde", "schema", "datetime", 
 serde = { workspace = true, features = ["derive"] }
 schemars = { workspace = true, features = ["uuid1"] }
 
-# Derive macros and error handling
-derive_more = { workspace = true, features = ["display"] }
+# Derive macros
 strum = { workspace = true, features = ["derive"] }
 
 # Primitive datatypes

--- a/crates/nvisy-policy/Cargo.toml
+++ b/crates/nvisy-policy/Cargo.toml
@@ -31,7 +31,7 @@ elide-operator = { workspace = true, features = ["serde", "schema", "datetime", 
 serde = { workspace = true, features = ["derive"] }
 schemars = { workspace = true, features = ["uuid1"] }
 
-# Derive macros
+# Derive macros and error handling
 strum = { workspace = true, features = ["derive"] }
 
 # Primitive datatypes

--- a/crates/nvisy-schema/Cargo.toml
+++ b/crates/nvisy-schema/Cargo.toml
@@ -40,7 +40,6 @@ nvisy-policy = { workspace = true, features = [] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = [] }
 schemars = { workspace = true, features = ["uuid1"] }
 
 # Primitive datatypes

--- a/crates/nvisy-template/Cargo.toml
+++ b/crates/nvisy-template/Cargo.toml
@@ -23,11 +23,11 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+# Elide crates
+elide-core = { workspace = true, features = ["serde"] }
+
 # Internal crates
 nvisy-policy = { workspace = true }
-
-# Elide crates — for LabelRef in template bodies
-elide-core = { workspace = true, features = ["serde"] }
 
 # Primitive datatypes
 hipstr = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
## Summary

Two atomic cleanups on unrelated but overlapping surface (\`Cargo.toml\` hygiene).

## 1. Prune unused dependencies

**Workspace \`elide-*\` deps** — the Phase 2 elide bump (nvisycom/runtime#367) added every new subcrate name to \`[workspace.dependencies]\` reflexively. Only five are actually consumed:

- \`elide\` — top-level facade (bulk of imports)
- \`elide-core\` — 123 direct-use sites (primitives)
- \`elide-operator\` — \`nvisy-policy\` re-exports \`DateGranularity\` / \`Sha2Algorithm\` / \`Clamp\`
- \`elide-ner\`, \`elide-ocr\` — used by \`elide-bento\`

Drop the other eight (\`elide-codec\`, \`elide-context\`, \`elide-detection\`, \`elide-engine\`, \`elide-llm\`, \`elide-pattern\`, \`elide-redaction\`, \`elide-stt\`). Every consumer reaches them through the \`elide::*\` facade re-exports.

**Crate-level unused deps** flagged by \`cargo machete\`:

- \`nvisy-engine\`: \`thiserror\`, \`derive_more\`, \`derive_builder\`, \`strum\`
- \`nvisy-policy\`: \`derive_more\`
- \`nvisy-schema\`: \`serde_json\`

None are macro-hidden — verified by grepping for every derive proc-macro name the crates might use.

## 2. Align Cargo.toml section headers

Root uses a stable set of headers in a fixed order (\`# Elide crates\`, \`# Elide extensions\`, \`# Internal crates\`, \`# Serialization\`, \`# Derive macros and error handling\`, \`# Primitive datatypes\`, ...). Crate-level manifests had drifted — same headers spelled differently or in different order. Normalize.

## Test plan

- [x] \`cargo machete\` — clean
- [x] \`cargo check --workspace --all-features --all-targets\`
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-features\` — 27 tests green
- [x] \`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)