### PR TITLE
Sweep stale entries in README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Rust crates (`crates/`)
 
-- **nvisy-context:** wire schema for reference-data collections.
 - **nvisy-policy:** wire schema for redaction governance (rules,
   predicates, operators).
-- **nvisy-schema:** umbrella re-exporting `nvisy-context` +
-  `nvisy-policy` alongside `plan` and `file`. Consumed by SDKs on
-  both sides of the HTTP boundary.
-- **nvisy-core:** deployment-side runtime configuration (NER and LLM
-  recognizer lineups, error vocabulary).
+- **nvisy-schema:** umbrella re-exporting `nvisy-policy` alongside
+  `plan` and `file`. Consumed by SDKs on both sides of the HTTP
+  boundary.
+- **nvisy-template:** ready-to-run policy templates for common
+  regulatory postures (HIPAA §164.514, GDPR Article 9, PCI DSS,
+  CCPA / CPRA).
 - **nvisy-engine:** stateless pipeline: decode, analyze, apply. Wraps
-  elide and hosts the per-modality orchestrator.
+  elide and hosts the per-modality orchestrator plus the
+  deployment-side NER / LLM recognizer configuration.
 - **elide-bento:** BentoML-hosted NER and OCR client implementing
   elide's recognizer traits.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **nvisy-context:** wire schema for reference-data collections.
 - **nvisy-policy:** wire schema for redaction governance (rules,
-  predicates, retention, audit).
+  predicates, operators).
 - **nvisy-schema:** umbrella re-exporting `nvisy-context` +
   `nvisy-policy` alongside `plan` and `file`. Consumed by SDKs on
   both sides of the HTTP boundary.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pipeline) embed the engine directly.
 
 - **[nvisy-policy](crates/nvisy-policy/)**: wire schema for redaction governance (rules, predicates, operators)
 - **[nvisy-schema](crates/nvisy-schema/)**: wire schema for plan, file, and the `elide-core` slice; re-exports `nvisy-policy`
+- **[nvisy-template](crates/nvisy-template/)**: ready-to-run policy templates for common regulatory postures (HIPAA, GDPR, PCI DSS, CCPA)
 - **[nvisy-engine](crates/nvisy-engine/)**: stateless pipeline (decode, analyze, apply) wrapping elide, hosting the per-modality orchestrator and the deployment-side NER / LLM recognizer configuration
 - **[elide-bento](crates/elide-bento/)**: BentoML-hosted NER and OCR client implementing elide's recognizer traits
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Rust crates ([`crates/`](crates/)) — library only, no long-running
 process. Hosts (a SaaS backend, a Tauri app, a language SDK, a custom
 pipeline) embed the engine directly.
 
-- **[nvisy-policy](crates/nvisy-policy/)**: wire schema for redaction governance (rules, predicates, retention, audit)
+- **[nvisy-policy](crates/nvisy-policy/)**: wire schema for redaction governance (rules, predicates, operators)
 - **[nvisy-schema](crates/nvisy-schema/)**: wire schema for plan, file, and the `elide-core` slice; re-exports `nvisy-policy`
 - **[nvisy-engine](crates/nvisy-engine/)**: stateless pipeline (decode, analyze, apply) wrapping elide, hosting the per-modality orchestrator and the deployment-side NER / LLM recognizer configuration
 - **[elide-bento](crates/elide-bento/)**: BentoML-hosted NER and OCR client implementing elide's recognizer traits


### PR DESCRIPTION
Two housekeeping fixes to authoritative documents new readers hit first:

1. **Drop retention** (follow-up to #382). The top-level README and CHANGELOG still advertised retention as a shipped nvisy-policy feature.

2. **Mention \`nvisy-template\`** and remove two ghost entries. Both docs listed \`nvisy-context\` and \`nvisy-core\` (Rust) — neither crate exists any more. Adds the \`nvisy-template\` crate we've been actively shipping into. Rewrites the \`nvisy-engine\` CHANGELOG blurb to include the NER/LLM lineup responsibility that used to live in \`nvisy-core\`.

The crate has never been published, so editing the CHANGELOG in place is honest — nobody's holding an old release that shipped retention or \`nvisy-context\`.

Three remaining \`retention\` mentions in \`gdpr.rs\`/\`ccpa.rs\` are genuine English uses (Article 9(2) \"authorizes retention\", §1798.145 \"retention exception\") and stay as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)