### PR TITLE
refactor(template): collapse Template.policies Vec to single policy

### DIFF
--- a/crates/nvisy-engine/tests/templates.rs
+++ b/crates/nvisy-engine/tests/templates.rs
@@ -56,11 +56,19 @@ fn default_spec() -> AnalyzerParams {
 /// and return the redacted body as a UTF-8 string.
 async fn apply(engine: &Engine, template: Template) -> String {
     let mut analyzed = engine
-        .analyze(raw_txt(), &template.policies, &default_spec())
+        .analyze(
+            raw_txt(),
+            std::slice::from_ref(&template.policy),
+            &default_spec(),
+        )
         .await
         .expect("analyze succeeds");
     let redacted = engine
-        .anonymize(raw_txt(), &template.policies, &mut analyzed)
+        .anonymize(
+            raw_txt(),
+            std::slice::from_ref(&template.policy),
+            &mut analyzed,
+        )
         .await
         .expect("anonymize succeeds");
     String::from_utf8(redacted.bytes.to_vec()).expect("body is utf-8")
@@ -133,11 +141,19 @@ async fn pci_dss_pan_hmac_requires_key_provider() {
     // capability requirement into place.
     let template = nvisy_template::pci_dss_pan_hmac();
     let mut analyzed = engine()
-        .analyze(raw_txt(), &template.policies, &default_spec())
+        .analyze(
+            raw_txt(),
+            std::slice::from_ref(&template.policy),
+            &default_spec(),
+        )
         .await
         .expect("analyze succeeds without a key provider");
     let err = engine()
-        .anonymize(raw_txt(), &template.policies, &mut analyzed)
+        .anonymize(
+            raw_txt(),
+            std::slice::from_ref(&template.policy),
+            &mut analyzed,
+        )
         .await
         .expect_err("anonymize must fail without a key provider");
     assert!(
@@ -191,11 +207,19 @@ async fn every_shipped_template_analyzes_and_anonymizes_the_sample() {
     for template in nvisy_template::TemplateCatalog::builtin().iter() {
         let id = &template.id;
         let mut analyzed = engine
-            .analyze(raw_txt(), &template.policies, &default_spec())
+            .analyze(
+                raw_txt(),
+                std::slice::from_ref(&template.policy),
+                &default_spec(),
+            )
             .await
             .unwrap_or_else(|e| panic!("template `{id}` failed to analyze: {e}"));
         engine
-            .anonymize(raw_txt(), &template.policies, &mut analyzed)
+            .anonymize(
+                raw_txt(),
+                std::slice::from_ref(&template.policy),
+                &mut analyzed,
+            )
             .await
             .unwrap_or_else(|e| panic!("template `{id}` failed to anonymize: {e}"));
     }

--- a/crates/nvisy-template/src/catalog.rs
+++ b/crates/nvisy-template/src/catalog.rs
@@ -411,11 +411,11 @@ mod tests {
             assert_eq!(recovered.version, template.version);
             assert_eq!(recovered.effective_date, template.effective_date);
             assert_eq!(recovered.description, template.description);
-            let round_policies = serde_json::to_value(&recovered.policies).unwrap();
-            let orig_policies = serde_json::to_value(&template.policies).unwrap();
+            let round_policy = serde_json::to_value(&recovered.policy).unwrap();
+            let orig_policy = serde_json::to_value(&template.policy).unwrap();
             assert_eq!(
-                round_policies, orig_policies,
-                "template `{}` policies must round-trip byte-identical",
+                round_policy, orig_policy,
+                "template `{}` policy must round-trip byte-identical",
                 template.id,
             );
         }

--- a/crates/nvisy-template/src/lib.rs
+++ b/crates/nvisy-template/src/lib.rs
@@ -7,8 +7,11 @@
 //! One function per shipped template, each returning a
 //! self-contained [`Template`] — the [`PolicyDefinition`]s each
 //! carrying its own inline [`LabelGroup`]s — matched to how the
-//! engine consumes them. Callers hand `template.policies`
-//! straight to `Engine::analyze` / `Engine::anonymize`.
+//! engine consumes them. Callers hand `template.policy`
+//! (as a one-element slice via `std::slice::from_ref`) to
+//! `Engine::analyze` / `Engine::anonymize`, or compose several
+//! templates' policies into one slice when they want more than
+//! one regulatory posture per request.
 //!
 //! Five templates across four regulatory postures:
 //! [`hipaa_safe_harbor`], [`gdpr_article_9`],

--- a/crates/nvisy-template/src/template/ccpa.rs
+++ b/crates/nvisy-template/src/template/ccpa.rs
@@ -109,7 +109,7 @@ pub(crate) fn template() -> Template {
              category."
                 .into(),
         ),
-        policies: vec![policy()],
+        policy: policy(),
     }
 }
 
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn rule_matches_the_group_and_erases() {
-        let PolicyRule::Predicated(rule) = &template().policies[0].rules[0] else {
+        let PolicyRule::Predicated(rule) = &template().policy.rules[0] else {
             panic!("expected Predicated rule");
         };
         assert!(matches!(
@@ -210,7 +210,7 @@ mod tests {
     fn template_ids_are_stable_across_calls() {
         let a = template();
         let b = template();
-        assert_eq!(a.policies[0].id, b.policies[0].id);
-        assert_eq!(a.policies[0].rules[0].id(), b.policies[0].rules[0].id());
+        assert_eq!(a.policy.id, b.policy.id);
+        assert_eq!(a.policy.rules[0].id(), b.policy.rules[0].id());
     }
 }

--- a/crates/nvisy-template/src/template/gdpr.rs
+++ b/crates/nvisy-template/src/template/gdpr.rs
@@ -72,7 +72,7 @@ pub(crate) fn template() -> Template {
         description: Some(
             "Erase the nine categories of personal data Article 9(1) treats as special.".into(),
         ),
-        policies: vec![policy()],
+        policy: policy(),
     }
 }
 
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn rule_matches_the_group_and_erases() {
-        let PolicyRule::Predicated(rule) = &template().policies[0].rules[0] else {
+        let PolicyRule::Predicated(rule) = &template().policy.rules[0] else {
             panic!("expected Predicated rule");
         };
         assert!(matches!(
@@ -169,7 +169,7 @@ mod tests {
     fn template_ids_are_stable_across_calls() {
         let a = template();
         let b = template();
-        assert_eq!(a.policies[0].id, b.policies[0].id);
-        assert_eq!(a.policies[0].rules[0].id(), b.policies[0].rules[0].id());
+        assert_eq!(a.policy.id, b.policy.id);
+        assert_eq!(a.policy.rules[0].id(), b.policy.rules[0].id());
     }
 }

--- a/crates/nvisy-template/src/template/hipaa.rs
+++ b/crates/nvisy-template/src/template/hipaa.rs
@@ -110,7 +110,7 @@ pub(crate) fn template() -> Template {
         description: Some(
             "45 CFR §164.514(b)(2) — remove the eighteen identifier categories.".into(),
         ),
-        policies: vec![policy()],
+        policy: policy(),
     }
 }
 
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn special_dispatch_rule_precedes_bulk_erase() {
-        let policy = &template().policies[0];
+        let policy = &template().policy;
         assert!(
             matches!(&policy.rules[0], PolicyRule::Table(_)),
             "table rule must fire first so `age` and dates reach their generalizers",
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn table_rule_dispatches_age_to_clamp_and_dates_to_generalize() {
-        let PolicyRule::Table(table) = &template().policies[0].rules[0] else {
+        let PolicyRule::Table(table) = &template().policy.rules[0] else {
             panic!("first rule must be Table");
         };
         let age = table
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn bulk_rule_matches_the_group() {
-        let PolicyRule::Predicated(rule) = &template().policies[0].rules[1] else {
+        let PolicyRule::Predicated(rule) = &template().policy.rules[1] else {
             panic!("second rule must be Predicated");
         };
         assert!(matches!(
@@ -283,8 +283,8 @@ mod tests {
     fn template_ids_are_stable_across_calls() {
         let a = template();
         let b = template();
-        assert_eq!(a.policies[0].id, b.policies[0].id);
-        assert_eq!(a.policies[0].rules[0].id(), b.policies[0].rules[0].id());
-        assert_eq!(a.policies[0].rules[1].id(), b.policies[0].rules[1].id());
+        assert_eq!(a.policy.id, b.policy.id);
+        assert_eq!(a.policy.rules[0].id(), b.policy.rules[0].id());
+        assert_eq!(a.policy.rules[1].id(), b.policy.rules[1].id());
     }
 }

--- a/crates/nvisy-template/src/template/mod.rs
+++ b/crates/nvisy-template/src/template/mod.rs
@@ -18,10 +18,10 @@ use serde::{Deserialize, Serialize};
 /// A regulatory posture packaged as engine-ready data.
 ///
 /// Templates are plain data; a caller wanting to diverge from
-/// the shipped defaults mutates the returned [`policies`]
+/// the shipped defaults mutates the returned [`policy`]
 /// before submitting. The engine never sees the [`Template`]
-/// itself — only its [`policies`] via `Engine::analyze` /
-/// `Engine::anonymize`. Each policy carries its own
+/// itself — only its [`policy`] via `Engine::analyze` /
+/// `Engine::anonymize`. The policy carries its own
 /// [`LabelGroup`]s inline via [`PolicyDefinition::groups`].
 ///
 /// # Identity
@@ -62,7 +62,7 @@ use serde::{Deserialize, Serialize};
 /// [`effective_date`]: Self::effective_date
 /// [`id`]: Self::id
 /// [`name`]: Self::name
-/// [`policies`]: Self::policies
+/// [`policy`]: Self::policy
 /// [`version`]: Self::version
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -87,10 +87,13 @@ pub struct Template {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Option<String>")]
     pub description: Option<HipStr<'static>>,
-    /// The [`PolicyDefinition`]s a caller submits in precedence
-    /// order. Every template ships at least one. Each policy
-    /// declares its own `LabelGroup`s inline.
+    /// The [`PolicyDefinition`] this template encodes. Carries
+    /// its own [`LabelGroup`]s inline. A caller composing
+    /// several regulatory postures in one request submits
+    /// multiple templates and unions their policies into the
+    /// engine's `&[PolicyDefinition]` slice.
     ///
+    /// [`LabelGroup`]: nvisy_policy::LabelGroup
     /// [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
-    pub policies: Vec<PolicyDefinition>,
+    pub policy: PolicyDefinition,
 }

--- a/crates/nvisy-template/src/template/pci.rs
+++ b/crates/nvisy-template/src/template/pci.rs
@@ -57,7 +57,7 @@ pub(crate) fn truncate_template() -> Template {
              (BIN) and last four digits."
                 .into(),
         ),
-        policies: vec![PolicyDefinition {
+        policy: PolicyDefinition {
             id: TRUNCATE_POLICY_ID,
             name: "pci-dss-pan-truncate".into(),
             description: Some(
@@ -75,7 +75,7 @@ pub(crate) fn truncate_template() -> Template {
             rules: vec![truncate_rule()],
             fallback: None,
             retention: Vec::new(),
-        }],
+        },
     }
 }
 
@@ -92,7 +92,7 @@ pub(crate) fn hmac_template() -> Template {
              the engine to have a KeyProvider wired."
                 .into(),
         ),
-        policies: vec![PolicyDefinition {
+        policy: PolicyDefinition {
             id: HMAC_POLICY_ID,
             name: "pci-dss-pan-hmac".into(),
             description: Some(
@@ -111,7 +111,7 @@ pub(crate) fn hmac_template() -> Template {
             rules: vec![hmac_rule()],
             fallback: None,
             retention: Vec::new(),
-        }],
+        },
     }
 }
 
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn truncate_rule_keeps_bin_and_last_four() {
-        let PolicyRule::Predicated(rule) = &truncate_template().policies[0].rules[0] else {
+        let PolicyRule::Predicated(rule) = &truncate_template().policy.rules[0] else {
             panic!("expected Predicated rule");
         };
         assert!(matches!(
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn hmac_rule_uses_sha256_by_default() {
-        let PolicyRule::Predicated(rule) = &hmac_template().policies[0].rules[0] else {
+        let PolicyRule::Predicated(rule) = &hmac_template().policy.rules[0] else {
             panic!("expected Predicated rule");
         };
         assert!(matches!(
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn both_templates_target_payment_card_label() {
         for template in [truncate_template(), hmac_template()] {
-            let PolicyRule::Predicated(rule) = &template.policies[0].rules[0] else {
+            let PolicyRule::Predicated(rule) = &template.policy.rules[0] else {
                 panic!("expected Predicated rule");
             };
             let Predicate::LabelOneOf { labels } = &rule.predicate else {
@@ -203,20 +203,14 @@ mod tests {
     fn template_ids_are_stable_across_calls() {
         let trunc_a = truncate_template();
         let trunc_b = truncate_template();
-        assert_eq!(trunc_a.policies[0].id, trunc_b.policies[0].id);
-        assert_eq!(
-            trunc_a.policies[0].rules[0].id(),
-            trunc_b.policies[0].rules[0].id(),
-        );
+        assert_eq!(trunc_a.policy.id, trunc_b.policy.id);
+        assert_eq!(trunc_a.policy.rules[0].id(), trunc_b.policy.rules[0].id(),);
         let hmac_a = hmac_template();
         let hmac_b = hmac_template();
-        assert_eq!(hmac_a.policies[0].id, hmac_b.policies[0].id);
-        assert_eq!(
-            hmac_a.policies[0].rules[0].id(),
-            hmac_b.policies[0].rules[0].id(),
-        );
+        assert_eq!(hmac_a.policy.id, hmac_b.policy.id);
+        assert_eq!(hmac_a.policy.rules[0].id(), hmac_b.policy.rules[0].id(),);
         assert_ne!(
-            trunc_a.policies[0].id, hmac_a.policies[0].id,
+            trunc_a.policy.id, hmac_a.policy.id,
             "the two PCI templates must ship distinct policy identities",
         );
     }


### PR DESCRIPTION
## Summary

\`Template.policies: Vec<PolicyDefinition>\` becomes \`Template.policy: PolicyDefinition\`. Every shipped template already carries exactly one policy; the Vec was defensive modeling for a case no template exercises.

The right composition model: two regulatory postures = two templates. Callers who want HIPAA + CCPA in one request submit both templates and union their policies into the engine's slice.

## Migration

- \`&t.policies\` → \`std::slice::from_ref(&t.policy)\`
- \`t.policies[0]\` → \`t.policy\`

## Test plan

- [x] \`cargo test --workspace --all-features\` — 40 tests green
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps\`
- [x] \`cargo machete\` — clean
- [x] \`cargo +nightly fmt --all --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)