### PR TITLE
chore(ci): faster caching, all-features tier, machete gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "chore"
+      - "dependencies"
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
@@ -35,6 +36,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "chore"
+      - "dependencies"
     commit-message:
       prefix: "chore(deps-py)"
       prefix-development: "chore(deps-py-dev)"
@@ -58,6 +60,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "chore"
+      - "dependencies"
     commit-message:
       prefix: "chore(actions)"
     groups:

--- a/.github/workflows/runtime-build.yml
+++ b/.github/workflows/runtime-build.yml
@@ -44,17 +44,13 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-check-
+        uses: Swatinem/rust-cache@v2
 
       - name: Cargo check
         run: cargo check --workspace
+
+      - name: Cargo check (all features)
+        run: cargo check --workspace --all-features
 
   clippy:
     name: Clippy
@@ -71,17 +67,13 @@ jobs:
           components: clippy
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-clippy-
+        uses: Swatinem/rust-cache@v2
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
+
+      - name: Clippy (all features)
+        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
   docs:
     name: Docs
@@ -91,25 +83,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Nightly: the `docsrs` cfg enables `feature(doc_cfg)`.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-docs-
+        uses: Swatinem/rust-cache@v2
 
+      # Build docs the way docs.rs publishes them: all features + docsrs on nightly.
       - name: Cargo doc
-        run: cargo doc --workspace --no-deps
+        run: cargo +nightly doc --workspace --no-deps --all-features
         env:
-          RUSTDOCFLAGS: "-D warnings"
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
 
   test:
     name: Test
@@ -126,17 +111,13 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-test-
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --workspace
+
+      - name: Run tests (all features)
+        run: cargo test --workspace --all-features
 
   build:
     name: Build
@@ -153,14 +134,29 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-build-
+        uses: Swatinem/rust-cache@v2
 
       - name: Build release
         run: cargo build --release
+
+  machete:
+    name: Machete
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install cargo-machete
+        run: cargo binstall cargo-machete --no-confirm --no-symlinks
+
+      - name: Run machete
+        run: cargo machete

--- a/.github/workflows/runtime-release.yml
+++ b/.github/workflows/runtime-release.yml
@@ -53,14 +53,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-publish-
+        uses: Swatinem/rust-cache@v2
 
       - name: Publish nvisy-ontology
         run: cargo publish -p nvisy-ontology --token ${{ secrets.CARGO_TOKEN }}


### PR DESCRIPTION
## Summary

Bring runtime CI up to the elide-side conventions the team is used to. Main win is the caching swap; two other quality bumps land at the same time; new machete job locks in the dep hygiene from runtime#368.

## Changes

### Caching (the main event)

Swap hand-rolled \`actions/cache@v6\` blocks for **\`Swatinem/rust-cache@v2\`** across \`runtime-build.yml\` and \`runtime-release.yml\`. Existing setup had a distinct cache scope per job (\`-cargo-check-\`, \`-cargo-clippy-\`, \`-cargo-test-\`, \`-cargo-docs-\`, \`-cargo-build-\`) so every job compiled from scratch on a fresh PR. \`Swatinem/rust-cache\` shares one warm cache across all jobs in the workflow, invalidates on toolchain bumps automatically, and prunes regen-able artefacts (\`target/**/incremental\`, \`target/**/build\`) so the cache stays under GH's 5 GB limit.

### All-features tier

Runtime ships feature-gated code paths (\`audit-json\` / \`audit-csv\`, per-codec toggles) that default-features CI never exercised. Add an \`--all-features\` step to \`check\`, \`clippy\`, and \`test\`. Catches drift.

### Nightly rustdoc

Runtime crates already carry \`#![cfg_attr(docsrs, feature(doc_cfg))]\` and \`#[cfg_attr(docsrs, doc(cfg(feature = "…")))]\` annotations, but the \`docs\` job built with stable Rust — silently dropping those annotations. Switch to \`dtolnay/rust-toolchain@nightly\` with \`RUSTDOCFLAGS: "--cfg docsrs -D warnings"\`, matching how docs.rs publishes.

### Machete gate

New \`machete\` job runs \`cargo machete\` via cargo-binstall. Catches unused deps in PRs going forward. Runs alongside the manual cleanup pass in runtime#368.

### Dependabot label

Auto-PRs now carry both \`chore\` and \`dependencies\` (label mirrors bentoml's convention; created just now).

## Not in this PR

- Splitting \`runtime-build.yml\` into build/test/security like elide's \`build.yml\`+\`security.yml\`. Runtime already has \`runtime-security.yml\` separate (cargo-deny weekly cron); no split needed.
- Fixing \`runtime-release.yml\` still referring to the long-deleted \`nvisy-ontology\` crate. Filed separately.

## Test plan

- [ ] Push triggers the new build workflow, all jobs go green
- [ ] Machete step catches an intentionally-unused dep if added
- [ ] Cache hit visible in job summary (\`Swatinem/rust-cache\` prints a summary line)
- [ ] Dependabot's next auto-PR carries both \`chore\` and \`dependencies\` labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)