### PR TITLE
refactor: move LabelGroup onto PolicyDefinition (per-policy scoping)

### DIFF
--- a/crates/nvisy-engine/src/analyzer/catalog.rs
+++ b/crates/nvisy-engine/src/analyzer/catalog.rs
@@ -1,31 +1,36 @@
-//! Compile a slice of [`PolicyDefinition`] and the request's
-//! [`LabelGroup`]s into an [`elide_core::entity::LabelCatalog`].
+//! Compile a slice of [`PolicyDefinition`] into an
+//! [`elide_core::entity::LabelCatalog`].
 //!
 //! Walks every policy's [`labels`] block, unions the builtin
 //! selections and the inline custom schemas into one catalog,
-//! then stamps a `group:<name>` synthetic tag on every label
-//! listed in each [`LabelGroup`]. Kept engine-side so the cached
-//! `with_builtins` lookup, the warn-and-skip policy for unknown
-//! builtin names, and the group tag synthesis stay out of
-//! `nvisy-policy`.
+//! then stamps a `group:<policy_id>:<name>` synthetic tag on
+//! every label listed in each policy's [`groups`]. Kept
+//! engine-side so the cached `with_builtins` lookup, the
+//! warn-and-skip policy for unknown builtin names, and the group
+//! tag synthesis stay out of `nvisy-policy`.
 //!
 //! [`PolicyDefinition`]: nvisy_schema::policy::PolicyDefinition
-//! [`LabelGroup`]: nvisy_schema::policy::LabelGroup
 //! [`labels`]: nvisy_schema::policy::PolicyDefinition::labels
+//! [`groups`]: nvisy_schema::policy::PolicyDefinition::groups
 
 use std::sync::OnceLock;
 
 use elide_core::entity::LabelCatalog;
 use nvisy_schema::policy::{LabelGroup, Labels, PolicyDefinition};
+use uuid::Uuid;
 
-/// Prefix elide-side synthetic tags carry so a `LabelGroup`
-/// named `hipaa_18` becomes the tag `group:hipaa_18` on every
-/// listed label. Keeps synthetic tags in their own namespace,
-/// away from elide's data-category tags (`pii`, `phi`, …).
-pub(crate) const GROUP_TAG_PREFIX: &str = "group:";
+/// Build the synthetic tag a `LabelGroup` compiles to:
+/// `group:<policy_id>:<group_name>`. Scoping by `policy_id` keeps
+/// two policies that both declare `hipaa_18` with different
+/// labelsets from stepping on each other.
+///
+/// Shared between catalog synthesis and the selector's rewrite
+/// of `Predicate::LabelInGroup` so the two sides can't drift.
+pub(crate) fn synthetic_group_tag(policy_id: Uuid, group_name: &str) -> String {
+    format!("group:{policy_id}:{group_name}")
+}
 
-/// Compile the label catalog for a request from its policy set
-/// and its [`LabelGroup`]s.
+/// Compile the label catalog for a request from its policy set.
 ///
 /// Every policy contributes its [`labels`] block; builtins are
 /// resolved once against the cached full builtin catalog, custom
@@ -33,44 +38,44 @@ pub(crate) const GROUP_TAG_PREFIX: &str = "group:";
 /// or between builtins and customs follow
 /// [`LabelCatalog::insert`] semantics: last write wins.
 ///
-/// After label union, each [`LabelGroup`] stamps a
-/// `group:<name>` tag onto every listed label present in the
-/// catalog — the compile-time rewrite that makes
+/// After label union, each policy's [`groups`] stamp a
+/// `group:<policy_id>:<name>` tag onto every listed label
+/// present in the catalog — the compile-time rewrite that makes
 /// [`Predicate::LabelInGroup { group }`] lower to
-/// [`TagOneOf`]`{ tags: ["group:<name>"] }`. A label listed in a
-/// group but absent from the catalog is silently skipped; groups
-/// can safely reference labels this build doesn't ship (e.g.
-/// modality-gated ones).
+/// [`TagOneOf`]`{ tags: ["group:<policy_id>:<name>"] }`.
+/// A label listed in a group but absent from the catalog is
+/// silently skipped; groups can safely reference labels this
+/// build doesn't ship (e.g. modality-gated ones).
 ///
 /// Unknown builtin names log a warning and are skipped — typos
 /// shouldn't fail the request. Unknown group *names* are
-/// separately validated by [`validate_groups_referenced_in_policies`].
+/// separately validated by
+/// `pipeline::orchestrator::validate_group_references`.
 ///
-/// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
 /// [`labels`]: nvisy_schema::policy::PolicyDefinition::labels
+/// [`groups`]: nvisy_schema::policy::PolicyDefinition::groups
 /// [`LabelCatalog::insert`]: elide_core::entity::LabelCatalog::insert
 /// [`Predicate::LabelInGroup { group }`]: nvisy_schema::policy::predicate::Predicate::LabelInGroup
 /// [`TagOneOf`]: nvisy_schema::policy::predicate::Predicate::TagOneOf
