### PR TITLE
chore(ci): add fmt gate + reformat workspace

### DIFF
--- a/.github/workflows/runtime-build.yml
+++ b/.github/workflows/runtime-build.yml
@@ -9,6 +9,7 @@ on:
       - "crates/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rustfmt.toml"
       - ".github/workflows/runtime-build.yml"
   pull_request:
     branches:
@@ -18,6 +19,7 @@ on:
       - "crates/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rustfmt.toml"
       - ".github/workflows/runtime-build.yml"
   workflow_dispatch:
 
@@ -30,6 +32,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo +nightly fmt --all --check
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/crates/nvisy-engine/src/analyzer/catalog.rs
+++ b/crates/nvisy-engine/src/analyzer/catalog.rs
@@ -256,7 +256,11 @@ mod tests {
         let catalog = compile_catalog(std::slice::from_ref(&policy), &[group.clone(), group]);
         let stamped = catalog.get(&LabelRef::new("email_address")).unwrap();
         assert_eq!(
-            stamped.tags().iter().filter(|t| t.as_str() == "group:dup").count(),
+            stamped
+                .tags()
+                .iter()
+                .filter(|t| t.as_str() == "group:dup")
+                .count(),
             1,
         );
     }

--- a/crates/nvisy-engine/src/anonymizer/compile/selector.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/selector.rs
@@ -108,9 +108,7 @@ where
         Predicate::LabelOneOf { labels } if labels.len() == 1 => {
             Rule::label(labels[0].clone(), operator)
         }
