### PR TITLE
Make RegisteredRecognizer owned

### DIFF
--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -250,7 +250,7 @@ impl Engine {
     /// name, optional description, and provider slug; connection
     /// details and (future) credentials stay in the private
     /// [`NerConfig`].
-    pub fn ner_recognizers(&self) -> impl ExactSizeIterator<Item = RegisteredRecognizer<'_>> {
+    pub fn ner_recognizers(&self) -> impl ExactSizeIterator<Item = RegisteredRecognizer> {
         self.ner.recognizers.iter().map(Into::into)
     }
 
@@ -260,7 +260,7 @@ impl Engine {
     /// Same shape as [`ner_recognizers`], for the LLM lineup.
     ///
     /// [`ner_recognizers`]: Self::ner_recognizers
-    pub fn llm_recognizers(&self) -> impl ExactSizeIterator<Item = RegisteredRecognizer<'_>> {
+    pub fn llm_recognizers(&self) -> impl ExactSizeIterator<Item = RegisteredRecognizer> {
         self.llm.recognizers.iter().map(Into::into)
     }
 

--- a/crates/nvisy-engine/src/pipeline/registered.rs
+++ b/crates/nvisy-engine/src/pipeline/registered.rs
@@ -6,6 +6,7 @@
 //! callers can list what's registered without seeing backend
 //! connection details or (future) credentials.
 
+use hipstr::HipStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -19,35 +20,42 @@ use crate::provider::ner::NerRecognizer;
 /// human-readable description, and a provider slug identifying
 /// the backend kind. Connection details and (future)
 /// credentials stay in the private `NerConfig` / `LlmConfig`.
+///
+/// Owned rather than borrowing from the engine so callers can
+/// carry the value past the borrow that produced it. Cloning is
+/// cheap — [`HipStr`] shares the backing string via an `Arc`
+/// header.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct RegisteredRecognizer<'a> {
+pub struct RegisteredRecognizer {
     /// Recognizer name — the identifier a request's allowlist
     /// picks by.
-    pub name: &'a str,
+    #[schemars(with = "String")]
+    pub name: HipStr<'static>,
     /// Optional human-readable description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    #[schemars(with = "Option<String>")]
+    pub description: Option<HipStr<'static>>,
     /// Provider slug. NER: `"bento"`, `"mock"`. LLM: `"openai"`,
     /// `"anthropic"`, `"gemini"`, `"ollama"`, `"mock"`.
     pub provider: &'static str,
 }
 
-impl<'a> From<&'a NerRecognizer> for RegisteredRecognizer<'a> {
-    fn from(r: &'a NerRecognizer) -> Self {
+impl From<&NerRecognizer> for RegisteredRecognizer {
+    fn from(r: &NerRecognizer) -> Self {
         Self {
-            name: &r.name,
-            description: r.description.as_deref(),
+            name: r.name.clone(),
+            description: r.description.clone(),
             provider: r.backend.provider(),
         }
     }
 }
 
-impl<'a> From<&'a LlmRecognizer> for RegisteredRecognizer<'a> {
-    fn from(r: &'a LlmRecognizer) -> Self {
+impl From<&LlmRecognizer> for RegisteredRecognizer {
+    fn from(r: &LlmRecognizer) -> Self {
         Self {
-            name: &r.name,
-            description: r.description.as_deref(),
+            name: r.name.clone(),
+            description: r.description.clone(),
             provider: r.source.provider(),
         }
     }

--- a/crates/nvisy-engine/src/provider/llm/recognizer.rs
+++ b/crates/nvisy-engine/src/provider/llm/recognizer.rs
@@ -22,7 +22,8 @@ pub struct LlmRecognizer {
     /// trail so audits can attribute detections to a specific
     /// configured recognizer. Must be unique across the
     /// deployment's LLM lineup.
-    pub name: String,
+    #[schemars(with = "String")]
+    pub name: HipStr<'static>,
     /// Optional human-readable description. Surfaces on the
     /// list-recognizers accessor so operators and SDK callers
     /// can identify what each recognizer is for.

--- a/crates/nvisy-engine/src/provider/ner/recognizer.rs
+++ b/crates/nvisy-engine/src/provider/ner/recognizer.rs
@@ -17,7 +17,8 @@ pub struct NerRecognizer {
     /// trail so audits can attribute detections to a specific
     /// configured recognizer. Must be unique across the
     /// deployment's NER lineup.
-    pub name: String,
+    #[schemars(with = "String")]
+    pub name: HipStr<'static>,
     /// Optional human-readable description. Surfaces on the
     /// list-recognizers accessor so operators and SDK callers
     /// can identify what each recognizer is for.


### PR DESCRIPTION
## Summary

\`RegisteredRecognizer<'a>\` borrowed \`name\` and \`description\` from the parent \`NerRecognizer\` / \`LlmRecognizer\` inside the engine. Callers that need to carry the value past the borrow that produced it (e.g. across an await point on a service that only holds an \`&Engine\`) couldn't.

Drops the lifetime and stores the two string fields as \`HipStr<'static>\` — cheap-cloneable via the shared-Arc header, matching the migration we did earlier for policy-schema \`description\` fields. The \`provider: &'static str\` slug stays static.

Also widens \`NerRecognizer.name\` and \`LlmRecognizer.name\` from \`String\` to \`HipStr<'static>\` so the projection is a cheap clone and matches the shape of the other schema \`name\` fields.

## Test plan

- [x] \`cargo test --workspace --all-features\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS=\"--cfg docsrs -D warnings\" cargo +nightly doc --workspace --no-deps --all-features\`
- [x] \`cargo +nightly fmt --all --check\`
- [x] \`cargo machete\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)