### PR TITLE
Expand template option enums, add SAV template, adopt elide labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "bytes",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "elide-core",
  "futures",
@@ -1035,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "elide-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "elide-operator"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#936f913516ad481bd6252edeb5006c3db0802a57"
+source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/nvisy-engine/src/analyzer/recognizer/pattern.rs
+++ b/crates/nvisy-engine/src/analyzer/recognizer/pattern.rs
@@ -128,7 +128,7 @@ fn compile_custom_rule(rule: &CustomPatternRule, guardrails: &PatternGuardrails)
         .collect::<Result<Vec<_>, _>>()?;
     Regex::builder()
         .with_name(rule.name.clone())
-        .with_label(rule.label.clone())
+        .with_labels(vec![rule.label.clone()])
         .with_variants(variants)
         .with_context(compile_context(&rule.context))
         .with_languages(rule.languages.clone())
@@ -166,7 +166,7 @@ fn compile_custom_dictionary(dict: &CustomDictionary) -> Result<Dictionary> {
         .collect::<Vec<_>>();
     Dictionary::builder()
         .with_name(dict.name.clone())
-        .with_label(dict.label.clone())
+        .with_labels(vec![dict.label.clone()])
         .with_terms(terms)
         .with_scoring(Scoring::Uniform(dict.score))
         .with_context(compile_context(&dict.context))

--- a/crates/nvisy-engine/tests/templates.rs
+++ b/crates/nvisy-engine/tests/templates.rs
@@ -16,7 +16,10 @@ use nvisy_schema::plan::{
     AnalyzerParams, EnricherParams, PatternRecognizerParams, ProviderSelection, RecognizerParams,
     ScopeParams,
 };
-use nvisy_template::{HipaaDeidMethod, PciPanRender, PolicyTemplate, Template, TemplateCatalog};
+use nvisy_template::{
+    GdprArticle9Treatment, HipaaDeidMethod, PciDssPart, PciPanRender, PolicyTemplate, Template,
+    TemplateCatalog,
+};
 
 const SAMPLE_TXT: &[u8] = include_bytes!("testdata/sample.txt");
 
@@ -164,7 +167,14 @@ async fn gdpr_article_9_leaves_non_special_categories_alone() {
     // health data, biometric, sexual orientation, etc.). So the
     // GDPR template should redact nothing — the output equals
     // the input.
-    let body = apply(&engine(), PolicyTemplate::GdprArticle9.build()).await;
+    let body = apply(
+        &engine(),
+        PolicyTemplate::GdprArticle9 {
+            treatment: GdprArticle9Treatment::Erase,
+        }
+        .build(),
+    )
+    .await;
     assert!(
         body.contains("jane.doe@example.com"),
         "GDPR Article 9 doesn't cover email; must survive. Body:\n{body}",
@@ -182,8 +192,10 @@ async fn pci_dss_pan_truncate_leaves_non_pan_labels_alone() {
     // round-trip unchanged.
     let body = apply(
         &engine(),
-        PolicyTemplate::PciDssPan {
-            render: PciPanRender::Truncate,
+        PolicyTemplate::PciDss {
+            part: PciDssPart::PanRender {
+                render: PciPanRender::Truncate,
+            },
         }
         .build(),
     )
@@ -199,13 +211,40 @@ async fn pci_dss_pan_truncate_leaves_non_pan_labels_alone() {
 }
 
 #[tokio::test]
+async fn pci_dss_sav_erase_leaves_non_sav_labels_alone() {
+    // The sample has no `card_security_code` entity — the PCI SAV
+    // template targets exactly one label, so the sample should
+    // round-trip unchanged. (The distinguishing behavior — erasing
+    // a real CVV — needs the richer sample fixture tracked in
+    // #366.)
+    let body = apply(
+        &engine(),
+        PolicyTemplate::PciDss {
+            part: PciDssPart::SavErase,
+        }
+        .build(),
+    )
+    .await;
+    assert!(
+        body.contains("jane.doe@example.com"),
+        "PCI SAV template doesn't cover email; must survive. Body:\n{body}",
+    );
+    assert!(
+        body.contains("123-45-6789"),
+        "PCI SAV template doesn't cover SSN; must survive. Body:\n{body}",
+    );
+}
+
+#[tokio::test]
 async fn pci_dss_pan_hmac_requires_key_provider() {
     // Without a key provider on the engine, compiling the HMAC
     // template's HmacHash operator fails at anonymize-time with
     // a Configuration error. Proves the template wires the right
     // capability requirement into place.
-    let template = PolicyTemplate::PciDssPan {
-        render: PciPanRender::HmacSha256,
+    let template = PolicyTemplate::PciDss {
+        part: PciDssPart::PanRender {
+            render: PciPanRender::HmacSha256,
+        },
     }
     .build();
     let mut analyzed = engine()
@@ -238,8 +277,10 @@ async fn pci_dss_pan_hmac_runs_with_a_key_provider() {
     // template-specific setup the operator needs.
     let body = apply(
         &engine_with_key(),
-        PolicyTemplate::PciDssPan {
-            render: PciPanRender::HmacSha256,
+        PolicyTemplate::PciDss {
+            part: PciDssPart::PanRender {
+                render: PciPanRender::HmacSha256,
+            },
         }
         .build(),
     )

--- a/crates/nvisy-template/README.md
+++ b/crates/nvisy-template/README.md
@@ -20,7 +20,7 @@ diverges from the shipped default.
 
 ## What's covered
 
-Four regulatory postures across seven shipped variants:
+Four regulatory postures across eleven shipped variants:
 
 - **HIPAA §164.514 de-identification**. Ships all three methods
   the rule permits: Safe Harbor (fixed 18-identifier removal),
@@ -30,12 +30,22 @@ Four regulatory postures across seven shipped variants:
   (identity-preserving pseudonymization; requires a qualified
   statistician to attest that re-identification risk is "very
   small" before the output can be treated as de-identified).
-- **GDPR Article 9** — special-category personal data.
-- **PCI DSS §3.5.1** — Primary Account Number render posture.
-  Ships both permitted approaches: truncation (BIN + last-four,
-  no key material) and keyed HMAC-SHA-256 (preserves per-row
-  identity for downstream joins and dedup; requires a key
-  provider wired into the engine).
+- **GDPR Article 9** — special-category personal data. Ships
+  two treatments: erasure (the default no-basis posture) and
+  pseudonymization (identity-preserving; requires an Article
+  9(2) lawful-basis carve-out established out-of-band).
+- **PCI DSS**. Two families:
+  - **§3.5.1 Primary Account Number render posture.** Ships four
+    render variants covering the truncation and keyed-hash
+    approaches §3.5.1 permits: keep-BIN-and-last-four truncation,
+    last-four-only truncation (the stricter §3.5.1.1 posture
+    required when a hashed copy of the same PAN coexists in the
+    environment), HMAC-SHA-256, and HMAC-SHA-512. HMAC variants
+    require a key provider wired into the engine.
+  - **§3.3.1 Sensitive Authentication Data erasure.** SAV
+    (CVV/CVC, track data, PIN blocks) is prohibited from storage
+    after authorization — the correct posture is erasure, not
+    render-unreadable. Currently covers CVV/CVC.
 - **CCPA** — Cal. Civ. Code §1798.140 personal-information
   categories.
 

--- a/crates/nvisy-template/src/catalog.rs
+++ b/crates/nvisy-template/src/catalog.rs
@@ -22,7 +22,9 @@ use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use super::{HipaaDeidMethod, PciPanRender, PolicyTemplate, Template};
+use super::{
+    GdprArticle9Treatment, HipaaDeidMethod, PciDssPart, PciPanRender, PolicyTemplate, Template,
+};
 
 /// Runtime registry of [`Template`]s, keyed by
 /// `(id, version)`. Templates are stored behind [`Arc`] so
@@ -101,12 +103,34 @@ impl TemplateCatalog {
             PolicyTemplate::HipaaDeidentification {
                 method: HipaaDeidMethod::ExpertDetermination,
             },
-            PolicyTemplate::GdprArticle9,
-            PolicyTemplate::PciDssPan {
-                render: PciPanRender::Truncate,
+            PolicyTemplate::GdprArticle9 {
+                treatment: GdprArticle9Treatment::Erase,
             },
-            PolicyTemplate::PciDssPan {
-                render: PciPanRender::HmacSha256,
+            PolicyTemplate::GdprArticle9 {
+                treatment: GdprArticle9Treatment::Pseudonymize,
+            },
+            PolicyTemplate::PciDss {
+                part: PciDssPart::PanRender {
+                    render: PciPanRender::Truncate,
+                },
+            },
+            PolicyTemplate::PciDss {
+                part: PciDssPart::PanRender {
+                    render: PciPanRender::TruncateLastFour,
+                },
+            },
+            PolicyTemplate::PciDss {
+                part: PciDssPart::PanRender {
+                    render: PciPanRender::HmacSha256,
+                },
+            },
+            PolicyTemplate::PciDss {
+                part: PciDssPart::PanRender {
+                    render: PciPanRender::HmacSha512,
+                },
+            },
+            PolicyTemplate::PciDss {
+                part: PciDssPart::SavErase,
             },
             PolicyTemplate::Ccpa,
         ];
@@ -319,25 +343,31 @@ mod tests {
     #[test]
     fn get_returns_the_exact_version_or_none() {
         let mut catalog = TemplateCatalog::new();
-        let mut v1 = PolicyTemplate::GdprArticle9.build();
+        let mut v1 = PolicyTemplate::GdprArticle9 {
+            treatment: GdprArticle9Treatment::Erase,
+        }
+        .build();
         v1.version = Version::new(1, 0, 0);
-        let mut v2 = PolicyTemplate::GdprArticle9.build();
+        let mut v2 = PolicyTemplate::GdprArticle9 {
+            treatment: GdprArticle9Treatment::Erase,
+        }
+        .build();
         v2.version = Version::new(2, 0, 0);
         catalog.insert(v1).unwrap();
         catalog.insert(v2).unwrap();
         assert!(
             catalog
-                .get("gdpr_article_9", &Version::new(1, 0, 0))
+                .get("gdpr_article_9_erase", &Version::new(1, 0, 0))
                 .is_some()
         );
         assert!(
             catalog
-                .get("gdpr_article_9", &Version::new(2, 0, 0))
+                .get("gdpr_article_9_erase", &Version::new(2, 0, 0))
                 .is_some()
         );
         assert!(
             catalog
-                .get("gdpr_article_9", &Version::new(3, 0, 0))
+                .get("gdpr_article_9_erase", &Version::new(3, 0, 0))
                 .is_none()
         );
         assert!(

--- a/crates/nvisy-template/src/lib.rs
+++ b/crates/nvisy-template/src/lib.rs
@@ -5,11 +5,14 @@
 //! ## Architecture
 //!
 //! [`PolicyTemplate`] enumerates the regulatory postures this
-//! crate ships. Variants that admit more than one operator
-//! choice the regulation permits carry a small options struct
-//! (e.g. [`PolicyTemplate::PciDssPan`] carries a [`PciPanRender`]
-//! picking truncate-vs-HMAC — both listed under PCI DSS §3.5.1);
-//! variants with a single shipped operator take no data.
+//! crate ships. Variants that admit more than one shipped
+//! posture carry a small options enum — e.g.
+//! [`PolicyTemplate::PciDss`] carries a [`PciDssPart`] picking
+//! between §3.5.1 PAN render (with a nested [`PciPanRender`]
+//! choice) and §3.3.1 SAV erasure;
+//! [`PolicyTemplate::GdprArticle9`] carries a
+//! [`GdprArticle9Treatment`] picking erasure vs.
+//! pseudonymization for the Article 9(2) lawful-basis case.
 //!
 //! [`PolicyTemplate::build`] materialises the picked variant
 //! into a [`Template`] — the [`PolicyDefinition`] carrying its
@@ -57,7 +60,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub use self::catalog::TemplateCatalog;
-pub use self::template::{HipaaDeidMethod, PciPanRender, Template};
+pub use self::template::{
+    GdprArticle9Treatment, HipaaDeidMethod, PciDssPart, PciPanRender, Template,
+};
 use self::template::{ccpa, gdpr, hipaa, pci};
 
 /// A regulatory posture this crate ships a [`Template`] for.
@@ -84,27 +89,23 @@ pub enum PolicyTemplate {
         /// for the tradeoff.
         method: HipaaDeidMethod,
     },
-    /// GDPR Article 9 special categories of personal data. Ships
-    /// a `gdpr_article_9` [`LabelGroup`] naming the nine special
-    /// categories the article enumerates, plus a [`Predicated`]
-    /// rule using [`Predicate::LabelInGroup`] to erase every
-    /// match.
-    ///
-    /// [`LabelGroup`]: nvisy_policy::LabelGroup
-    /// [`Predicate::LabelInGroup`]: nvisy_policy::predicate::Predicate::LabelInGroup
-    /// [`Predicated`]: nvisy_policy::PolicyRule::Predicated
-    GdprArticle9,
-    /// PCI DSS §3.5.1 — render stored Primary Account Numbers
-    /// (PAN) unreadable. `render` picks between the truncation
-    /// and keyed-HMAC postures §3.5.1 permits. Targets the
-    /// elide-builtin `payment_card` label; no [`LabelGroup`]
-    /// (one label, one operator).
-    ///
-    /// [`LabelGroup`]: nvisy_policy::LabelGroup
-    PciDssPan {
-        /// Which of the §3.5.1-permitted render approaches to
-        /// apply. See [`PciPanRender`] for the tradeoff.
-        render: PciPanRender,
+    /// GDPR Article 9 special categories of personal data.
+    /// `treatment` picks between erasure (the default no-basis
+    /// posture) and pseudonymization (identity-preserving,
+    /// requires an Article 9(2) lawful-basis carve-out
+    /// established out-of-band).
+    GdprArticle9 {
+        /// Which operator to apply to Article 9 matches. See
+        /// [`GdprArticle9Treatment`] for the tradeoff.
+        treatment: GdprArticle9Treatment,
+    },
+    /// PCI DSS. `part` picks between §3.5.1 stored-PAN render
+    /// postures (with a nested [`PciPanRender`] choice) and
+    /// §3.3.1 Sensitive Authentication Data erasure.
+    PciDss {
+        /// Which DSS subsection this template addresses. See
+        /// [`PciDssPart`] for the shipped subsections.
+        part: PciDssPart,
     },
     /// CCPA "personal information" categories per Cal. Civ.
     /// Code §1798.140(v). Ships a `ccpa_personal_information`
@@ -129,8 +130,8 @@ impl PolicyTemplate {
     pub fn build(self) -> Template {
         match self {
             Self::HipaaDeidentification { method } => hipaa::template(method),
-            Self::GdprArticle9 => gdpr::template(),
-            Self::PciDssPan { render } => pci::template(render),
+            Self::GdprArticle9 { treatment } => gdpr::template(treatment),
+            Self::PciDss { part } => pci::template(part),
             Self::Ccpa => ccpa::template(),
         }
     }

--- a/crates/nvisy-template/src/template/ccpa.rs
+++ b/crates/nvisy-template/src/template/ccpa.rs
@@ -37,13 +37,15 @@ use super::Template;
 pub(crate) const GROUP_NAME: &str = "ccpa_personal_information";
 
 /// Elide-builtin labels the group covers, mapped from
-/// §1798.140(v)(1) categories. See the caveats issue for two
-/// known coverage gaps ((J) non-public education info, (K)
-/// inferences — neither has a dedicated label today).
+/// §1798.140(v)(1) categories.
 const CCPA_LABELS: &[LabelRef] = &[
-    // (A) Identifiers
+    // (A) Identifiers — includes geographic subdivisions (finer
+    // than country / state), account credentials, and dates
+    // directly related to an individual.
     LabelRef::from_static("person_name"),
     LabelRef::from_static("address"),
+    LabelRef::from_static("street_address"),
+    LabelRef::from_static("city"),
     LabelRef::from_static("postal_code"),
     LabelRef::from_static("email_address"),
     LabelRef::from_static("phone_number"),
@@ -51,18 +53,23 @@ const CCPA_LABELS: &[LabelRef] = &[
     LabelRef::from_static("mac_address"),
     LabelRef::from_static("device_id"),
     LabelRef::from_static("username"),
+    LabelRef::from_static("password"),
+    LabelRef::from_static("security_question_answer"),
     LabelRef::from_static("government_id"),
     LabelRef::from_static("national_insurance_number"),
     LabelRef::from_static("drivers_license"),
     LabelRef::from_static("passport_number"),
+    LabelRef::from_static("individual_date"),
     // (B) §1798.80 categories overlap with (A) + adds signature,
     // physical description, education/employment, financial /
-    // medical / insurance.
+    // medical / insurance. `health_narrative` catches the
+    // free-form clinical content that specific IDs miss.
     LabelRef::from_static("signature"),
     LabelRef::from_static("handwriting"),
     LabelRef::from_static("occupation"),
     LabelRef::from_static("medical_id"),
     LabelRef::from_static("insurance_id"),
+    LabelRef::from_static("health_narrative"),
     LabelRef::from_static("bank_account"),
     // (C) Protected classifications (CA/federal)
     LabelRef::from_static("ethnicity"),
@@ -70,6 +77,7 @@ const CCPA_LABELS: &[LabelRef] = &[
     LabelRef::from_static("religion"),
     LabelRef::from_static("gender"),
     LabelRef::from_static("sexual_orientation"),
+    LabelRef::from_static("sex_life"),
     LabelRef::from_static("age"),
     LabelRef::from_static("date_of_birth"),
     // (D) Commercial information
@@ -81,17 +89,26 @@ const CCPA_LABELS: &[LabelRef] = &[
     LabelRef::from_static("retina_scan"),
     LabelRef::from_static("facial_geometry"),
     LabelRef::from_static("genetic_data"),
-    // (F) Internet / network activity
+    // (F) Internet / network activity — includes CPRA §1798.140(ae)(4)
+    // communications content (mail/email/text/chat bodies).
     LabelRef::from_static("url"),
-    // (G) Geolocation data
+    LabelRef::from_static("communications_content"),
+    // (G) Geolocation data — CPRA §1798.140(ae)(2) singles out
+    // precise geolocation (≤1850 ft) as SPI; both survive erase
+    // under regular PI.
     LabelRef::from_static("coordinates"),
     LabelRef::from_static("geolocation_metadata"),
+    LabelRef::from_static("precise_geolocation"),
     // (H) Sensory (audio, visual, thermal, olfactory)
     LabelRef::from_static("face"),
     // (I) Professional / employment information
     LabelRef::from_static("certificate_number"),
     LabelRef::from_static("company_id"),
     LabelRef::from_static("department_name"),
+    // (J) Non-public education information per FERPA
+    LabelRef::from_static("education_record"),
+    // (K) Inferences drawn to build a consumer profile
+    LabelRef::from_static("inference"),
 ];
 
 const POLICY_ID: Uuid = uuid!("016806b5-bc00-7000-8000-000000000001");
@@ -174,18 +191,19 @@ mod tests {
     fn every_shipped_ccpa_category_has_at_least_one_anchor_label() {
         // Spot-check one label per shipped category so a future
         // edit dropping a whole category trips this rather than
-        // silently regressing coverage. Categories (J) and (K)
-        // aren't covered — see caveats issue.
+        // silently regressing coverage.
         for anchor in [
-            "person_name",  // (A) identifiers
-            "signature",    // (B) §1798.80
-            "ethnicity",    // (C) protected classifications
-            "payment_card", // (D) commercial info
-            "fingerprint",  // (E) biometric
-            "url",          // (F) internet/network activity
-            "coordinates",  // (G) geolocation
-            "face",         // (H) sensory
-            "occupation",   // (I) professional/employment
+            "person_name",      // (A) identifiers
+            "signature",        // (B) §1798.80
+            "ethnicity",        // (C) protected classifications
+            "payment_card",     // (D) commercial info
+            "fingerprint",      // (E) biometric
+            "url",              // (F) internet/network activity
+            "coordinates",      // (G) geolocation
+            "face",             // (H) sensory
+            "occupation",       // (I) professional/employment
+            "education_record", // (J) non-public education info
+            "inference",        // (K) inferences
         ] {
             assert!(
                 CCPA_LABELS.iter().any(|l| l.as_str() == anchor),

--- a/crates/nvisy-template/src/template/gdpr.rs
+++ b/crates/nvisy-template/src/template/gdpr.rs
@@ -5,33 +5,66 @@
 //! opinions, religious/philosophical beliefs, trade-union
 //! membership, genetic data, biometric data used to uniquely
 //! identify a person, health data, sex life, sexual orientation).
-//! The shipped template ships a single [`Predicated`] rule that
-//! erases any entity whose label falls in the
-//! `gdpr_article_9` [`LabelGroup`], leaving the caller to
-//! override with [`Pseudonymize`] where a lawful-basis carve-out
-//! (Article 9(2)) allows retention.
 //!
-//! [`LabelGroup`]: nvisy_policy::LabelGroup
+//! Article 9(2) enumerates ten lawful-basis carve-outs (explicit
+//! consent, employment law, vital interests, public interest in
+//! public health, ...) that permit processing. Callers invoking
+//! one of those carve-outs commonly need to retain the
+//! special-category data with per-entity identity preserved
+//! across mentions — pseudonymization rather than erasure.
+//!
+//! [`GdprArticle9Treatment`] picks between the two shipped
+//! postures: [`Erase`](GdprArticle9Treatment::Erase) for the
+//! default no-lawful-basis posture, and
+//! [`Pseudonymize`](GdprArticle9Treatment::Pseudonymize) for the
+//! carve-out-backed retention posture.
+//!
 //! [`Predicated`]: nvisy_policy::PolicyRule::Predicated
-//! [`Pseudonymize`]: nvisy_policy::redaction::TextRedaction::Pseudonymize
 
 use elide_core::entity::LabelRef;
 use jiff::civil::Date;
 use nvisy_policy::predicate::Predicate;
 use nvisy_policy::redaction::{ModalityRedactions, TextRedaction};
 use nvisy_policy::{LabelGroup, Labels, PolicyDefinition, PolicyRule, PredicatedRule};
+use schemars::JsonSchema;
 use semver::Version;
+use serde::{Deserialize, Serialize};
 use uuid::{Uuid, uuid};
 
 use super::Template;
 
-/// Group name every Article 9 rule references.
-pub(crate) const GROUP_NAME: &str = "gdpr_article_9";
+/// Which operator to apply to Article 9 special-category entities.
+///
+/// - [`Erase`](Self::Erase) — the default no-lawful-basis posture.
+///   Every match is removed.
+/// - [`Pseudonymize`](Self::Pseudonymize) — identity-preserving
+///   surrogate. Suitable when an Article 9(2) carve-out
+///   (explicit consent, employment law, public-health public
+///   interest, ...) authorizes retention and downstream
+///   analytics need per-entity coreference across mentions. The
+///   9(2) basis itself remains the caller's out-of-band
+///   obligation to establish and document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GdprArticle9Treatment {
+    /// Erase every match. The default posture when no Article
+    /// 9(2) carve-out applies.
+    Erase,
+    /// Pseudonymize every match (identity-preserving surrogate).
+    /// Requires an Article 9(2) lawful-basis carve-out
+    /// established out-of-band.
+    Pseudonymize,
+}
+
+/// Group name Erase's bulk rule references.
+const ERASE_GROUP: &str = "gdpr_article_9_erase";
+/// Group name Pseudonymize's bulk rule references. Separate name
+/// so audits distinguish the two postures by group id alone.
+const PSEUDONYMIZE_GROUP: &str = "gdpr_article_9_pseudonymize";
 
 /// Elide-builtin labels the group covers, mapped from Article
-/// 9(1) categories. See the caveats issue for two known
-/// coverage gaps (`nationality` conflated with racial/ethnic
-/// origin; no dedicated `sex_life` label).
+/// 9(1) categories.
 const GDPR_LABELS: &[LabelRef] = &[
     // Racial or ethnic origin
     LabelRef::from_static("ethnicity"),
@@ -49,56 +82,93 @@ const GDPR_LABELS: &[LabelRef] = &[
     LabelRef::from_static("voiceprint"),
     LabelRef::from_static("retina_scan"),
     LabelRef::from_static("facial_geometry"),
-    // Health data
+    // Health data — specific identifiers plus the broader
+    // Article 4(15) health-narrative catch-all (blood pressure,
+    // appointment notes, therapy references, care plans).
     LabelRef::from_static("medical_id"),
     LabelRef::from_static("insurance_id"),
     LabelRef::from_static("prescription_id"),
     LabelRef::from_static("diagnosis"),
     LabelRef::from_static("medication"),
-    // Sexual orientation (sex life has no dedicated label — see caveats)
+    LabelRef::from_static("health_narrative"),
+    // Sex life and sexual orientation
+    LabelRef::from_static("sex_life"),
     LabelRef::from_static("sexual_orientation"),
 ];
 
-const POLICY_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000001");
-const RULE_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000002");
+const EFFECTIVE_DATE: Date = Date::constant(2018, 5, 25);
 
-/// Build the GDPR Article 9 template.
-pub(crate) fn template() -> Template {
-    Template {
-        id: "gdpr_article_9".into(),
-        name: "GDPR Article 9 special categories".into(),
-        version: Version::new(1, 0, 0),
-        effective_date: Date::constant(2018, 5, 25),
-        description: Some(
-            "Erase the nine categories of personal data Article 9(1) treats as special.".into(),
-        ),
-        policy: policy(),
+const ERASE_POLICY_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000001");
+const ERASE_RULE_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000002");
+const PSEUDONYMIZE_POLICY_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000003");
+const PSEUDONYMIZE_RULE_ID: Uuid = uuid!("01639498-5000-7000-8000-000000000004");
+
+/// Build the GDPR Article 9 template for the picked treatment.
+pub(crate) fn template(treatment: GdprArticle9Treatment) -> Template {
+    match treatment {
+        GdprArticle9Treatment::Erase => erase_template(),
+        GdprArticle9Treatment::Pseudonymize => pseudonymize_template(),
     }
 }
 
-fn group() -> LabelGroup {
-    LabelGroup {
-        name: GROUP_NAME.into(),
+fn erase_template() -> Template {
+    Template {
+        id: "gdpr_article_9_erase".into(),
+        name: "GDPR Article 9 special categories — erase".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: EFFECTIVE_DATE,
         description: Some(
-            "The nine special categories of personal data enumerated in \
-             GDPR Article 9(1) (racial/ethnic origin, political opinions, \
-             religious/philosophical beliefs, trade-union membership, genetic \
-             data, biometric data for unique identification, health data, sex \
-             life, sexual orientation)."
-                .to_owned(),
+            "Erase the nine categories of personal data Article 9(1) treats as special.".into(),
         ),
+        policy: erase_policy(),
+    }
+}
+
+fn pseudonymize_template() -> Template {
+    Template {
+        id: "gdpr_article_9_pseudonymize".into(),
+        name: "GDPR Article 9 special categories — pseudonymize".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: EFFECTIVE_DATE,
+        description: Some(
+            "Pseudonymize the nine categories of personal data Article 9(1) treats as special. \
+             Requires an Article 9(2) lawful-basis carve-out established out-of-band."
+                .into(),
+        ),
+        policy: pseudonymize_policy(),
+    }
+}
+
+fn erase_group() -> LabelGroup {
+    LabelGroup {
+        name: ERASE_GROUP.into(),
+        description: Some(article_9_group_description().to_owned()),
         labels: GDPR_LABELS.to_vec(),
     }
 }
 
-fn policy() -> PolicyDefinition {
+fn pseudonymize_group() -> LabelGroup {
+    LabelGroup {
+        name: PSEUDONYMIZE_GROUP.into(),
+        description: Some(article_9_group_description().to_owned()),
+        labels: GDPR_LABELS.to_vec(),
+    }
+}
+
+const fn article_9_group_description() -> &'static str {
+    "The nine special categories of personal data enumerated in GDPR Article 9(1) \
+     (racial/ethnic origin, political opinions, religious/philosophical beliefs, \
+     trade-union membership, genetic data, biometric data for unique identification, \
+     health data, sex life, sexual orientation)."
+}
+
+fn erase_policy() -> PolicyDefinition {
     PolicyDefinition {
-        id: POLICY_ID,
-        name: "gdpr-article-9".into(),
+        id: ERASE_POLICY_ID,
+        name: "gdpr-article-9-erase".into(),
         description: Some(
-            "Erase every Article 9(1) special-category entity by default. \
-             Callers with an Article 9(2) lawful-basis carve-out override \
-             the operator to Pseudonymize or HmacHash on the returned rule."
+            "Erase every Article 9(1) special-category entity by default. The posture for \
+             callers without an Article 9(2) lawful-basis carve-out."
                 .to_owned(),
         ),
         when: None,
@@ -106,8 +176,30 @@ fn policy() -> PolicyDefinition {
             builtins: GDPR_LABELS.to_vec(),
             custom: Vec::new(),
         },
-        groups: vec![group()],
+        groups: vec![erase_group()],
         rules: vec![erase_rule()],
+        fallback: None,
+        retention: Vec::new(),
+    }
+}
+
+fn pseudonymize_policy() -> PolicyDefinition {
+    PolicyDefinition {
+        id: PSEUDONYMIZE_POLICY_ID,
+        name: "gdpr-article-9-pseudonymize".into(),
+        description: Some(
+            "Pseudonymize every Article 9(1) special-category entity (identity-preserving \
+             surrogate). Requires an Article 9(2) lawful-basis carve-out established \
+             out-of-band; the template does not verify or record the basis."
+                .to_owned(),
+        ),
+        when: None,
+        labels: Labels {
+            builtins: GDPR_LABELS.to_vec(),
+            custom: Vec::new(),
+        },
+        groups: vec![pseudonymize_group()],
+        rules: vec![pseudonymize_rule()],
         fallback: None,
         retention: Vec::new(),
     }
@@ -115,15 +207,32 @@ fn policy() -> PolicyDefinition {
 
 fn erase_rule() -> PolicyRule {
     PolicyRule::Predicated(Box::new(PredicatedRule {
-        id: RULE_ID,
+        id: ERASE_RULE_ID,
         name: "gdpr-article-9-erase".into(),
         description: Some(
-            "Erase any entity whose label falls in the gdpr_article_9 group.".to_owned(),
+            "Erase any entity whose label falls in the Article 9 special-category group."
+                .to_owned(),
         ),
         predicate: Predicate::LabelInGroup {
-            group: GROUP_NAME.to_owned(),
+            group: ERASE_GROUP.to_owned(),
         },
         action: ModalityRedactions::text(TextRedaction::Erase),
+    }))
+}
+
+fn pseudonymize_rule() -> PolicyRule {
+    PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: PSEUDONYMIZE_RULE_ID,
+        name: "gdpr-article-9-pseudonymize".into(),
+        description: Some(
+            "Pseudonymize any entity whose label falls in the Article 9 special-category \
+             group (identity-preserving surrogate)."
+                .to_owned(),
+        ),
+        predicate: Predicate::LabelInGroup {
+            group: PSEUDONYMIZE_GROUP.to_owned(),
+        },
+        action: ModalityRedactions::text(TextRedaction::Pseudonymize),
     }))
 }
 
@@ -144,20 +253,58 @@ mod tests {
             "genetic_data",
             "fingerprint",
             "medical_id",
+            "health_narrative",
+            "sex_life",
             "sexual_orientation",
         ] {
             assert!(
                 GDPR_LABELS.iter().any(|l| l.as_str() == anchor),
-                "expected anchor label `{anchor}` in gdpr_article_9 group",
+                "expected anchor label `{anchor}` in Article 9 group",
             );
         }
     }
 
     #[test]
+    fn erase_treatment_uses_erase_action() {
+        let PolicyRule::Predicated(rule) = &template(GdprArticle9Treatment::Erase).policy.rules[0]
+        else {
+            panic!("expected Predicated rule");
+        };
+        assert!(matches!(rule.action.text, Some(TextRedaction::Erase)));
+    }
+
+    #[test]
+    fn pseudonymize_treatment_uses_pseudonymize_action() {
+        let PolicyRule::Predicated(rule) =
+            &template(GdprArticle9Treatment::Pseudonymize).policy.rules[0]
+        else {
+            panic!("expected Predicated rule");
+        };
+        assert!(matches!(
+            rule.action.text,
+            Some(TextRedaction::Pseudonymize)
+        ));
+    }
+
+    #[test]
+    fn treatments_ship_distinct_policy_identities() {
+        let e = template(GdprArticle9Treatment::Erase);
+        let p = template(GdprArticle9Treatment::Pseudonymize);
+        assert_ne!(e.id, p.id);
+        assert_ne!(e.policy.id, p.policy.id);
+    }
+
+    #[test]
     fn template_ids_are_stable_across_calls() {
-        let a = template();
-        let b = template();
-        assert_eq!(a.policy.id, b.policy.id);
-        assert_eq!(a.policy.rules[0].id(), b.policy.rules[0].id());
+        for treatment in [
+            GdprArticle9Treatment::Erase,
+            GdprArticle9Treatment::Pseudonymize,
+        ] {
+            let a = template(treatment);
+            let b = template(treatment);
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.policy.id, b.policy.id);
+            assert_eq!(a.policy.rules[0].id(), b.policy.rules[0].id());
+        }
     }
 }

--- a/crates/nvisy-template/src/template/hipaa.rs
+++ b/crates/nvisy-template/src/template/hipaa.rs
@@ -104,11 +104,17 @@ const LDS_GROUP: &str = "hipaa_limited_data_set";
 const ED_GROUP: &str = "hipaa_expert_determination";
 
 /// Every label the Safe Harbor bulk-erase rule targets.
-/// `age`, `date_of_birth`, `date_time` are absent — the table
-/// rule owns them.
+/// `age`, `date_of_birth`, `individual_date` are absent — the
+/// table rule owns them.
 const SAFE_HARBOR_LABELS: &[LabelRef] = &[
     LabelRef::from_static("person_name"),
+    // §(B) geographic subdivisions smaller than state — every
+    // level from `address` blob down to `city` erases; `state`
+    // and `country` are permitted to survive per Safe Harbor and
+    // are deliberately absent.
     LabelRef::from_static("address"),
+    LabelRef::from_static("street_address"),
+    LabelRef::from_static("city"),
     LabelRef::from_static("postal_code"),
     LabelRef::from_static("phone_number"),
     LabelRef::from_static("fax_number"),
@@ -133,24 +139,38 @@ const SAFE_HARBOR_LABELS: &[LabelRef] = &[
     LabelRef::from_static("face"),
     LabelRef::from_static("internal_id"),
     LabelRef::from_static("case_number"),
+    // §(R) "any other unique identifying number, characteristic,
+    // or code" — the elide-builtin catch-all catches ad-hoc
+    // identifiers (badge numbers, room numbers, provider
+    // taxonomy codes) that don't map to a specific label.
+    LabelRef::from_static("unresolved"),
 ];
 
 /// Labels Safe Harbor's table rule dispatches per-operator.
 /// Kept separate from [`SAFE_HARBOR_LABELS`] so the bulk-erase
 /// rule never matches them.
+///
+/// `date_time` deliberately absent: §(C) targets dates *directly
+/// related to an individual*; generic `date_time` (invoice
+/// dates, meeting timestamps) shouldn't be generalized. Elide's
+/// `individual_date` label is the narrower fit.
 const SAFE_HARBOR_TABLE_LABELS: &[LabelRef] = &[
     LabelRef::from_static("age"),
     LabelRef::from_static("date_of_birth"),
-    LabelRef::from_static("date_time"),
+    LabelRef::from_static("individual_date"),
 ];
 
 /// Every label the Limited Data Set bulk-erase rule targets.
 /// Sixteen categories per §164.514(e)(2) — dates, ages,
 /// town/city, state, and ZIP survive (dropped from this list vs.
-/// Safe Harbor's).
+/// Safe Harbor's). Only `street_address` erases from the
+/// geographic set; if the recognizer emits the broader `address`
+/// blob rather than the fine-grained split, the LDS survivor
+/// intent is defeated for that entity — enable elide's
+/// address-split patterns to close that gap.
 const LDS_LABELS: &[LabelRef] = &[
     LabelRef::from_static("person_name"),
-    LabelRef::from_static("address"),
+    LabelRef::from_static("street_address"),
     LabelRef::from_static("phone_number"),
     LabelRef::from_static("fax_number"),
     LabelRef::from_static("email_address"),
@@ -174,6 +194,10 @@ const LDS_LABELS: &[LabelRef] = &[
     LabelRef::from_static("face"),
     LabelRef::from_static("internal_id"),
     LabelRef::from_static("case_number"),
+    // §164.514(e)(2)(xvi) "any other unique identifying number,
+    // characteristic, or code" — catch-all for ad-hoc identifiers
+    // that don't map to a specific label.
+    LabelRef::from_static("unresolved"),
 ];
 
 const SAFE_HARBOR_POLICY_ID: Uuid = uuid!("0197c348-8800-7000-8000-000000000001");
@@ -395,7 +419,7 @@ fn safe_harbor_table_rule() -> PolicyRule {
                 }),
             },
             LabelEntry {
-                label: LabelRef::from_static("date_time"),
+                label: LabelRef::from_static("individual_date"),
                 action: ModalityRedactions::text(TextRedaction::GeneralizeDate {
                     granularity: DateGranularity::Year,
                     style: DateStyle::Iso,
@@ -469,7 +493,7 @@ fn ed_table_rule() -> PolicyRule {
                 }),
             },
             LabelEntry {
-                label: LabelRef::from_static("date_time"),
+                label: LabelRef::from_static("individual_date"),
                 action: ModalityRedactions::text(TextRedaction::GeneralizeDate {
                     granularity: DateGranularity::Year,
                     style: DateStyle::Iso,
@@ -546,7 +570,7 @@ mod tests {
             age.action.text,
             Some(TextRedaction::Clamp { ceiling: Some(c), .. }) if (c - 90.0).abs() < f64::EPSILON,
         ));
-        for date_label in ["date_of_birth", "date_time"] {
+        for date_label in ["date_of_birth", "individual_date"] {
             let entry = table
                 .operators
                 .iter()
@@ -564,7 +588,13 @@ mod tests {
         // The whole point of LDS is that dates, ages, and coarse
         // geography survive. If any of these ends up in the LDS
         // erase set, the template is broken.
-        for survivor in ["age", "date_of_birth", "date_time", "postal_code"] {
+        for survivor in [
+            "age",
+            "date_of_birth",
+            "individual_date",
+            "date_time",
+            "postal_code",
+        ] {
             assert!(
                 !LDS_LABELS.iter().any(|l| l.as_str() == survivor),
                 "LDS must not erase `{survivor}` — it's a survivor per §164.514(e)(2)",

--- a/crates/nvisy-template/src/template/mod.rs
+++ b/crates/nvisy-template/src/template/mod.rs
@@ -15,8 +15,9 @@ use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
+pub use self::gdpr::GdprArticle9Treatment;
 pub use self::hipaa::HipaaDeidMethod;
-pub use self::pci::PciPanRender;
+pub use self::pci::{PciDssPart, PciPanRender};
 
 /// A regulatory posture packaged as engine-ready data.
 ///

--- a/crates/nvisy-template/src/template/pci.rs
+++ b/crates/nvisy-template/src/template/pci.rs
@@ -1,23 +1,47 @@
-//! PCI DSS §3.5.1 — render stored Primary Account Numbers (PAN)
-//! unreadable.
+//! PCI DSS — Primary Account Number (PAN) and Sensitive
+//! Authentication Data (SAV) postures.
+//!
+//! Two families ship from this module:
+//!
+//! ## §3.5.1 — render stored PAN unreadable
 //!
 //! §3.5.1 lists four acceptable render approaches: one-way hashes
 //! based on strong cryptography, truncation, index tokens with
 //! securely stored pads, and strong cryptography with associated
-//! key-management processes. This module ships two:
+//! key-management processes. This module ships four render
+//! variants covering (a) and (b):
 //!
 //! - [`PciPanRender::Truncate`] → `Truncate { keep_prefix: 6, keep_suffix: 4 }`
-//!   — the historical PCI truncation posture. No key material
-//!   involved.
+//!   — the historical PCI truncation posture. Keeps BIN and
+//!   last-four for downstream lookups. No key material involved.
+//! - [`PciPanRender::TruncateLastFour`] → `Truncate { keep_prefix: 0, keep_suffix: 4 }`
+//!   — the stricter §3.5.1.1 posture (mandatory 2025-03-31): safe
+//!   when a downstream system also stores a hashed version of the
+//!   same PAN. Loses the BIN.
 //! - [`PciPanRender::HmacSha256`] → `HmacHash { algorithm: Sha256 }`
 //!   — the "keyed cryptographic hash" posture PCI DSS v4.0.1
 //!   introduces. Requires the engine to have a `KeyProvider`
 //!   wired.
+//! - [`PciPanRender::HmacSha512`] → `HmacHash { algorithm: Sha512 }`
+//!   — same posture as `HmacSha256` with SHA-512 (§A2.1 allows
+//!   SHA-256 or better).
 //!
-//! Both target the elide-builtin `payment_card` label. No
-//! [`LabelGroup`] — one label, one rule per template. Callers
-//! wanting both dispatched from one policy compose the two
-//! [`PolicyDefinition`]s themselves.
+//! All render variants target the elide-builtin `payment_card`
+//! label. No [`LabelGroup`] — one label, one rule per template.
+//! Callers wanting more than one dispatched from one policy
+//! compose the [`PolicyDefinition`]s themselves.
+//!
+//! ## §3.3.1 — never store Sensitive Authentication Data
+//!
+//! §3.3.1 prohibits storage of SAV after authorization completes
+//! (CVV/CVC, track data, PIN blocks). Unlike PAN, the correct
+//! posture is not "render unreadable" but *erase* — SAV is never
+//! allowed to persist. [`sav_template`] ships a single-posture
+//! template targeting every elide-builtin SAV label
+//! (`card_security_code`, `card_track_data`, `pin_block`) with
+//! plain [`Erase`].
+//!
+//! [`Erase`]: nvisy_policy::redaction::TextRedaction::Erase
 //!
 //! [`LabelGroup`]: nvisy_policy::LabelGroup
 //! [`PolicyDefinition`]: nvisy_policy::PolicyDefinition
@@ -34,25 +58,49 @@ use uuid::{Uuid, uuid};
 
 use super::Template;
 
+/// Which PCI DSS subsection this template addresses.
+///
+/// - [`PanRender`](Self::PanRender) — §3.5.1 render posture for
+///   stored Primary Account Numbers. Carries a [`PciPanRender`]
+///   picking between the shipped render approaches.
+/// - [`SavErase`](Self::SavErase) — §3.3.1 prohibition on
+///   storing Sensitive Authentication Data (CVV/CVC, track data,
+///   PIN blocks) after authorization. No options — SAV has one
+///   posture: erase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "part", rename_all = "snake_case")]
+pub enum PciDssPart {
+    /// §3.5.1 PAN render posture.
+    PanRender {
+        /// Which of the §3.5.1-permitted render approaches to
+        /// apply.
+        render: PciPanRender,
+    },
+    /// §3.3.1 Sensitive Authentication Data erasure.
+    SavErase,
+}
+
 /// Which PCI DSS §3.5.1-permitted render approach to apply to
 /// stored PAN.
 ///
-/// The choice is a real operational decision, not a style knob:
+/// The truncation / hash split is a real operational decision,
+/// not a style knob:
 ///
-/// - [`Truncate`](Self::Truncate) — irreversible, no key material,
-///   nothing secret to protect. Destroys uniqueness (two PANs
-///   sharing BIN + last-4 collapse to the same string), so it's
-///   unsuitable when downstream joins or dedup need per-row
-///   identity across a PAN column.
-/// - [`HmacSha256`](Self::HmacSha256) — preserves 1:1 uniqueness
-///   (same PAN → same digest), enabling joins, dedup, and
-///   fraud-scoring on the digest. But now the tenant owns a key
-///   the engine reads via [`Engine::with_key_provider`]; a leaked
-///   key permits offline PAN enumeration against the shipped
-///   digests.
+/// - Truncation is irreversible with no key material to protect;
+///   destroys uniqueness (two PANs sharing the retained digits
+///   collapse to the same string), so unsuitable when downstream
+///   joins or dedup need per-row identity across a PAN column.
+/// - HMAC preserves 1:1 uniqueness (same PAN → same digest),
+///   enabling joins, dedup, and fraud-scoring on the digest. But
+///   the tenant owns a key the engine reads via
+///   [`Engine::with_key_provider`]; a leaked key permits offline
+///   PAN enumeration against the shipped digests.
 ///
-/// Callers wanting both dispatched from one policy compose two
-/// templates.
+/// The two axes inside truncation and inside HMAC are narrower.
+///
+/// Callers wanting more than one dispatched from one policy
+/// compose multiple templates.
 ///
 /// [`Engine::with_key_provider`]: https://docs.rs/nvisy-engine/latest/nvisy_engine/struct.Engine.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -62,104 +110,201 @@ pub enum PciPanRender {
     /// Truncate stored PAN to the first six (BIN) and last four
     /// digits.
     Truncate,
+    /// Truncate stored PAN to the last four digits only (BIN
+    /// dropped). The §3.5.1.1 posture required when a downstream
+    /// system stores a hashed version of the same PAN — see
+    /// PCI DSS v4.0.1 §3.5.1.1.
+    TruncateLastFour,
     /// Replace stored PAN with an HMAC-SHA-256 digest keyed on
     /// the engine's `KeyProvider`.
     HmacSha256,
+    /// Replace stored PAN with an HMAC-SHA-512 digest keyed on
+    /// the engine's `KeyProvider`. §A2.1 permits SHA-512 for
+    /// §3.5.1's keyed-hash posture.
+    HmacSha512,
 }
 
 /// The elide-builtin label PCI PAN templates dispatch on.
 const PAN_LABEL: LabelRef = LabelRef::from_static("payment_card");
+
+/// Elide-builtin labels PCI SAV templates dispatch on. Every
+/// category §3.3.1 prohibits from post-authorization storage:
+/// CVV/CVC (`card_security_code`), magnetic-stripe / chip
+/// contents (`card_track_data`), and PIN blocks (`pin_block`).
+const SAV_LABELS: &[LabelRef] = &[
+    LabelRef::from_static("card_security_code"),
+    LabelRef::from_static("card_track_data"),
+    LabelRef::from_static("pin_block"),
+];
 
 /// PCI DSS §3.5.1 effective date (v4.0.1 mandatory compliance).
 const EFFECTIVE_DATE: Date = Date::constant(2025, 3, 31);
 
 const TRUNCATE_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000001");
 const TRUNCATE_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000002");
-const HMAC_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000003");
-const HMAC_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000004");
+const HMAC_SHA256_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000003");
+const HMAC_SHA256_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000004");
+const TRUNCATE_LAST_FOUR_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000005");
+const TRUNCATE_LAST_FOUR_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000006");
+const HMAC_SHA512_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000007");
+const SAV_POLICY_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000009");
+const SAV_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-00000000000a");
+const HMAC_SHA512_RULE_ID: Uuid = uuid!("01958ccd-0000-7000-8000-000000000008");
+
+/// Per-render specification collapsed into the shape [`template`]
+/// uses to fill in the shared shell.
+struct RenderSpec {
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+    policy_id: Uuid,
+    policy_name: &'static str,
+    policy_description: &'static str,
+    rule: PolicyRule,
+}
+
+/// Build the PCI DSS template for the picked subsection.
+pub(crate) fn template(part: PciDssPart) -> Template {
+    match part {
+        PciDssPart::PanRender { render } => pan_template(render),
+        PciDssPart::SavErase => sav_template(),
+    }
+}
 
 /// PCI DSS §3.5.1 render template dispatched by `render`.
-pub(crate) fn template(render: PciPanRender) -> Template {
-    let (id, name, description, policy_id, policy_name, policy_description, rule) = match render {
-        PciPanRender::Truncate => (
-            "pci_dss_pan_truncate",
-            "PCI DSS §3.5.1 PAN — truncate",
-            "Render stored PAN unreadable via truncation, keeping the first six \
-             (BIN) and last four digits.",
-            TRUNCATE_POLICY_ID,
-            "pci-dss-pan-truncate",
-            "Truncate stored PAN to the first six digits and last four, dropping \
-             the middle. Keeps BIN and last-four for downstream lookups without \
-             leaving a reversible ciphertext or a key surface to protect.",
-            truncate_rule(),
-        ),
-        PciPanRender::HmacSha256 => (
-            "pci_dss_pan_hmac_sha256",
-            "PCI DSS §3.5.1 PAN — HMAC-SHA-256",
-            "Render stored PAN unreadable via a keyed HMAC-SHA-256 digest. Requires \
-             the engine to have a KeyProvider wired.",
-            HMAC_POLICY_ID,
-            "pci-dss-pan-hmac-sha256",
-            "Replace stored PAN with a keyed HMAC-SHA-256 digest. Requires the \
-             engine to have a KeyProvider wired via `Engine::with_key_provider`. \
-             The key must stay secret; a leaked key permits offline PAN enumeration \
-             against the shipped hash.",
-            hmac_rule(),
-        ),
-    };
+fn pan_template(render: PciPanRender) -> Template {
+    let spec = spec(render);
     Template {
-        id: id.into(),
-        name: name.into(),
+        id: spec.id.into(),
+        name: spec.name.into(),
         version: Version::new(1, 0, 0),
         effective_date: EFFECTIVE_DATE,
-        description: Some(description.into()),
+        description: Some(spec.description.into()),
         policy: PolicyDefinition {
-            id: policy_id,
-            name: policy_name.into(),
-            description: Some(policy_description.to_owned()),
+            id: spec.policy_id,
+            name: spec.policy_name.into(),
+            description: Some(spec.policy_description.to_owned()),
             when: None,
             labels: Labels {
                 builtins: vec![PAN_LABEL.clone()],
                 custom: Vec::new(),
             },
             groups: Vec::new(),
-            rules: vec![rule],
+            rules: vec![spec.rule],
             fallback: None,
             retention: Vec::new(),
         },
     }
 }
 
-fn truncate_rule() -> PolicyRule {
+fn spec(render: PciPanRender) -> RenderSpec {
+    match render {
+        PciPanRender::Truncate => RenderSpec {
+            id: "pci_dss_pan_truncate",
+            name: "PCI DSS §3.5.1 PAN — truncate",
+            description: "Render stored PAN unreadable via truncation, keeping the first six \
+                          (BIN) and last four digits.",
+            policy_id: TRUNCATE_POLICY_ID,
+            policy_name: "pci-dss-pan-truncate",
+            policy_description: "Truncate stored PAN to the first six digits and last four, \
+                                 dropping the middle. Keeps BIN and last-four for downstream \
+                                 lookups without leaving a reversible ciphertext or a key \
+                                 surface to protect.",
+            rule: truncate_rule(6, 4, TRUNCATE_RULE_ID, "pci-truncate-pan-bin-last-four"),
+        },
+        PciPanRender::TruncateLastFour => RenderSpec {
+            id: "pci_dss_pan_truncate_last_four",
+            name: "PCI DSS §3.5.1 PAN — truncate to last four",
+            description: "Render stored PAN unreadable via truncation to the last four digits \
+                          only. The stricter §3.5.1.1 posture (mandatory 2025-03-31) required \
+                          when a downstream system also stores a hashed version of the same PAN.",
+            policy_id: TRUNCATE_LAST_FOUR_POLICY_ID,
+            policy_name: "pci-dss-pan-truncate-last-four",
+            policy_description: "Truncate stored PAN to the last four digits, dropping BIN and \
+                                 middle. Required by PCI DSS v4.0.1 §3.5.1.1 when the same \
+                                 environment also stores a hashed version of the same PAN — \
+                                 first-six + last-four coexistence with a hash requires \
+                                 additional controls.",
+            rule: truncate_rule(
+                0,
+                4,
+                TRUNCATE_LAST_FOUR_RULE_ID,
+                "pci-truncate-pan-last-four",
+            ),
+        },
+        PciPanRender::HmacSha256 => RenderSpec {
+            id: "pci_dss_pan_hmac_sha256",
+            name: "PCI DSS §3.5.1 PAN — HMAC-SHA-256",
+            description: "Render stored PAN unreadable via a keyed HMAC-SHA-256 digest. Requires \
+                          the engine to have a KeyProvider wired.",
+            policy_id: HMAC_SHA256_POLICY_ID,
+            policy_name: "pci-dss-pan-hmac-sha256",
+            policy_description: HMAC_POLICY_DESCRIPTION,
+            rule: hmac_rule(
+                Sha2Algorithm::Sha256,
+                HMAC_SHA256_RULE_ID,
+                "pci-hmac-pan-sha256",
+                "SHA-256",
+            ),
+        },
+        PciPanRender::HmacSha512 => RenderSpec {
+            id: "pci_dss_pan_hmac_sha512",
+            name: "PCI DSS §3.5.1 PAN — HMAC-SHA-512",
+            description: "Render stored PAN unreadable via a keyed HMAC-SHA-512 digest. Requires \
+                          the engine to have a KeyProvider wired.",
+            policy_id: HMAC_SHA512_POLICY_ID,
+            policy_name: "pci-dss-pan-hmac-sha512",
+            policy_description: HMAC_POLICY_DESCRIPTION,
+            rule: hmac_rule(
+                Sha2Algorithm::Sha512,
+                HMAC_SHA512_RULE_ID,
+                "pci-hmac-pan-sha512",
+                "SHA-512",
+            ),
+        },
+    }
+}
+
+const HMAC_POLICY_DESCRIPTION: &str = "Replace stored PAN with a keyed HMAC digest. Requires the engine to have a KeyProvider \
+     wired via `Engine::with_key_provider`. The key must stay secret; a leaked key permits \
+     offline PAN enumeration against the shipped hash.";
+
+fn truncate_rule(keep_prefix: usize, keep_suffix: usize, rule_id: Uuid, name: &str) -> PolicyRule {
+    let description = if keep_prefix == 0 {
+        format!("Drop everything but the last {keep_suffix} digits of every payment_card value.",)
+    } else {
+        format!(
+            "Drop the middle of every payment_card value, keeping the first {keep_prefix} \
+             (BIN) and last {keep_suffix} digits.",
+        )
+    };
     PolicyRule::Predicated(Box::new(PredicatedRule {
-        id: TRUNCATE_RULE_ID,
-        name: "pci-truncate-pan".into(),
-        description: Some(
-            "Drop the middle of every payment_card value, keeping the first six \
-             (BIN) and last four digits."
-                .to_owned(),
-        ),
+        id: rule_id,
+        name: name.into(),
+        description: Some(description),
         predicate: single_label(PAN_LABEL.clone()),
         action: ModalityRedactions::text(TextRedaction::Truncate {
-            keep_prefix: 6,
-            keep_suffix: 4,
+            keep_prefix,
+            keep_suffix,
         }),
     }))
 }
 
-fn hmac_rule() -> PolicyRule {
+fn hmac_rule(
+    algorithm: Sha2Algorithm,
+    rule_id: Uuid,
+    name: &str,
+    algorithm_label: &str,
+) -> PolicyRule {
     PolicyRule::Predicated(Box::new(PredicatedRule {
-        id: HMAC_RULE_ID,
-        name: "pci-hmac-pan".into(),
-        description: Some(
-            "Replace every payment_card value with an HMAC-SHA-256 digest keyed on \
-             the engine's KeyProvider."
-                .to_owned(),
-        ),
+        id: rule_id,
+        name: name.into(),
+        description: Some(format!(
+            "Replace every payment_card value with an HMAC-{algorithm_label} digest keyed on \
+             the engine's KeyProvider.",
+        )),
         predicate: single_label(PAN_LABEL.clone()),
-        action: ModalityRedactions::text(TextRedaction::HmacHash {
-            algorithm: Sha2Algorithm::Sha256,
-        }),
+        action: ModalityRedactions::text(TextRedaction::HmacHash { algorithm }),
     }))
 }
 
@@ -169,19 +314,77 @@ fn single_label(label: LabelRef) -> Predicate {
     }
 }
 
+/// PCI DSS §3.3.1 — erase stored Sensitive Authentication Data
+/// (SAV). Covers all three §3.3.1 categories: CVV/CVC
+/// (`card_security_code`), magnetic-stripe / chip track data
+/// (`card_track_data`), and PIN blocks (`pin_block`).
+fn sav_template() -> Template {
+    Template {
+        id: "pci_dss_sav_erase".into(),
+        name: "PCI DSS §3.3.1 SAV — erase".into(),
+        version: Version::new(1, 0, 0),
+        effective_date: EFFECTIVE_DATE,
+        description: Some(
+            "Erase Sensitive Authentication Data (CVV/CVC, track data, PIN blocks). \
+             §3.3.1 prohibits storing SAV after authorization — the correct posture is \
+             erasure, not render-unreadable."
+                .into(),
+        ),
+        policy: PolicyDefinition {
+            id: SAV_POLICY_ID,
+            name: "pci-dss-sav-erase".into(),
+            description: Some(
+                "Erase every SAV entity — CVV/CVC, magnetic-stripe/chip track data, \
+                 and PIN blocks. PCI DSS §3.3.1 forbids SAV storage after \
+                 authorization completes; unlike PAN, SAV has no render-unreadable \
+                 posture — it must be erased."
+                    .to_owned(),
+            ),
+            when: None,
+            labels: Labels {
+                builtins: SAV_LABELS.to_vec(),
+                custom: Vec::new(),
+            },
+            groups: Vec::new(),
+            rules: vec![sav_rule()],
+            fallback: None,
+            retention: Vec::new(),
+        },
+    }
+}
+
+fn sav_rule() -> PolicyRule {
+    PolicyRule::Predicated(Box::new(PredicatedRule {
+        id: SAV_RULE_ID,
+        name: "pci-sav-erase".into(),
+        description: Some("Erase every SAV entity (CVV/CVC, track data, PIN blocks).".to_owned()),
+        predicate: Predicate::LabelOneOf {
+            labels: SAV_LABELS.to_vec(),
+        },
+        action: ModalityRedactions::text(TextRedaction::Erase),
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const ALL: &[PciPanRender] = &[
+        PciPanRender::Truncate,
+        PciPanRender::TruncateLastFour,
+        PciPanRender::HmacSha256,
+        PciPanRender::HmacSha512,
+    ];
+
     #[test]
-    fn both_renders_target_payment_card_label() {
-        for render in [PciPanRender::Truncate, PciPanRender::HmacSha256] {
-            let t = template(render);
+    fn every_render_targets_payment_card_label() {
+        for render in ALL {
+            let t = pan_template(*render);
             let PolicyRule::Predicated(rule) = &t.policy.rules[0] else {
-                panic!("expected Predicated rule");
+                panic!("expected Predicated rule for {render:?}");
             };
             let Predicate::LabelOneOf { labels } = &rule.predicate else {
-                panic!("expected LabelOneOf predicate");
+                panic!("expected LabelOneOf predicate for {render:?}");
             };
             assert_eq!(labels.len(), 1);
             assert_eq!(labels[0], PAN_LABEL);
@@ -189,18 +392,102 @@ mod tests {
     }
 
     #[test]
+    fn truncate_last_four_drops_the_bin() {
+        let PolicyRule::Predicated(rule) =
+            &pan_template(PciPanRender::TruncateLastFour).policy.rules[0]
+        else {
+            panic!("expected Predicated rule");
+        };
+        let TextRedaction::Truncate {
+            keep_prefix,
+            keep_suffix,
+        } = rule.action.text.as_ref().unwrap()
+        else {
+            panic!("expected Truncate action");
+        };
+        assert_eq!(*keep_prefix, 0, "TruncateLastFour must drop BIN");
+        assert_eq!(*keep_suffix, 4);
+    }
+
+    #[test]
+    fn hmac_sha512_uses_sha512_algorithm() {
+        let PolicyRule::Predicated(rule) = &pan_template(PciPanRender::HmacSha512).policy.rules[0]
+        else {
+            panic!("expected Predicated rule");
+        };
+        let TextRedaction::HmacHash { algorithm } = rule.action.text.as_ref().unwrap() else {
+            panic!("expected HmacHash action");
+        };
+        assert_eq!(*algorithm, Sha2Algorithm::Sha512);
+    }
+
+    #[test]
+    fn every_render_ships_a_distinct_policy_identity() {
+        // Distinct template ids and policy ids across all four —
+        // audits key on these to tell the postures apart, and
+        // `TemplateCatalog::builtin()` inserts by (id, version)
+        // so any collision silently drops one.
+        let mut ids = std::collections::HashSet::new();
+        let mut policy_ids = std::collections::HashSet::new();
+        for render in ALL {
+            let t = pan_template(*render);
+            assert!(
+                ids.insert(t.id.clone()),
+                "duplicate template id for {render:?}: {}",
+                t.id,
+            );
+            assert!(
+                policy_ids.insert(t.policy.id),
+                "duplicate policy id for {render:?}: {}",
+                t.policy.id,
+            );
+        }
+    }
+
+    #[test]
     fn template_ids_are_stable_across_calls() {
-        let trunc_a = template(PciPanRender::Truncate);
-        let trunc_b = template(PciPanRender::Truncate);
-        assert_eq!(trunc_a.policy.id, trunc_b.policy.id);
-        assert_eq!(trunc_a.policy.rules[0].id(), trunc_b.policy.rules[0].id());
-        let hmac_a = template(PciPanRender::HmacSha256);
-        let hmac_b = template(PciPanRender::HmacSha256);
-        assert_eq!(hmac_a.policy.id, hmac_b.policy.id);
-        assert_eq!(hmac_a.policy.rules[0].id(), hmac_b.policy.rules[0].id());
-        assert_ne!(
-            trunc_a.policy.id, hmac_a.policy.id,
-            "the two PCI renders must ship distinct policy identities",
-        );
+        for render in ALL {
+            let a = pan_template(*render);
+            let b = pan_template(*render);
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.policy.id, b.policy.id);
+            assert_eq!(a.policy.rules[0].id(), b.policy.rules[0].id());
+        }
+    }
+
+    #[test]
+    fn sav_template_erases_every_sav_label() {
+        let t = sav_template();
+        let PolicyRule::Predicated(rule) = &t.policy.rules[0] else {
+            panic!("expected Predicated rule");
+        };
+        let Predicate::LabelOneOf { labels } = &rule.predicate else {
+            panic!("expected LabelOneOf predicate");
+        };
+        // Every §3.3.1 SAV label must be in the rule's predicate.
+        for expected in SAV_LABELS {
+            assert!(
+                labels.contains(expected),
+                "SAV rule missing label `{}`",
+                expected.as_str(),
+            );
+        }
+        assert!(matches!(rule.action.text, Some(TextRedaction::Erase)));
+    }
+
+    #[test]
+    fn sav_and_pan_ship_distinct_identities() {
+        // The SAV template must not collide with any PAN render on
+        // template id or policy id — different regulatory subsection
+        // (§3.3.1 vs §3.5.1), different label, different posture.
+        let sav = sav_template();
+        for render in ALL {
+            let pan = pan_template(*render);
+            assert_ne!(sav.id, pan.id, "sav vs pan template id collision");
+            assert_ne!(
+                sav.policy.id, pan.policy.id,
+                "sav vs pan policy id collision"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Three coordinated changes on \`PolicyTemplate\` shape + one label-catalog adoption pass:

1. **PCI DSS refactor.** Collapse \`PciDssPan { render }\` under \`PciDss { part: PciDssPart }\` where \`PciDssPart\` picks between \`PanRender { render: PciPanRender }\` (§3.5.1) and \`SavErase\` (§3.3.1). Two new PAN renders shipped:
   - \`PciPanRender::TruncateLastFour\` — the stricter §3.5.1.1 posture (mandatory 2025-03-31 when a hash of the same PAN coexists in the environment).
   - \`PciPanRender::HmacSha512\` — §A2.1 permits SHA-512 alongside SHA-256.

   SAV posture covers all three §3.3.1 categories: CVV/CVC (\`card_security_code\`), magnetic-stripe track data (\`card_track_data\`), PIN blocks (\`pin_block\`).

2. **GDPR.** \`GdprArticle9 { treatment: Erase | Pseudonymize }\` for the Article 9(2) lawful-basis carve-out case. Label list adopts \`health_narrative\` and \`sex_life\`.

3. **HIPAA.** Label lists adopt geographic-granularity splits and switch the table-rule date dispatch to the narrower \`individual_date\` label (closes §(C) scope-creep gap tracked in #362). Safe Harbor and Expert Determination table rules dispatch \`individual_date\`; Limited Data Set switches from the \`address\` blob to \`street_address\` so town/city/state/ZIP survive when the recognizer emits the fine-grained labels.

4. **CCPA label adoption.** All newly-available labels wired in: \`street_address\`, \`city\`, \`password\`, \`security_question_answer\`, \`individual_date\`, \`health_narrative\`, \`sex_life\`, \`communications_content\`, \`precise_geolocation\`, \`education_record\`, \`inference\`. §(J) non-public education info and §(K) inferences are now covered.

Also bumps elide upstream to \`e0b4ed85\` (nvisycom/elide#177 — the label-catalog PR that shipped every label above) and migrates \`Regex::with_label\` / \`Dictionary::with_label\` to the new multi-candidate \`with_labels(Vec<LabelRef>)\` API at the two custom-recognizer call sites.

## Follows up on

Closes multiple deviations tracked in #362 (HIPAA), #363 (GDPR), #364 (PCI), #365 (CCPA) — issue bodies updated in this PR's turn to reflect what's now resolved vs. still open.

Wire form breaks vs. previous shape (\`GdprArticle9\` was unit; \`PciDssPan\` was a top-level variant) — no external consumer deserializes \`PolicyTemplate\` today, so the break is free.

## Test plan

- [x] \`cargo test --workspace --all-features\` (30 unit tests + 10 engine integration tests pass)
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS=\"-D warnings -D rustdoc::broken-intra-doc-links\" cargo doc --workspace --all-features --no-deps\`
- [x] \`cargo +nightly fmt --all --check\`
- [x] \`cargo machete\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)