-        Predicate::TagOneOf { tags } if tags.len() == 1 => {
-            Rule::tag(tags[0].clone(), operator)
-        }
+        Predicate::TagOneOf { tags } if tags.len() == 1 => Rule::tag(tags[0].clone(), operator),
         Predicate::LabelInGroup { group } => {
             // Groups compile to a synthetic `group:<name>` tag on
             // every listed label (see `analyzer::catalog`), so a

--- a/crates/nvisy-engine/src/pipeline/audit_csv.rs
+++ b/crates/nvisy-engine/src/pipeline/audit_csv.rs
@@ -16,8 +16,7 @@
 //! polymorphic locations. Callers that need location details or
 //! nested payloads use [`Audit::write_json`].
 
-use std::io;
-use std::result;
+use std::{io, result};
 
 use elide_core::entity::provenance::EventKind;
 use elide_core::modality::Modality;

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -77,8 +77,6 @@ mod audit_csv;
 mod orchestrator;
 mod registered;
 
-pub use self::registered::RegisteredRecognizer;
-
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -101,6 +99,7 @@ use nvisy_schema::policy::{LabelGroup, PolicyDefinition};
 use uuid::Uuid;
 
 pub use self::audit::{Audit, AuditContext};
+pub use self::registered::RegisteredRecognizer;
 use crate::PatternGuardrails;
 use crate::entity::{EntityGroup, take_body, take_part};
 use crate::provider::llm::LlmConfig;

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -44,7 +44,6 @@ use elide::redaction::vault::InMemoryVault;
 use elide::{Orchestrator, Result};
 use elide_core::entity::LabelCatalog;
 use elide_core::modality::Modality;
-use elide_core::{Error, ErrorKind};
 #[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
 #[cfg(feature = "internal_image")]
@@ -52,6 +51,7 @@ use elide_core::modality::image::Image;
 #[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
+use elide_core::{Error, ErrorKind};
 use nvisy_schema::plan::AnalyzerParams;
 use nvisy_schema::policy::predicate::Predicate;
 use nvisy_schema::policy::redaction::ModalityRedactions;
@@ -241,10 +241,7 @@ impl Engine {
 /// [`HashSet`] over the request's group names.
 ///
 /// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
-fn validate_group_references(
-    policies: &[PolicyDefinition],
-    groups: &[LabelGroup],
-) -> Result<()> {
+fn validate_group_references(policies: &[PolicyDefinition], groups: &[LabelGroup]) -> Result<()> {
     let known: HashSet<&str> = groups.iter().map(|g| g.name.as_str()).collect();
     for policy in policies {
         for rule in &policy.rules {
@@ -266,16 +263,16 @@ fn check_predicate_groups(
     rule: &PolicyRule,
 ) -> Result<()> {
     match predicate {
-        Predicate::LabelInGroup { group } if !known.contains(group.as_str()) => {
-            Err(Error::new(
-                ErrorKind::Configuration,
-                format!(
-                    "policy `{}` rule `{}` references unknown label group `{}` — \
+        Predicate::LabelInGroup { group } if !known.contains(group.as_str()) => Err(Error::new(
+            ErrorKind::Configuration,
+            format!(
+                "policy `{}` rule `{}` references unknown label group `{}` — \
                      no `LabelGroup` with that name was submitted with the request",
-                    policy.id, rule.id(), group,
-                ),
-            ))
-        }
+                policy.id,
+                rule.id(),
+                group,
+            ),
+        )),
         Predicate::All { all } => all
             .iter()
             .try_for_each(|p| check_predicate_groups(p, known, policy, rule)),

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -200,12 +200,22 @@ async fn anonymize_succeeds_when_policies_supply_catalog_afresh() {
         retention: Vec::new(),
     };
     let mut analyzed = engine
-        .analyze(raw_docx(), std::slice::from_ref(&policy), &[], &default_spec())
+        .analyze(
+            raw_docx(),
+            std::slice::from_ref(&policy),
+            &[],
+            &default_spec(),
+        )
         .await
         .expect("analyze succeeds");
 
     engine
-        .anonymize(raw_docx(), std::slice::from_ref(&policy), &[], &mut analyzed)
+        .anonymize(
+            raw_docx(),
+            std::slice::from_ref(&policy),
+            &[],
+            &mut analyzed,
+        )
         .await
         .expect("anonymize succeeds when catalog is re-derived from the same policy set");
 }

--- a/crates/nvisy-engine/tests/policy_shapes.rs
+++ b/crates/nvisy-engine/tests/policy_shapes.rs
@@ -100,7 +100,10 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
         description: None,
         when: None,
         labels: Labels {
-            builtins: vec![LabelRef::new("email_address"), LabelRef::new("phone_number")],
+            builtins: vec![
+                LabelRef::new("email_address"),
+                LabelRef::new("phone_number"),
+            ],
             custom: Vec::new(),
         },
         rules: vec![table],
@@ -118,12 +121,7 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
         .await
         .expect("analyze succeeds");
     let redacted = engine
-        .anonymize(
-            raw_txt(),
-            std::slice::from_ref(&policy),
-            &[],
-            &mut analyzed,
-        )
+        .anonymize(raw_txt(), std::slice::from_ref(&policy), &[], &mut analyzed)
         .await
         .expect("anonymize succeeds");
 
@@ -189,7 +187,10 @@ async fn label_in_group_predicate_fires_on_grouped_labels() {
         description: None,
         when: None,
         labels: Labels {
-            builtins: vec![LabelRef::new("email_address"), LabelRef::new("phone_number")],
+            builtins: vec![
+                LabelRef::new("email_address"),
+                LabelRef::new("phone_number"),
+            ],
             custom: Vec::new(),
         },
         rules: vec![PolicyRule::Predicated(Box::new(PredicatedRule {
@@ -210,7 +211,10 @@ async fn label_in_group_predicate_fires_on_grouped_labels() {
     let group = LabelGroup {
         name: "contact_info".into(),
         description: None,
-        labels: vec![LabelRef::new("email_address"), LabelRef::new("phone_number")],
+        labels: vec![
+            LabelRef::new("email_address"),
+            LabelRef::new("phone_number"),
+        ],
     };
 
     let mut analyzed = engine
@@ -248,4 +252,3 @@ async fn label_in_group_predicate_fires_on_grouped_labels() {
     // The positive checks above are sufficient to prove the
     // group predicate wired through the compile path.
 }
-

--- a/crates/nvisy-engine/tests/templates.rs
+++ b/crates/nvisy-engine/tests/templates.rs
@@ -25,7 +25,8 @@ fn engine() -> Engine {
 }
 
 fn engine_with_key() -> Engine {
-    let provider: Arc<dyn KeyProvider> = Arc::new(StaticKey::new(*b"nvisy-template-test-key-32bytes"));
+    let provider: Arc<dyn KeyProvider> =
+        Arc::new(StaticKey::new(*b"nvisy-template-test-key-32bytes"));
     Engine::new().with_key_provider(provider)
 }
 
@@ -55,7 +56,12 @@ fn default_spec() -> AnalyzerParams {
 /// and return the redacted body as a UTF-8 string.
 async fn apply(engine: &Engine, template: Template) -> String {
     let mut analyzed = engine
-        .analyze(raw_txt(), &template.policies, &template.groups, &default_spec())
+        .analyze(
+            raw_txt(),
+            &template.policies,
+            &template.groups,
+            &default_spec(),
+        )
         .await
         .expect("analyze succeeds");
     let redacted = engine
@@ -137,7 +143,12 @@ async fn pci_dss_pan_hmac_requires_key_provider() {
     // capability requirement into place.
     let template = nvisy_template::pci_dss_pan_hmac();
     let mut analyzed = engine()
-        .analyze(raw_txt(), &template.policies, &template.groups, &default_spec())
+        .analyze(
+            raw_txt(),
+            &template.policies,
+            &template.groups,
+            &default_spec(),
+        )
         .await
         .expect("analyze succeeds without a key provider");
     let err = engine()
@@ -200,7 +211,12 @@ async fn every_shipped_template_analyzes_and_anonymizes_the_sample() {
     for (name, build) in nvisy_template::ALL {
         let template = build();
         let mut analyzed = engine
-            .analyze(raw_txt(), &template.policies, &template.groups, &default_spec())
+            .analyze(
+                raw_txt(),
+                &template.policies,
+                &template.groups,
+                &default_spec(),
+            )
             .await
             .unwrap_or_else(|e| panic!("template `{name}` failed to analyze: {e}"));
         engine

--- a/crates/nvisy-template/src/template/ccpa.rs
+++ b/crates/nvisy-template/src/template/ccpa.rs
@@ -182,15 +182,15 @@ mod tests {
         // silently regressing coverage. Categories (J) and (K)
         // aren't covered — see caveats issue.
         for anchor in [
-            "person_name",        // (A) identifiers
-            "signature",          // (B) §1798.80
-            "ethnicity",          // (C) protected classifications
-            "payment_card",       // (D) commercial info
-            "fingerprint",        // (E) biometric
-            "url",                // (F) internet/network activity
-            "coordinates",        // (G) geolocation
-            "face",               // (H) sensory
-            "occupation",         // (I) professional/employment
+            "person_name",  // (A) identifiers
+            "signature",    // (B) §1798.80
+            "ethnicity",    // (C) protected classifications
+            "payment_card", // (D) commercial info
+            "fingerprint",  // (E) biometric
+            "url",          // (F) internet/network activity
+            "coordinates",  // (G) geolocation
+            "face",         // (H) sensory
+            "occupation",   // (I) professional/employment
         ] {
             assert!(
                 CCPA_LABELS.iter().any(|l| l.as_str() == anchor),

--- a/crates/nvisy-template/src/template/hipaa.rs
+++ b/crates/nvisy-template/src/template/hipaa.rs
@@ -199,9 +199,7 @@ fn bulk_erase_rule() -> PolicyRule {
     PolicyRule::Predicated(Box::new(PredicatedRule {
         id: RULE_BULK_ID,
         name: "hipaa-bulk-erase".into(),
-        description: Some(
-            "Every remaining §164.514(b)(2) identifier is erased.".to_owned(),
-        ),
+        description: Some("Every remaining §164.514(b)(2) identifier is erased.".to_owned()),
         predicate: Predicate::LabelInGroup {
             group: GROUP_NAME.to_owned(),
         },


### PR DESCRIPTION
## Summary

Runtime had a \`rustfmt.toml\` but no CI gate enforcing it — formatting drifted across 22 files. Two atomic commits:

1. **Reformat workspace with nightly rustfmt** — one \`cargo +nightly fmt --all\` sweep, no behavior change. Lands so the CI gate has a clean tree to check.
2. **Add \`fmt\` CI gate** — new \`fmt\` job in \`runtime-build.yml\` running \`cargo +nightly fmt --all --check\` on every push/PR. Mirrors the pattern elide adopted in nvisycom/elide#172. Nightly is required because \`rustfmt.toml\` uses unstable options (\`group_imports = "StdExternalCrate"\`, \`imports_granularity = "Module"\`).

Also adds \`rustfmt.toml\` to the workflow path filter so a config edit re-triggers the check.

## Test plan

- [x] \`cargo +nightly fmt --all --check\` — clean on the branch
- [x] \`cargo test --workspace --all-features\` — 27 tests green
- [ ] CI \`fmt\` job passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)