-pub(crate) fn compile_catalog(
-    policies: &[PolicyDefinition],
-    groups: &[LabelGroup],
-) -> LabelCatalog {
+pub(crate) fn compile_catalog(policies: &[PolicyDefinition]) -> LabelCatalog {
     let mut catalog = LabelCatalog::new();
     for policy in policies {
         insert_params(&mut catalog, &policy.labels);
     }
-    apply_group_tags(&mut catalog, groups);
+    for policy in policies {
+        apply_group_tags(&mut catalog, policy.id, &policy.groups);
+    }
     catalog
 }
 
-/// Stamp `group:<name>` on every label a group lists that the
-/// catalog carries. Preserves the label's existing tag list —
-/// elide's `with_tags` builder *replaces* the tag list, so we
-/// read the current tags, append the synthetic one, and
+/// Stamp `group:<policy_id>:<name>` on every label a group lists
+/// that the catalog carries. Preserves the label's existing tag
+/// list — elide's `with_tags` builder *replaces* the tag list,
+/// so we read the current tags, append the synthetic one, and
 /// re-insert (last-write-wins on the catalog side).
-fn apply_group_tags(catalog: &mut LabelCatalog, groups: &[LabelGroup]) {
+fn apply_group_tags(catalog: &mut LabelCatalog, policy_id: Uuid, groups: &[LabelGroup]) {
     for group in groups {
-        let synthetic_tag = format!("{GROUP_TAG_PREFIX}{}", group.name);
+        let synthetic_tag = synthetic_group_tag(policy_id, group.name.as_str());
         for label_ref in &group.labels {
             let Some(label) = catalog.get(label_ref) else {
                 continue;
@@ -131,51 +136,58 @@ mod tests {
 
     use super::*;
 
-    fn policy_with_labels(labels: Labels) -> PolicyDefinition {
+    const FIXED_POLICY_ID: Uuid = Uuid::from_u128(0x01234567_89ab_7000_8000_000000000001_u128);
+
+    fn policy(labels: Labels, groups: Vec<LabelGroup>) -> PolicyDefinition {
         PolicyDefinition {
-            id: Uuid::now_v7(),
+            id: FIXED_POLICY_ID,
             name: HipStr::from("test"),
             description: None,
             when: None,
             labels,
+            groups,
             rules: Vec::new(),
             fallback: None,
             retention: Vec::new(),
         }
     }
 
+    fn policy_with_labels(labels: Labels) -> PolicyDefinition {
+        policy(labels, Vec::new())
+    }
+
     #[test]
     fn empty_policy_set_yields_empty_catalog() {
-        assert!(compile_catalog(&[], &[]).is_empty());
+        assert!(compile_catalog(&[]).is_empty());
     }
 
     #[test]
     fn policy_with_no_labels_contributes_nothing() {
-        let policy = policy_with_labels(Labels::default());
-        assert!(compile_catalog(std::slice::from_ref(&policy), &[]).is_empty());
+        let p = policy_with_labels(Labels::default());
+        assert!(compile_catalog(std::slice::from_ref(&p)).is_empty());
     }
 
     #[test]
     fn builtin_names_land_in_the_catalog() {
-        let policy = policy_with_labels(Labels {
+        let p = policy_with_labels(Labels {
             builtins: vec![LabelRef::new("email_address")],
             custom: Vec::new(),
         });
-        let catalog = compile_catalog(std::slice::from_ref(&policy), &[]);
+        let catalog = compile_catalog(std::slice::from_ref(&p));
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert_eq!(catalog.len(), 1);
     }
 
     #[test]
     fn unknown_builtin_names_skip_instead_of_failing() {
-        let policy = policy_with_labels(Labels {
+        let p = policy_with_labels(Labels {
             builtins: vec![
                 LabelRef::new("email_address"),
                 LabelRef::new("definitely_not_a_real_label"),
             ],
             custom: Vec::new(),
         });
-        let catalog = compile_catalog(std::slice::from_ref(&policy), &[]);
+        let catalog = compile_catalog(std::slice::from_ref(&p));
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert!(!catalog.contains(&LabelRef::new("definitely_not_a_real_label")));
         assert_eq!(catalog.len(), 1);
@@ -183,11 +195,11 @@ mod tests {
 
     #[test]
     fn custom_labels_land_in_the_catalog() {
-        let policy = policy_with_labels(Labels {
+        let p = policy_with_labels(Labels {
             builtins: Vec::new(),
             custom: vec![Label::new("project_code", "Project code")],
         });
-        let catalog = compile_catalog(std::slice::from_ref(&policy), &[]);
+        let catalog = compile_catalog(std::slice::from_ref(&p));
         assert!(catalog.contains(&LabelRef::new("project_code")));
     }
 
@@ -201,26 +213,30 @@ mod tests {
             builtins: vec![LabelRef::new("phone_number")],
             custom: Vec::new(),
         });
-        let catalog = compile_catalog(&[a, b], &[]);
+        let catalog = compile_catalog(&[a, b]);
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert!(catalog.contains(&LabelRef::new("phone_number")));
         assert_eq!(catalog.len(), 2);
     }
 
     #[test]
-    fn group_stamps_synthetic_tag_and_preserves_existing_tags() {
-        let policy = policy_with_labels(Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        });
+    fn group_stamps_scoped_synthetic_tag_and_preserves_existing_tags() {
         let group = LabelGroup {
             name: HipStr::from("contact_sweep"),
             description: None,
             labels: vec![LabelRef::new("email_address")],
         };
-        let catalog = compile_catalog(std::slice::from_ref(&policy), &[group]);
+        let p = policy(
+            Labels {
+                builtins: vec![LabelRef::new("email_address")],
+                custom: Vec::new(),
+            },
+            vec![group],
+        );
+        let expected_tag = synthetic_group_tag(FIXED_POLICY_ID, "contact_sweep");
+        let catalog = compile_catalog(std::slice::from_ref(&p));
         let stamped = catalog.get(&LabelRef::new("email_address")).unwrap();
-        assert!(stamped.has_tag("group:contact_sweep"));
+        assert!(stamped.has_tag(&expected_tag));
         // Elide's builtin email_address carries `contact_info` and `pii`;
         // synthesis appends, doesn't replace.
         assert!(stamped.has_tag("pii"));
@@ -229,39 +245,81 @@ mod tests {
 
     #[test]
     fn group_referencing_absent_label_is_silently_skipped() {
-        // No policy contributes labels; the group's target label
-        // isn't in the catalog, so the group is a no-op.
         let group = LabelGroup {
             name: HipStr::from("nothing_present"),
             description: None,
             labels: vec![LabelRef::new("email_address")],
         };
-        let catalog = compile_catalog(&[], &[group]);
+        // No policy labels are declared; the group's target label
+        // is absent from the catalog, so the group is a no-op.
+        let p = policy(Labels::default(), vec![group]);
+        let catalog = compile_catalog(std::slice::from_ref(&p));
         assert!(catalog.is_empty());
     }
 
     #[test]
     fn repeated_group_application_is_idempotent() {
-        // Two groups with the same name applied twice should not
-        // double-stamp the tag (has_tag short-circuits).
-        let policy = policy_with_labels(Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        });
+        // The same group appearing twice on a policy stamps the
+        // tag once (has_tag short-circuits the second attempt).
         let group = LabelGroup {
             name: HipStr::from("dup"),
             description: None,
             labels: vec![LabelRef::new("email_address")],
         };
-        let catalog = compile_catalog(std::slice::from_ref(&policy), &[group.clone(), group]);
+        let p = policy(
+            Labels {
+                builtins: vec![LabelRef::new("email_address")],
+                custom: Vec::new(),
+            },
+            vec![group.clone(), group],
+        );
+        let expected_tag = synthetic_group_tag(FIXED_POLICY_ID, "dup");
+        let catalog = compile_catalog(std::slice::from_ref(&p));
         let stamped = catalog.get(&LabelRef::new("email_address")).unwrap();
         assert_eq!(
             stamped
                 .tags()
                 .iter()
-                .filter(|t| t.as_str() == "group:dup")
+                .filter(|t| t.as_str() == expected_tag)
                 .count(),
             1,
         );
+    }
+
+    #[test]
+    fn two_policies_with_same_group_name_get_distinct_tags() {
+        // Strict scoping: two policies declaring `hipaa_18` with
+        // different labelsets don't step on each other — each
+        // stamps its own `group:<policy_id>:hipaa_18` tag.
+        let policy_a_id = Uuid::from_u128(0x01234567_89ab_7000_8000_000000000010_u128);
+        let policy_b_id = Uuid::from_u128(0x01234567_89ab_7000_8000_000000000011_u128);
+        let mut a = policy(
+            Labels {
+                builtins: vec![LabelRef::new("email_address")],
+                custom: Vec::new(),
+            },
+            vec![LabelGroup {
+                name: HipStr::from("hipaa_18"),
+                description: None,
+                labels: vec![LabelRef::new("email_address")],
+            }],
+        );
+        a.id = policy_a_id;
+        let mut b = policy(
+            Labels {
+                builtins: vec![LabelRef::new("email_address")],
+                custom: Vec::new(),
+            },
+            vec![LabelGroup {
+                name: HipStr::from("hipaa_18"),
+                description: None,
+                labels: vec![LabelRef::new("email_address")],
+            }],
+        );
+        b.id = policy_b_id;
+        let catalog = compile_catalog(&[a, b]);
+        let stamped = catalog.get(&LabelRef::new("email_address")).unwrap();
+        assert!(stamped.has_tag(&synthetic_group_tag(policy_a_id, "hipaa_18")));
+        assert!(stamped.has_tag(&synthetic_group_tag(policy_b_id, "hipaa_18")));
     }
 }

--- a/crates/nvisy-engine/src/analyzer/mod.rs
+++ b/crates/nvisy-engine/src/analyzer/mod.rs
@@ -49,7 +49,7 @@ use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
 use nvisy_schema::plan::AnalyzerParams;
 
-pub(crate) use self::catalog::{GROUP_TAG_PREFIX, compile_catalog};
+pub(crate) use self::catalog::{compile_catalog, synthetic_group_tag};
 pub use self::recognizer::PatternGuardrails;
 use crate::provider::llm::LlmConfig;
 use crate::provider::ner::NerConfig;

--- a/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/dispatch.rs
@@ -36,11 +36,14 @@ use super::selector::{attach, attach_override, fallback_attribution, rule_attrib
 pub(in crate::anonymizer) enum Target<'a, M: Modality> {
     /// Rule attachment: predicate-guarded redaction with a
     /// name + description attribution. Maps to
-    /// [`super::selector::attach`].
+    /// [`super::selector::attach`]. `policy_id` scopes any
+    /// [`Predicate::LabelInGroup`] to the enclosing policy's
+    /// synthetic tag namespace.
     Rule {
         anonymizer: Anonymizer<M>,
         predicate: &'a Predicate,
         attribution: Attribution,
+        policy_id: Uuid,
     },
     /// PolicyDefinition `fallback`: catch-all redaction attached
     /// via [`Rule::fallback`] with a `because(fallback_attribution)`.
@@ -73,7 +76,8 @@ impl<'a, M: Modality + 'static> Target<'a, M> {
                 anonymizer,
                 predicate,
                 attribution,
-            } => attach(anonymizer, predicate, operator, attribution),
+                policy_id,
+            } => attach(anonymizer, predicate, operator, attribution, policy_id),
             Target::Fallback {
                 anonymizer,
                 attribution,
@@ -124,6 +128,7 @@ where
                         anonymizer,
                         predicate: &predicate,
                         attribution: attribution.clone(),
+                        policy_id: policy.id,
                     },
                     action,
                 )?;

--- a/crates/nvisy-engine/src/anonymizer/compile/selector.rs
+++ b/crates/nvisy-engine/src/anonymizer/compile/selector.rs
@@ -35,7 +35,7 @@ use nvisy_schema::policy::predicate::Predicate;
 use nvisy_schema::policy::{PolicyDefinition, PolicyRule};
 use uuid::Uuid;
 
-use crate::analyzer::GROUP_TAG_PREFIX;
+use crate::analyzer::synthetic_group_tag;
 
 /// Build an [`Attribution`] for a concrete rule that fired.
 ///
@@ -90,6 +90,12 @@ where
 /// [`Predicate`], stamping `attribution` so every redaction it
 /// drives carries the policy's identity on its provenance event.
 ///
+/// `policy_id` scopes any [`Predicate::LabelInGroup`] inside the
+/// tree: the rewrite target becomes
+/// `group:<policy_id>:<group_name>`, matching how the catalog
+/// synthesised the tag. A rule can only see groups its own
+/// policy declared.
+///
 /// Pattern-matches the predicate against degenerate single-label
 /// / single-tag shapes to keep elide's indexed fast paths. Any
 /// composite predicate falls through to [`Rule::predicate`] with
@@ -99,6 +105,7 @@ pub(super) fn attach<M, O>(
     predicate: &Predicate,
     operator: O,
     attribution: Attribution,
+    policy_id: Uuid,
 ) -> Anonymizer<M>
 where
     M: Modality,
@@ -110,13 +117,14 @@ where
         }
         Predicate::TagOneOf { tags } if tags.len() == 1 => Rule::tag(tags[0].clone(), operator),
         Predicate::LabelInGroup { group } => {
-            // Groups compile to a synthetic `group:<name>` tag on
-            // every listed label (see `analyzer::catalog`), so a
-            // group predicate takes the same fast path as any
-            // single-tag `TagOneOf`.
-            Rule::tag(format!("{GROUP_TAG_PREFIX}{group}"), operator)
+            // Groups compile to a synthetic
+            // `group:<policy_id>:<group_name>` tag on every listed
+            // label (see `analyzer::catalog`), so a group predicate
+            // takes the same fast path as any single-tag
+            // `TagOneOf`.
+            Rule::tag(synthetic_group_tag(policy_id, group), operator)
         }
-        other => Rule::predicate(compile_predicate::<M>(other.clone()), operator),
+        other => Rule::predicate(compile_predicate::<M>(other.clone(), policy_id), operator),
     };
     anonymizer.with(rule.because(attribution))
 }
@@ -127,19 +135,24 @@ where
 /// the per-anonymizer [`LabelCatalog`] even inside composites
 /// ([`All`] / [`Any`] / [`Not`]).
 ///
+/// `policy_id` scopes any nested [`Predicate::LabelInGroup`] to
+/// the synthetic `group:<policy_id>:<name>` tag the catalog
+/// synthesised.
+///
 /// [`All`]: Predicate::All
 /// [`Any`]: Predicate::Any
 /// [`Not`]: Predicate::Not
 pub(super) fn compile_predicate<M>(
     predicate: Predicate,
+    policy_id: Uuid,
 ) -> impl Fn(&MatchContext<'_, M>) -> bool + Send + Sync + 'static
 where
     M: Modality,
 {
-    move |cx| eval(&predicate, cx)
+    move |cx| eval(&predicate, cx, policy_id)
 }
 
-fn eval<M: Modality>(predicate: &Predicate, cx: &MatchContext<'_, M>) -> bool {
+fn eval<M: Modality>(predicate: &Predicate, cx: &MatchContext<'_, M>, policy_id: Uuid) -> bool {
     match predicate {
         Predicate::Confidence { min } => f32::from(cx.entity.confidence) >= f32::from(*min),
         Predicate::LabelOneOf { labels } => labels.iter().any(|l| l == &cx.entity.label),
@@ -148,7 +161,7 @@ fn eval<M: Modality>(predicate: &Predicate, cx: &MatchContext<'_, M>) -> bool {
             .get(&cx.entity.label)
             .is_some_and(|label| tags.iter().any(|tag| label.has_tag(tag.as_str()))),
         Predicate::LabelInGroup { group } => {
-            let synthetic_tag = format!("{GROUP_TAG_PREFIX}{group}");
+            let synthetic_tag = synthetic_group_tag(policy_id, group);
             cx.catalog
                 .get(&cx.entity.label)
                 .is_some_and(|label| label.has_tag(&synthetic_tag))
@@ -158,8 +171,8 @@ fn eval<M: Modality>(predicate: &Predicate, cx: &MatchContext<'_, M>) -> bool {
             .coref
             .as_ref()
             .is_some_and(|c| c.as_str() == coref.as_str()),
-        Predicate::All { all } => all.iter().all(|p| eval(p, cx)),
-        Predicate::Any { any } => any.iter().any(|p| eval(p, cx)),
-        Predicate::Not { not } => !eval(not, cx),
+        Predicate::All { all } => all.iter().all(|p| eval(p, cx, policy_id)),
+        Predicate::Any { any } => any.iter().any(|p| eval(p, cx, policy_id)),
+        Predicate::Not { not } => !eval(not, cx, policy_id),
     }
 }

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -17,9 +17,9 @@
 //!   per-request orchestrator builder.
 //! - [`Engine::analyze`] and [`Engine::anonymize`] compile and
 //!   run the full [`elide::Orchestrator`] against one document.
-//!   Both take the request's `policies` and the shared
-//!   `groups` (named [`LabelGroup`]s the policies reference by
-//!   name) alongside the document.
+//!   Both take the request's `policies` alongside the document;
+//!   each policy carries its own [`LabelGroup`]s inline via
+//!   [`PolicyDefinition::groups`].
 //! - [`Audit`] carries the analyze → anonymize handoff: the
 //!   modality-tagged entity groups plus an [`AuditContext`] with
 //!   the request's asserted scope and correlation id.
@@ -31,6 +31,7 @@
 //! straight into [`Engine::analyze`] / [`Engine::anonymize`].
 //!
 //! [`LabelGroup`]: nvisy_schema::policy::LabelGroup
+//! [`PolicyDefinition::groups`]: nvisy_schema::policy::PolicyDefinition::groups
 //!
 //! [`elide`]: elide
 

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -94,8 +94,8 @@ use elide_core::modality::text::Text;
 use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::file::Document;
 use nvisy_schema::plan::AnalyzerParams;
+use nvisy_schema::policy::PolicyDefinition;
 use nvisy_schema::policy::redaction::ModalityRedactions;
-use nvisy_schema::policy::{LabelGroup, PolicyDefinition};
 use uuid::Uuid;
 
 pub use self::audit::{Audit, AuditContext};
@@ -239,34 +239,36 @@ impl Engine {
     ///
     /// `policies` contributes the label catalog (each
     /// [`PolicyDefinition::labels`] unions in) that drives
-    /// recognizer dispatch. `groups` are the [`LabelGroup`]s the
-    /// policies' `LabelInGroup` predicates reference by name; the
-    /// engine stamps a `group:<name>` synthetic tag on every
-    /// listed label at request-compile time and rejects any
-    /// group reference the request didn't submit.
+    /// recognizer dispatch. Every policy carries its own
+    /// [`LabelGroup`]s in [`PolicyDefinition::groups`]; the
+    /// engine stamps a `group:<policy_id>:<name>` synthetic tag
+    /// on every listed label at request-compile time and rejects
+    /// any [`LabelInGroup`] reference the enclosing policy
+    /// doesn't declare.
     ///
     /// The catalog is not persisted onto the returned [`Audit`] —
     /// the anonymize path re-derives it from the policy set it
-    /// was handed. Pass the same policy set + groups to
+    /// was handed. Pass the same policy set to
     /// [`Self::anonymize`] so its rule bodies match against a
     /// catalog they helped define.
     ///
     /// [`Orchestrator::analyze`]: elide::Orchestrator::analyze
     /// [`EntityGroup`]: crate::entity::EntityGroup
     /// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
+    /// [`LabelInGroup`]: nvisy_schema::policy::predicate::Predicate::LabelInGroup
     /// [`PolicyDefinition::labels`]: nvisy_schema::policy::PolicyDefinition::labels
+    /// [`PolicyDefinition::groups`]: nvisy_schema::policy::PolicyDefinition::groups
     pub async fn analyze(
         &self,
         document: Document,
         policies: &[PolicyDefinition],
-        groups: &[LabelGroup],
         spec: &AnalyzerParams,
     ) -> Result<Audit> {
         let correlation_id = document.correlation_id;
         let extension = document.extension.clone();
         let mut handle = self.decode(document).await?;
         let (orchestrator, context) =
-            self.build_analyze_orchestrator(spec, policies, groups, correlation_id)?;
+            self.build_analyze_orchestrator(spec, policies, correlation_id)?;
         let directives = build_analyze_directives(spec);
         let mut report = orchestrator.analyze(&mut handle, &directives).await?;
 
@@ -334,17 +336,18 @@ impl Engine {
     ///
     /// `policies` is the policy set already filtered by
     /// [`PolicyDefinition::when`] against the per-doc facts; the
-    /// engine does not re-evaluate predicates. `groups` are the
-    /// [`LabelGroup`]s the policies' `LabelInGroup` predicates
-    /// reference by name — same shape as [`Self::analyze`]. The
-    /// label catalog is re-derived from `policies` + `groups` on
-    /// every call — policies are the sole source of label
-    /// vocabulary. The asserted scope (languages, jurisdictions,
-    /// metadata) travels on [`Audit::context`] from analyze. The
-    /// document's `correlation_id` is threaded into tracing spans
-    /// on the redaction path.
+    /// engine does not re-evaluate predicates. Each policy
+    /// carries its own [`LabelGroup`]s inline via
+    /// [`PolicyDefinition::groups`] — same shape as
+    /// [`Self::analyze`]. The label catalog is re-derived from
+    /// `policies` on every call — policies are the sole source
+    /// of label vocabulary. The asserted scope (languages,
+    /// jurisdictions, metadata) travels on [`Audit::context`]
+    /// from analyze. The document's `correlation_id` is threaded
+    /// into tracing spans on the redaction path.
     ///
     /// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
+    /// [`PolicyDefinition::groups`]: nvisy_schema::policy::PolicyDefinition::groups
     ///
     /// The body's modality (read from `audit.body`'s
     /// [`EntityGroup`] variant) pins which typed handle the
@@ -359,7 +362,6 @@ impl Engine {
         &self,
         document: Document,
         policies: &[PolicyDefinition],
-        groups: &[LabelGroup],
         audit: &mut Audit,
     ) -> Result<Document> {
         let body_group = audit.body.as_ref().ok_or_else(|| {
@@ -384,7 +386,6 @@ impl Engine {
         let orchestrator = self.build_anonymize_orchestrator(
             &audit.context,
             policies,
-            groups,
             &overrides,
             correlation_id,
         )?;

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -55,7 +55,7 @@ use elide_core::{Error, ErrorKind};
 use nvisy_schema::plan::AnalyzerParams;
 use nvisy_schema::policy::predicate::Predicate;
 use nvisy_schema::policy::redaction::ModalityRedactions;
-use nvisy_schema::policy::{LabelGroup, PolicyDefinition, PolicyRule};
+use nvisy_schema::policy::{PolicyDefinition, PolicyRule};
 use uuid::Uuid;
 
 use super::Engine;
@@ -93,11 +93,10 @@ impl Engine {
         &self,
         spec: &AnalyzerParams,
         policies: &[PolicyDefinition],
-        groups: &[LabelGroup],
         correlation_id: Uuid,
     ) -> Result<(Orchestrator<'_>, AuditContext)> {
-        validate_group_references(policies, groups)?;
-        let catalog = compile_catalog(policies, groups);
+        validate_group_references(policies)?;
+        let catalog = compile_catalog(policies);
         let context = AuditContext {
             languages: spec.scope.languages.clone(),
             countries: spec.scope.countries.clone(),
@@ -159,12 +158,11 @@ impl Engine {
         &self,
         context: &AuditContext,
         policies: &[PolicyDefinition],
-        groups: &[LabelGroup],
         overrides: &[(Uuid, ModalityRedactions)],
         correlation_id: Uuid,
     ) -> Result<Orchestrator<'_>> {
-        validate_group_references(policies, groups)?;
-        let catalog = compile_catalog(policies, groups);
+        validate_group_references(policies)?;
+        let catalog = compile_catalog(policies);
         let live_scope = build_scope(context, catalog.clone(), correlation_id);
 
         // Fresh per-request text-operator context. `Pseudonymize`
@@ -229,21 +227,22 @@ impl Engine {
     }
 }
 
-/// Reject a request whose policy set references a
-/// [`LabelGroup`] name that no submitted group provides.
+/// Reject a request whose rule references a [`LabelGroup`] name
+/// its own policy didn't declare.
 ///
-/// Runs before catalog compilation so an authoring typo
-/// (`"gdpr_arcticle_9"`) surfaces as a
+/// Groups are scoped to the policy that owns them (strict
+/// per-policy namespace). A rule inside policy A can reference
+/// only groups declared in policy A's own [`groups`] slot — not
+/// groups declared by policy B. Runs before catalog compilation
+/// so an authoring typo (`"gdpr_arcticle_9"`) surfaces as a
 /// [`Configuration`](ErrorKind::Configuration) error at request
 /// validation time, not as a silent underfire at apply time.
 ///
-/// Complexity is O(rules × 1) in practice — the lookup uses a
-/// [`HashSet`] over the request's group names.
-///
 /// [`LabelGroup`]: nvisy_schema::policy::LabelGroup
-fn validate_group_references(policies: &[PolicyDefinition], groups: &[LabelGroup]) -> Result<()> {
-    let known: HashSet<&str> = groups.iter().map(|g| g.name.as_str()).collect();
+/// [`groups`]: nvisy_schema::policy::PolicyDefinition::groups
+fn validate_group_references(policies: &[PolicyDefinition]) -> Result<()> {
     for policy in policies {
+        let known: HashSet<&str> = policy.groups.iter().map(|g| g.name.as_str()).collect();
         for rule in &policy.rules {
             for (predicate, _) in rule.attachments() {
                 check_predicate_groups(&predicate, &known, policy, rule)?;
@@ -254,8 +253,9 @@ fn validate_group_references(policies: &[PolicyDefinition], groups: &[LabelGroup
 }
 
 /// Walk a predicate tree; every [`Predicate::LabelInGroup`] leaf
-/// must name a known group. Returns the first unknown reference
-/// with policy + rule context for the error message.
+/// must name a group declared by the enclosing policy. Returns
+/// the first unknown reference with policy + rule context for the
+/// error message.
 fn check_predicate_groups(
     predicate: &Predicate,
     known: &HashSet<&str>,
@@ -267,7 +267,7 @@ fn check_predicate_groups(
             ErrorKind::Configuration,
             format!(
                 "policy `{}` rule `{}` references unknown label group `{}` — \
-                     no `LabelGroup` with that name was submitted with the request",
+                 the enclosing policy declares no `LabelGroup` with that name",
                 policy.id,
                 rule.id(),
                 group,

--- a/crates/nvisy-engine/tests/audit.rs
+++ b/crates/nvisy-engine/tests/audit.rs
@@ -52,7 +52,7 @@ fn default_spec() -> AnalyzerParams {
 
 async fn analyze() -> Audit {
     engine()
-        .analyze(raw_txt(), &[], &[], &default_spec())
+        .analyze(raw_txt(), &[], &default_spec())
         .await
         .expect("analyze succeeds")
 }

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -67,7 +67,7 @@ fn read_zip_entry(buf: &[u8], name: &str) -> Option<Vec<u8>> {
 async fn analyze_captures_text_body_and_image_part() {
     let engine = engine();
     let analyzed = engine
-        .analyze(raw_docx(), &[], &[], &default_spec())
+        .analyze(raw_docx(), &[], &default_spec())
         .await
         .expect("analyze succeeds");
 
@@ -97,7 +97,7 @@ async fn analyze_captures_text_body_and_image_part() {
 async fn anonymize_redacts_targeted_entity_and_preserves_other_parts() {
     let engine = engine();
     let mut analyzed = engine
-        .analyze(raw_docx(), &[], &[], &default_spec())
+        .analyze(raw_docx(), &[], &default_spec())
         .await
         .expect("analyze succeeds");
     let body_group = analyzed.body.as_ref().expect("body group present");
@@ -124,7 +124,7 @@ async fn anonymize_redacts_targeted_entity_and_preserves_other_parts() {
     });
 
     let outcome = engine
-        .anonymize(raw_docx(), &[], &[], &mut analyzed)
+        .anonymize(raw_docx(), &[], &mut analyzed)
         .await
         .expect("anonymize succeeds");
     write_artefact("sample", "out.docx", &outcome.bytes);
@@ -160,7 +160,7 @@ async fn audit_context_mirrors_spec_scope_and_carries_correlation_id() {
     let correlation_id = doc.correlation_id;
 
     let audit = engine
-        .analyze(doc, &[], &[], &spec)
+        .analyze(doc, &[], &spec)
         .await
         .expect("analyze succeeds");
 
@@ -195,27 +195,18 @@ async fn anonymize_succeeds_when_policies_supply_catalog_afresh() {
             builtins: vec![LabelRef::new("email_address")],
             custom: Vec::new(),
         },
+        groups: Vec::new(),
         rules: Vec::new(),
         fallback: None,
         retention: Vec::new(),
     };
     let mut analyzed = engine
-        .analyze(
-            raw_docx(),
-            std::slice::from_ref(&policy),
-            &[],
-            &default_spec(),
-        )
+        .analyze(raw_docx(), std::slice::from_ref(&policy), &default_spec())
         .await
         .expect("analyze succeeds");
 
     engine
-        .anonymize(
-            raw_docx(),
-            std::slice::from_ref(&policy),
-            &[],
-            &mut analyzed,
-        )
+        .anonymize(raw_docx(), std::slice::from_ref(&policy), &mut analyzed)
         .await
         .expect("anonymize succeeds when catalog is re-derived from the same policy set");
 }
@@ -224,7 +215,7 @@ async fn anonymize_succeeds_when_policies_supply_catalog_afresh() {
 async fn audit_rejects_missing_context_on_deserialize() {
     let engine = engine();
     let analyzed = engine
-        .analyze(raw_docx(), &[], &[], &default_spec())
+        .analyze(raw_docx(), &[], &default_spec())
         .await
         .expect("analyze succeeds");
     let mut value = serde_json::to_value(&analyzed).expect("serialize");
@@ -267,18 +258,14 @@ async fn analyze_rejects_policy_that_references_unknown_group() {
         description: None,
         when: None,
         labels: Labels::default(),
+        groups: Vec::new(),
         rules: vec![rule],
         fallback: None,
         retention: Vec::new(),
     };
 
     let err = engine
-        .analyze(
-            raw_docx(),
-            std::slice::from_ref(&policy),
-            &[],
-            &default_spec(),
-        )
+        .analyze(raw_docx(), std::slice::from_ref(&policy), &default_spec())
         .await
         .expect_err("analyze must reject unknown group references");
     assert!(
@@ -300,7 +287,7 @@ async fn empty_analyzed_document_anonymize_fails_validation() {
             correlation_id: uuid::Uuid::now_v7(),
         },
     };
-    let outcome = engine.anonymize(raw_docx(), &[], &[], &mut audit).await;
+    let outcome = engine.anonymize(raw_docx(), &[], &mut audit).await;
     let err = outcome.expect_err("anonymize must reject a missing body group");
     assert!(
         err.to_string().contains("body group is missing"),

--- a/crates/nvisy-engine/tests/patterns.rs
+++ b/crates/nvisy-engine/tests/patterns.rs
@@ -65,7 +65,7 @@ async fn custom_regex_produces_entity_with_caller_label() {
     });
 
     let analyzed = engine
-        .analyze(raw_docx(), &[], &[], &spec)
+        .analyze(raw_docx(), &[], &spec)
         .await
         .expect("analyze succeeds");
 
@@ -103,7 +103,7 @@ async fn custom_dictionary_produces_entity_with_caller_label() {
     });
 
     let analyzed = engine
-        .analyze(raw_docx(), &[], &[], &spec)
+        .analyze(raw_docx(), &[], &spec)
         .await
         .expect("analyze succeeds");
 
@@ -153,7 +153,7 @@ async fn too_many_custom_rules_rejects_at_analyze() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &[], &spec)
+        .analyze(raw_docx(), &[], &spec)
         .await
         .expect_err("33 rules must exceed the per-request cap");
     let msg = err.to_string();
@@ -183,7 +183,7 @@ async fn tightened_rule_count_guardrail_takes_effect() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &[], &spec)
+        .analyze(raw_docx(), &[], &spec)
         .await
         .expect_err("5 rules must exceed a tightened cap of 4");
     let msg = err.to_string();
@@ -211,7 +211,7 @@ async fn tightened_regex_source_len_guardrail_takes_effect() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &[], &spec)
+        .analyze(raw_docx(), &[], &spec)
         .await
         .expect_err("60-byte source must exceed a tightened cap of 16 bytes");
     let msg = err.to_string();
@@ -246,7 +246,7 @@ async fn regex_source_len_config_above_ceiling_is_clamped() {
     });
 
     let err = engine
-        .analyze(raw_docx(), &[], &[], &spec)
+        .analyze(raw_docx(), &[], &spec)
         .await
         .expect_err("engine must clamp max_regex_source_len to the wire ceiling");
     let msg = err.to_string();

--- a/crates/nvisy-engine/tests/policy_shapes.rs
+++ b/crates/nvisy-engine/tests/policy_shapes.rs
@@ -106,22 +106,18 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
             ],
             custom: Vec::new(),
         },
+        groups: Vec::new(),
         rules: vec![table],
         fallback: None,
         retention: Vec::new(),
     };
 
     let mut analyzed = engine
-        .analyze(
-            raw_txt(),
-            std::slice::from_ref(&policy),
-            &[],
-            &default_spec(),
-        )
+        .analyze(raw_txt(), std::slice::from_ref(&policy), &default_spec())
         .await
         .expect("analyze succeeds");
     let redacted = engine
-        .anonymize(raw_txt(), std::slice::from_ref(&policy), &[], &mut analyzed)
+        .anonymize(raw_txt(), std::slice::from_ref(&policy), &mut analyzed)
         .await
         .expect("anonymize succeeds");
 
@@ -181,6 +177,14 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
 #[tokio::test]
 async fn label_in_group_predicate_fires_on_grouped_labels() {
     let engine = engine();
+    let group = LabelGroup {
+        name: "contact_info".into(),
+        description: None,
+        labels: vec![
+            LabelRef::new("email_address"),
+            LabelRef::new("phone_number"),
+        ],
+    };
     let policy = PolicyDefinition {
         id: uuid::Uuid::now_v7(),
         name: "sweep".into(),
@@ -193,6 +197,7 @@ async fn label_in_group_predicate_fires_on_grouped_labels() {
             ],
             custom: Vec::new(),
         },
+        groups: vec![group],
         rules: vec![PolicyRule::Predicated(Box::new(PredicatedRule {
             id: uuid::Uuid::now_v7(),
             name: "erase-contacts".into(),
@@ -208,31 +213,13 @@ async fn label_in_group_predicate_fires_on_grouped_labels() {
         fallback: None,
         retention: Vec::new(),
     };
-    let group = LabelGroup {
-        name: "contact_info".into(),
-        description: None,
-        labels: vec![
-            LabelRef::new("email_address"),
-            LabelRef::new("phone_number"),
-        ],
-    };
 
     let mut analyzed = engine
-        .analyze(
-            raw_txt(),
-            std::slice::from_ref(&policy),
-            std::slice::from_ref(&group),
-            &default_spec(),
-        )
+        .analyze(raw_txt(), std::slice::from_ref(&policy), &default_spec())
         .await
         .expect("analyze succeeds");
     engine
-        .anonymize(
-            raw_txt(),
-            std::slice::from_ref(&policy),
-            std::slice::from_ref(&group),
-            &mut analyzed,
-        )
+        .anonymize(raw_txt(), std::slice::from_ref(&policy), &mut analyzed)
         .await
         .expect("anonymize succeeds");
 

--- a/crates/nvisy-engine/tests/templates.rs
+++ b/crates/nvisy-engine/tests/templates.rs
@@ -56,21 +56,11 @@ fn default_spec() -> AnalyzerParams {
 /// and return the redacted body as a UTF-8 string.
 async fn apply(engine: &Engine, template: Template) -> String {
     let mut analyzed = engine
-        .analyze(
-            raw_txt(),
-            &template.policies,
-            &template.groups,
-            &default_spec(),
-        )
+        .analyze(raw_txt(), &template.policies, &default_spec())
         .await
         .expect("analyze succeeds");
     let redacted = engine
-        .anonymize(
-            raw_txt(),
-            &template.policies,
-            &template.groups,
-            &mut analyzed,
-        )
+        .anonymize(raw_txt(), &template.policies, &mut analyzed)
         .await
         .expect("anonymize succeeds");
     String::from_utf8(redacted.bytes.to_vec()).expect("body is utf-8")
@@ -143,21 +133,11 @@ async fn pci_dss_pan_hmac_requires_key_provider() {
     // capability requirement into place.
     let template = nvisy_template::pci_dss_pan_hmac();
     let mut analyzed = engine()
-        .analyze(
-            raw_txt(),
-            &template.policies,
-            &template.groups,
-            &default_spec(),
-        )
+        .analyze(raw_txt(), &template.policies, &default_spec())
         .await
         .expect("analyze succeeds without a key provider");
     let err = engine()
-        .anonymize(
-            raw_txt(),
-            &template.policies,
-            &template.groups,
-            &mut analyzed,
-        )
+        .anonymize(raw_txt(), &template.policies, &mut analyzed)
         .await
         .expect_err("anonymize must fail without a key provider");
     assert!(
@@ -211,21 +191,11 @@ async fn every_shipped_template_analyzes_and_anonymizes_the_sample() {
     for (name, build) in nvisy_template::ALL {
         let template = build();
         let mut analyzed = engine
-            .analyze(
-                raw_txt(),
-                &template.policies,
-                &template.groups,
-                &default_spec(),
-            )
+            .analyze(raw_txt(), &template.policies, &default_spec())
             .await
             .unwrap_or_else(|e| panic!("template `{name}` failed to analyze: {e}"));
         engine
-            .anonymize(
-                raw_txt(),
-                &template.policies,
-                &template.groups,
-                &mut analyzed,
-            )
+            .anonymize(raw_txt(), &template.policies, &mut analyzed)
             .await
             .unwrap_or_else(|e| panic!("template `{name}` failed to anonymize: {e}"));
     }

--- a/crates/nvisy-policy/src/label.rs
+++ b/crates/nvisy-policy/src/label.rs
@@ -8,14 +8,15 @@
 //!   custom schemas. The engine unions every submitted policy's
 //!   `labels` into one `elide_core::entity::LabelCatalog` at
 //!   request-compile time.
-//! - [`LabelGroup`] — a named cluster of [`LabelRef`]s shared
-//!   across a request. Templates ship groups (`"hipaa_18"`,
-//!   `"gdpr_article_9"`, `"pci_chd"`); rules reference groups by
-//!   name via [`Predicate::LabelInGroup`]. Engine synthesises a
-//!   `group:<name>` tag on every listed label at request time
-//!   and rewrites [`LabelInGroup`] to
-//!   [`TagOneOf`]`{ tags: ["group:<name>"] }` — same fast path
-//!   as any tag-based rule.
+//! - [`LabelGroup`] — a named cluster of [`LabelRef`]s carried
+//!   on the policy that declares it. Templates ship groups
+//!   (`"hipaa_18"`, `"gdpr_article_9"`, `"pci_chd"`); rules
+//!   inside the same policy reference groups by name via
+//!   [`Predicate::LabelInGroup`]. Engine synthesises a
+//!   `group:<policy_id>:<name>` tag on every listed label at
+//!   request time and rewrites [`LabelInGroup`] to
+//!   [`TagOneOf`]`{ tags: ["group:<policy_id>:<name>"] }` — same
+//!   fast path as any tag-based rule.
 //!
 //! [`PolicyDefinition`]: super::PolicyDefinition
 //! [`Predicate::LabelInGroup`]: super::predicate::Predicate::LabelInGroup
@@ -52,37 +53,35 @@ impl Labels {
     }
 }
 
-/// Named cluster of [`LabelRef`]s a policy predicate can reference
+/// Named cluster of [`LabelRef`]s a policy's rules can reference
 /// by name via [`Predicate::LabelInGroup`].
 ///
-/// Groups are the primitive regulatory templates compose on top
-/// of: a template ships one group per canonical label list
-/// (`"hipaa_18"`, `"gdpr_article_9"`, `"pci_chd"`, `"pci_sad"`),
-/// and every rule that targets that list references the group by
-/// name instead of respelling the labels. When elide adds a new
-/// label to a category, extending the group covers every rule
-/// that referenced it — no policy edit.
+/// Groups live on the [`PolicyDefinition`] that declares them
+/// and are visible only to that policy's own rules. Templates
+/// ship one group per canonical label list (`"hipaa_18"`,
+/// `"gdpr_article_9"`, `"pci_chd"`, `"pci_sad"`), and every
+/// rule that targets that list references the group by name
+/// instead of respelling the labels. When elide adds a new label
+/// to a category, extending the group covers every rule that
+/// referenced it — no rule edit.
 ///
 /// **Compilation**: at request time the engine synthesises a
-/// `group:<name>` tag on every label listed in the group, then
-/// rewrites [`Predicate::LabelInGroup { group }`] into
-/// [`Predicate::TagOneOf { tags: ["group:<name>"] }`]. That
-/// routes through the same `Anonymizer::with_tag` fast path as
-/// any authored tag — no new engine machinery, no per-request
-/// walk over group membership.
+/// `group:<policy_id>:<name>` tag on every label listed in the
+/// group, then rewrites [`Predicate::LabelInGroup { group }`]
+/// into [`Predicate::TagOneOf { tags: ["group:<policy_id>:<name>"] }`].
+/// That routes through the same `Anonymizer::with_tag` fast
+/// path as any authored tag — no new engine machinery, no
+/// per-request walk over group membership. Scoping the tag by
+/// `policy_id` keeps two policies that both declare `hipaa_18`
+/// with different labelsets from stepping on each other.
 ///
 /// **Unknown group names error at request validation**, not at
 /// apply time. A typo doesn't silently underfire.
 ///
-/// Groups are per-request, not per-policy: the caller (or a
-/// template loader) submits a `Vec<LabelGroup>` alongside the
-/// policy set. This keeps groups reusable across policies within
-/// one request and keeps them out of individual `PolicyDefinition`
-/// wire payloads.
-///
+/// [`PolicyDefinition`]: super::PolicyDefinition
 /// [`Predicate::LabelInGroup`]: super::predicate::Predicate::LabelInGroup
 /// [`Predicate::LabelInGroup { group }`]: super::predicate::Predicate::LabelInGroup
-/// [`Predicate::TagOneOf { tags: ["group:<name>"] }`]: super::predicate::Predicate::TagOneOf
+/// [`Predicate::TagOneOf { tags: ["group:<policy_id>:<name>"] }`]: super::predicate::Predicate::TagOneOf
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelGroup {

--- a/crates/nvisy-policy/src/lib.rs
+++ b/crates/nvisy-policy/src/lib.rs
@@ -6,9 +6,8 @@
 //!
 //! Authored vocabulary for redaction governance.
 //!
-//! A request submits `Vec<PolicyDefinition>` in precedence order,
-//! plus a `Vec<LabelGroup>` shared across every policy. Engine
-//! walks the policies; for each policy whose
+//! A request submits `Vec<PolicyDefinition>` in precedence order.
+//! Engine walks the policies; for each policy whose
 //! [`PolicyDefinition::when`] holds against the document, it walks
 //! [`PolicyDefinition::rules`] in order and runs the first matching
 //! rule's redaction operators. If no rule in a policy matches, the
@@ -26,11 +25,12 @@
 //!   fan-out).
 //!
 //! [`LabelGroup`]s are named clusters of [`LabelRef`]s a
-//! [`Predicate::LabelInGroup`] references by name. Templates ship
-//! groups (`"hipaa_18"`, `"gdpr_article_9"`); rules reference
-//! them without respelling the label list. At request-compile
-//! time the engine stamps `group:<name>` tags on the listed
-//! labels; unknown group names error at validation.
+//! [`Predicate::LabelInGroup`] references by name. Groups live
+//! on the policy that declares them (`hipaa_safe_harbor` policy
+//! carries a `hipaa_18` group); a rule can reference groups its
+//! own policy declared, not another policy's. At request-compile
+//! time the engine stamps `group:<policy_id>:<name>` tags on the
+//! listed labels; unknown group names error at validation.
 //!
 //! Identity is UUID-keyed: every [`PolicyDefinition`] and every
 //! [`PolicyRule`] carries a stable [`Uuid`]. Engine stamps
@@ -98,6 +98,17 @@ pub struct PolicyDefinition {
     /// [`Predicate::TagOneOf`]: predicate::Predicate::TagOneOf
     #[serde(default, skip_serializing_if = "Labels::is_empty")]
     pub labels: Labels,
+    /// Named clusters of [`LabelRef`]s this policy's rules may
+    /// reference by name via [`Predicate::LabelInGroup`]. Scoped
+    /// to this policy — a rule can only name a group its own
+    /// policy declared; unknown references error at request
+    /// validation. Two policies that both declare `hipaa_18` with
+    /// different labelsets stay independent.
+    ///
+    /// [`LabelRef`]: elide_core::entity::LabelRef
+    /// [`Predicate::LabelInGroup`]: predicate::Predicate::LabelInGroup
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<LabelGroup>,
     /// Ordered rules. First match wins within this policy.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rules: Vec<PolicyRule>,

--- a/crates/nvisy-policy/src/predicate/mod.rs
+++ b/crates/nvisy-policy/src/predicate/mod.rs
@@ -56,19 +56,24 @@ pub enum Predicate {
         /// Allowed tags.
         tags: Vec<String>,
     },
-    /// Entity label is in the named [`LabelGroup`] submitted
-    /// alongside this request.
+    /// Entity label is in the named [`LabelGroup`] declared by
+    /// the same [`PolicyDefinition`] this rule lives in.
     ///
-    /// Sugar over [`TagOneOf`]`{ tags: ["group:<name>"] }`: the
-    /// engine synthesises a `group:<name>` tag on every label
-    /// listed in the matching group at request-compile time, then
-    /// rewrites `LabelInGroup { group }` to that `TagOneOf` form.
-    /// Same fast path as any authored tag; the group indirection
-    /// keeps the wire compact when templates target a canonical
-    /// label cluster (e.g. `hipaa_18`, `gdpr_article_9`).
+    /// Sugar over [`TagOneOf`]`{ tags: ["group:<policy_id>:<name>"] }`:
+    /// the engine synthesises a `group:<policy_id>:<name>` tag on
+    /// every label listed in the matching group at request-compile
+    /// time, then rewrites `LabelInGroup { group }` to that
+    /// `TagOneOf` form. Same fast path as any authored tag; the
+    /// group indirection keeps the wire compact when templates
+    /// target a canonical label cluster (e.g. `hipaa_18`,
+    /// `gdpr_article_9`).
     ///
-    /// An unknown group name is a request-validation error, not a
-    /// silent no-op.
+    /// Groups are scoped to the declaring policy — a rule cannot
+    /// reference a group declared by another policy in the same
+    /// request. An unknown group name is a request-validation
+    /// error, not a silent no-op.
+    ///
+    /// [`PolicyDefinition`]: super::PolicyDefinition
     ///
     /// [`LabelGroup`]: super::LabelGroup
     /// [`TagOneOf`]: Predicate::TagOneOf

--- a/crates/nvisy-template/src/lib.rs
+++ b/crates/nvisy-template/src/lib.rs
@@ -5,11 +5,11 @@
 //! ## Architecture
 //!
 //! One function per regulatory posture, each returning a
-//! self-contained [`Template`] — the [`PolicyDefinition`]s plus
-//! the [`LabelGroup`]s those policies reference by name — matched
-//! to how the engine consumes them. Callers hand the [`Template`]
-//! straight to `Engine::analyze` / `Engine::anonymize` via
-//! [`Template::policies`] and [`Template::groups`].
+//! self-contained [`Template`] — the [`PolicyDefinition`]s each
+//! carrying its own inline [`LabelGroup`]s — matched to how the
+//! engine consumes them. Callers hand the [`Template`] straight
+//! to `Engine::analyze` / `Engine::anonymize` via
+//! [`Template::policies`].
 //!
 //! Templates are plain data. Nothing is registered globally, and
 //! no template constructor talks to the engine or hits I/O. A

--- a/crates/nvisy-template/src/template/ccpa.rs
+++ b/crates/nvisy-template/src/template/ccpa.rs
@@ -104,7 +104,6 @@ pub(crate) fn template() -> Template {
         version: Version::new(1, 0, 0),
         effective_date: Date::constant(2020, 1, 1),
         description: "CCPA / CPRA — Cal. Civ. Code §1798.140(v)(1) personal information".into(),
-        groups: vec![group()],
         policies: vec![policy()],
     }
 }
@@ -139,6 +138,7 @@ fn policy() -> PolicyDefinition {
             builtins: CCPA_LABELS.to_vec(),
             custom: Vec::new(),
         },
+        groups: vec![group()],
         rules: vec![erase_rule()],
         fallback: None,
         retention: Vec::new(),
@@ -170,9 +170,9 @@ mod tests {
         let t = template();
         assert_eq!(t.name, "ccpa");
         assert_eq!(t.version, Version::new(1, 0, 0));
-        assert_eq!(t.groups.len(), 1);
-        assert_eq!(t.groups[0].name, GROUP_NAME);
         assert_eq!(t.policies.len(), 1);
+        assert_eq!(t.policies[0].groups.len(), 1);
+        assert_eq!(t.policies[0].groups[0].name, GROUP_NAME);
     }
 
     #[test]

--- a/crates/nvisy-template/src/template/gdpr.rs
+++ b/crates/nvisy-template/src/template/gdpr.rs
@@ -69,7 +69,6 @@ pub(crate) fn template() -> Template {
         version: Version::new(1, 0, 0),
         effective_date: Date::constant(2018, 5, 25),
         description: "GDPR Article 9 — special categories of personal data".into(),
-        groups: vec![group()],
         policies: vec![policy()],
     }
 }
@@ -104,6 +103,7 @@ fn policy() -> PolicyDefinition {
             builtins: GDPR_LABELS.to_vec(),
             custom: Vec::new(),
         },
+        groups: vec![group()],
         rules: vec![erase_rule()],
         fallback: None,
         retention: Vec::new(),
@@ -133,9 +133,9 @@ mod tests {
         let t = template();
         assert_eq!(t.name, "gdpr_article_9");
         assert_eq!(t.version, Version::new(1, 0, 0));
-        assert_eq!(t.groups.len(), 1);
-        assert_eq!(t.groups[0].name, GROUP_NAME);
         assert_eq!(t.policies.len(), 1);
+        assert_eq!(t.policies[0].groups.len(), 1);
+        assert_eq!(t.policies[0].groups[0].name, GROUP_NAME);
     }
 
     #[test]

--- a/crates/nvisy-template/src/template/hipaa.rs
+++ b/crates/nvisy-template/src/template/hipaa.rs
@@ -105,7 +105,6 @@ pub(crate) fn template() -> Template {
         version: Version::new(1, 0, 0),
         effective_date: Date::constant(2003, 4, 14),
         description: "HIPAA Safe Harbor de-identification — 45 CFR §164.514(b)(2)".into(),
-        groups: vec![group()],
         policies: vec![policy()],
     }
 }
@@ -143,6 +142,7 @@ fn policy() -> PolicyDefinition {
                 .collect(),
             custom: Vec::new(),
         },
+        groups: vec![group()],
         rules: vec![special_dispatch_rule(), bulk_erase_rule()],
         fallback: None,
         retention: Vec::new(),
@@ -216,9 +216,9 @@ mod tests {
         let t = template();
         assert_eq!(t.name, "hipaa_safe_harbor");
         assert_eq!(t.version, Version::new(1, 0, 0));
-        assert_eq!(t.groups.len(), 1);
-        assert_eq!(t.groups[0].name, GROUP_NAME);
         assert_eq!(t.policies.len(), 1);
+        assert_eq!(t.policies[0].groups.len(), 1);
+        assert_eq!(t.policies[0].groups[0].name, GROUP_NAME);
     }
 
     #[test]

--- a/crates/nvisy-template/src/template/mod.rs
+++ b/crates/nvisy-template/src/template/mod.rs
@@ -1,7 +1,7 @@
 //! The [`Template`] value every template constructor returns:
-//! the [`PolicyDefinition`]s + [`LabelGroup`]s a caller submits
-//! together, plus identity metadata the engine records on every
-//! run driven by this template.
+//! the [`PolicyDefinition`]s a caller submits, plus identity
+//! metadata the engine records on every run driven by this
+//! template.
 
 pub(crate) mod ccpa;
 pub(crate) mod gdpr;
@@ -10,17 +10,18 @@ pub(crate) mod pci;
 
 use hipstr::HipStr;
 use jiff::civil::Date;
+use nvisy_policy::PolicyDefinition;
 use nvisy_policy::redaction::{ModalityRedactions, TextRedaction};
-use nvisy_policy::{LabelGroup, PolicyDefinition};
 use semver::Version;
 
 /// A regulatory posture packaged as engine-ready data.
 ///
 /// Templates are plain data; a caller wanting to diverge from
-/// the shipped defaults mutates the returned [`policies`] /
-/// [`groups`] before submitting. The engine never sees the
-/// [`Template`] itself — only its [`policies`] and [`groups`]
-/// via `Engine::analyze` / `Engine::anonymize`.
+/// the shipped defaults mutates the returned [`policies`]
+/// before submitting. The engine never sees the [`Template`]
+/// itself — only its [`policies`] via `Engine::analyze` /
+/// `Engine::anonymize`. Each policy carries its own
+/// [`LabelGroup`]s inline via [`PolicyDefinition::groups`].
 ///
 /// # Identity
 ///
@@ -33,10 +34,11 @@ use semver::Version;
 /// from under them.
 ///
 /// [`effective_date`]: Self::effective_date
-/// [`groups`]: Self::groups
 /// [`policies`]: Self::policies
 /// [`version`]: Self::version
+/// [`LabelGroup`]: nvisy_policy::LabelGroup
 /// [`PolicyDefinition::id`]: nvisy_policy::PolicyDefinition::id
+/// [`PolicyDefinition::groups`]: nvisy_policy::PolicyDefinition::groups
 #[derive(Debug, Clone)]
 pub struct Template {
     /// Stable identifier for the template, matched to the
@@ -59,16 +61,9 @@ pub struct Template {
     /// Human-readable name for reviewers. `name` is the machine
     /// identifier; this is the string a customer sees.
     pub description: HipStr<'static>,
-    /// [`LabelGroup`]s the template's [`policies`] reference by
-    /// name. Passed as-is to `Engine::analyze` / `anonymize`.
-    /// May be empty for templates whose rules address labels
-    /// directly (e.g. PAN-only templates).
-    ///
-    /// [`policies`]: Self::policies
-    /// [`LabelGroup`]: nvisy_policy::LabelGroup
-    pub groups: Vec<LabelGroup>,
     /// The [`PolicyDefinition`]s a caller submits in precedence
-    /// order. Every template ships at least one.
+    /// order. Every template ships at least one. Each policy
+    /// declares its own `LabelGroup`s inline.
     ///
     /// [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
     pub policies: Vec<PolicyDefinition>,

--- a/crates/nvisy-template/src/template/pci.rs
+++ b/crates/nvisy-template/src/template/pci.rs
@@ -53,7 +53,6 @@ pub(crate) fn truncate_template() -> Template {
         effective_date: EFFECTIVE_DATE,
         description: "PCI DSS §3.5.1 — PAN render via truncation (keep first-six / last-four)"
             .into(),
-        groups: Vec::new(),
         policies: vec![PolicyDefinition {
             id: TRUNCATE_POLICY_ID,
             name: "pci-dss-pan-truncate".into(),
@@ -68,6 +67,7 @@ pub(crate) fn truncate_template() -> Template {
                 builtins: vec![PAN_LABEL.clone()],
                 custom: Vec::new(),
             },
+            groups: Vec::new(),
             rules: vec![truncate_rule()],
             fallback: None,
             retention: Vec::new(),
@@ -84,7 +84,6 @@ pub(crate) fn hmac_template() -> Template {
         effective_date: EFFECTIVE_DATE,
         description: "PCI DSS §3.5.1 — PAN render via keyed cryptographic hash (HMAC-SHA-256)"
             .into(),
-        groups: Vec::new(),
         policies: vec![PolicyDefinition {
             id: HMAC_POLICY_ID,
             name: "pci-dss-pan-hmac".into(),
@@ -100,6 +99,7 @@ pub(crate) fn hmac_template() -> Template {
                 builtins: vec![PAN_LABEL.clone()],
                 custom: Vec::new(),
             },
+            groups: Vec::new(),
             rules: vec![hmac_rule()],
             fallback: None,
             retention: Vec::new(),
@@ -155,7 +155,10 @@ mod tests {
         let t = truncate_template();
         assert_eq!(t.name, "pci_dss_pan_truncate");
         assert_eq!(t.version, Version::new(1, 0, 0));
-        assert!(t.groups.is_empty(), "PCI templates ship no LabelGroup");
+        assert!(
+            t.policies[0].groups.is_empty(),
+            "PCI templates ship no LabelGroup",
+        );
         assert_eq!(t.policies.len(), 1);
     }
 
@@ -164,7 +167,7 @@ mod tests {
         let t = hmac_template();
         assert_eq!(t.name, "pci_dss_pan_hmac");
         assert_eq!(t.version, Version::new(1, 0, 0));
-        assert!(t.groups.is_empty());
+        assert!(t.policies[0].groups.is_empty());
         assert_eq!(t.policies.len(), 1);
     }
 


### PR DESCRIPTION
## Summary

Wire cleanup: \`LabelGroup\` moves from a separate \`Vec<LabelGroup>\` parameter on \`Engine::analyze\`/\`anonymize\` to a \`groups: Vec<LabelGroup>\` field on \`PolicyDefinition\`. Scoping is strict per-policy — a rule can only reference groups its own policy declared.

**Why.** The Phase 1 design carried groups as a request-scoped submission alongside policies, on the theory that groups were cross-policy vocabulary. In practice every shipped template referenced its group from inside a single policy, and the two-parameter API pushed an internal wire detail onto every caller. Embedding groups in the policy that declares them collapses the API and models the actual usage.

## Behavior change

- **API**: \`engine.analyze(doc, &policies, &groups, &spec)\` → \`engine.analyze(doc, &policies, &spec)\`. Same for \`anonymize\`.
- **Scoping**: strict — policy A's rule can no longer name a group declared by policy B in the same request. In practice nothing did.
- **Tag synthesis**: \`group:<name>\` → \`group:<policy_id>:<name>\`. Two policies that both declare \`hipaa_18\` with different labelsets stay independent (verified by new test).

## Test plan

- [x] \`cargo test --workspace --all-features\` — 28 tests green
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps\`
- [x] \`cargo machete\` — clean
- [x] \`cargo +nightly fmt --all --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)