### PR TITLE
Add per-request AnalyzerParams.ocr_mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "elide-core",
  "futures",
@@ -1035,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "elide-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "elide-operator"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/nvisy-engine/Cargo.toml
+++ b/crates/nvisy-engine/Cargo.toml
@@ -99,6 +99,7 @@ elide-bento = { workspace = true, features = ["ner", "ocr"] }
 
 # Internal crates
 nvisy-schema = { workspace = true, features = [] }
+nvisy-template = { workspace = true }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }
@@ -114,7 +115,6 @@ hipstr = { workspace = true, features = ["serde"] }
 [dev-dependencies]
 # Internal crates
 nvisy-engine = { path = ".", features = ["test-utils", "audit-json", "audit-csv"] }
-nvisy-template = { workspace = true }
 
 # Serialization
 serde_json = { workspace = true, features = [] }

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -50,6 +50,7 @@ pub use elide::codec::FormatRegistry;
 #[doc(inline)]
 pub use elide::redaction::operators::{KeyProvider, StaticKey};
 #[doc(inline)]
+pub use elide_core::primitive::OcrMode;
 pub use elide_core::{Error, ErrorKind, Result};
 #[doc(inline)]
 pub use nvisy_schema::file::{Document, FileMetadata};

--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -25,11 +25,12 @@
 //!   the request's asserted scope and correlation id.
 //!
 //! Ready-to-run policy sets for common regulatory postures
-//! (HIPAA Safe Harbor, GDPR Article 9, PCI DSS §3.5.1, CCPA)
-//! live in the sibling `nvisy-template` crate. Each template
-//! carries a single `PolicyDefinition` (with inline
-//! [`LabelGroup`]s) that a caller hands to [`Engine::analyze`] /
-//! [`Engine::anonymize`] as a one-element slice.
+//! (HIPAA §164.514, GDPR Article 9, PCI DSS, CCPA / CPRA)
+//! live in the sibling `nvisy-template` crate, re-exported here
+//! as [`template`]. Each template carries a single
+//! `PolicyDefinition` (with inline [`LabelGroup`]s) that a caller
+//! hands to [`Engine::analyze`] / [`Engine::anonymize`] as a
+//! one-element slice.
 //!
 //! [`LabelGroup`]: nvisy_schema::policy::LabelGroup
 //! [`PolicyDefinition::groups`]: nvisy_schema::policy::PolicyDefinition::groups
@@ -58,6 +59,10 @@ pub use nvisy_schema::file::{Document, FileMetadata};
 /// operators.
 #[doc(inline)]
 pub use nvisy_schema::policy;
+/// Ready-to-run policy templates for common regulatory postures
+/// (HIPAA §164.514, GDPR Article 9, PCI DSS, CCPA / CPRA).
+#[doc(inline)]
+pub use nvisy_template as template;
 
 pub use self::analyzer::PatternGuardrails;
 pub use self::entity::EntityGroup;

--- a/crates/nvisy-engine/src/pipeline/audit.rs
+++ b/crates/nvisy-engine/src/pipeline/audit.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use elide::recognition::ScopeMetadata;
-use elide_core::primitive::{CountryCode, Languages};
+use elide_core::primitive::{CountryCode, Languages, OcrMode};
 #[cfg(feature = "audit-json")]
 use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::plan::scope_metadata_is_empty;
@@ -137,6 +137,14 @@ pub struct AuditContext {
     ///
     /// [`Document`]: nvisy_schema::file::Document
     pub correlation_id: Uuid,
+    /// OCR mode the analyze call decoded with. Recorded so the
+    /// anonymize call re-decodes the same document under the same
+    /// codec configuration — otherwise entity offsets stored in
+    /// the audit wouldn't line up against a differently-rendered
+    /// second decode. Defaults to [`OcrMode::Auto`] (the codec's
+    /// built-in behaviour) when omitted.
+    #[serde(default)]
+    pub ocr_mode: OcrMode,
 }
 
 #[cfg(feature = "audit-json")]

--- a/crates/nvisy-engine/src/pipeline/mod.rs
+++ b/crates/nvisy-engine/src/pipeline/mod.rs
@@ -91,6 +91,7 @@ use elide_core::modality::image::Image;
 #[cfg(feature = "internal_tabular")]
 use elide_core::modality::tabular::Tabular;
 use elide_core::modality::text::Text;
+use elide_core::primitive::OcrMode;
 use elide_core::{Error, ErrorKind, Result};
 use nvisy_schema::file::Document;
 use nvisy_schema::plan::AnalyzerParams;
@@ -321,7 +322,7 @@ impl Engine {
     ) -> Result<Audit> {
         let correlation_id = document.correlation_id;
         let extension = document.extension.clone();
-        let mut handle = self.decode(document).await?;
+        let mut handle = self.decode(document, spec.ocr_mode).await?;
         let (orchestrator, context) =
             self.build_analyze_orchestrator(spec, policies, correlation_id)?;
         let directives = build_analyze_directives(spec);
@@ -454,7 +455,7 @@ impl Engine {
         let correlation_id = document.correlation_id;
         let extension = document.extension.clone();
         let content_type = document.content_type.clone();
-        let mut handle = self.decode(document).await?;
+        let mut handle = self.decode(document, audit.context.ocr_mode).await?;
 
         let mut report = body_group.insert_into_body(Report::new());
         let mut overrides: Vec<OverrideEntry> = Vec::new();
@@ -488,19 +489,55 @@ impl Engine {
         })
     }
 
-    async fn decode(&self, document: Document) -> Result<UntypedDocumentHandle> {
+    async fn decode(&self, document: Document, ocr_mode: OcrMode) -> Result<UntypedDocumentHandle> {
         let Document {
             bytes, extension, ..
         } = document;
-        self.formats
-            .decode(bytes, extension.as_str())
-            .await
-            .map_err(|err| {
-                Error::new(
-                    ErrorKind::MalformedInput,
-                    format!("codec decode failed for extension {extension:?}: {err}"),
-                )
-            })
+        let result = match ocr_mode {
+            OcrMode::Auto => self.formats.decode(bytes, extension.as_str()).await,
+            _ => {
+                self.decode_with_ocr_mode(bytes, extension.as_str(), ocr_mode)
+                    .await
+            }
+        };
+        result.map_err(|err| {
+            Error::new(
+                ErrorKind::MalformedInput,
+                format!("codec decode failed for extension {extension:?}: {err}"),
+            )
+        })
+    }
+
+    /// Slow-path decode for requests overriding the default OCR
+    /// mode. Rebuilds a [`FormatRegistry`] with the PDF handler
+    /// replaced by one wired to `ocr_mode`; other codecs come
+    /// from the built-in set. Callers pay one registry build per
+    /// non-default request — trivial next to the OCR render
+    /// itself (`Force { dpi }` pages the whole document at the
+    /// chosen DPI), but not free, so the default path skips it.
+    #[cfg(feature = "codec-pdf-render")]
+    async fn decode_with_ocr_mode(
+        &self,
+        bytes: bytes::Bytes,
+        extension: &str,
+        ocr_mode: OcrMode,
+    ) -> std::result::Result<UntypedDocumentHandle, elide_core::Error> {
+        use elide::codec::handler::pdf_format_with;
+        let registry =
+            FormatRegistry::with_builtin().with_replaced_format(pdf_format_with(ocr_mode));
+        registry.decode(bytes, extension).await
+    }
+
+    /// Fallback when the render feature is off: any non-default
+    /// mode falls through to the shared registry.
+    #[cfg(not(feature = "codec-pdf-render"))]
+    async fn decode_with_ocr_mode(
+        &self,
+        bytes: bytes::Bytes,
+        extension: &str,
+        _ocr_mode: OcrMode,
+    ) -> std::result::Result<UntypedDocumentHandle, elide_core::Error> {
+        self.formats.decode(bytes, extension).await
     }
 }
 

--- a/crates/nvisy-engine/src/pipeline/orchestrator.rs
+++ b/crates/nvisy-engine/src/pipeline/orchestrator.rs
@@ -101,6 +101,7 @@ impl Engine {
             countries: spec.scope.countries.clone(),
             metadata: spec.scope.metadata.clone(),
             correlation_id,
+            ocr_mode: spec.ocr_mode,
         };
         let live_scope = build_scope(&context, catalog.clone(), correlation_id);
 

--- a/crates/nvisy-engine/tests/audit.rs
+++ b/crates/nvisy-engine/tests/audit.rs
@@ -47,6 +47,7 @@ fn default_spec() -> AnalyzerParams {
         deduplication: Default::default(),
         scope: ScopeParams::default(),
         annotations: Default::default(),
+        ocr_mode: Default::default(),
     }
 }
 

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -53,6 +53,7 @@ fn default_spec() -> AnalyzerParams {
         deduplication: Default::default(),
         scope: ScopeParams::default(),
         annotations: Default::default(),
+        ocr_mode: Default::default(),
     }
 }
 

--- a/crates/nvisy-engine/tests/multimodal.rs
+++ b/crates/nvisy-engine/tests/multimodal.rs
@@ -304,6 +304,7 @@ async fn empty_analyzed_document_anonymize_fails_validation() {
             countries: Vec::new(),
             metadata: Default::default(),
             correlation_id: uuid::Uuid::now_v7(),
+            ocr_mode: Default::default(),
         },
     };
     let outcome = engine.anonymize(raw_docx(), &[], &mut audit).await;

--- a/crates/nvisy-engine/tests/policy_shapes.rs
+++ b/crates/nvisy-engine/tests/policy_shapes.rs
@@ -46,6 +46,7 @@ fn default_spec() -> AnalyzerParams {
         deduplication: Default::default(),
         scope: ScopeParams::default(),
         annotations: Default::default(),
+        ocr_mode: Default::default(),
     }
 }
 

--- a/crates/nvisy-engine/tests/templates.rs
+++ b/crates/nvisy-engine/tests/templates.rs
@@ -52,6 +52,7 @@ fn default_spec() -> AnalyzerParams {
         deduplication: Default::default(),
         scope: ScopeParams::default(),
         annotations: Default::default(),
+        ocr_mode: Default::default(),
     }
 }
 

--- a/crates/nvisy-schema/src/plan/analyzer.rs
+++ b/crates/nvisy-schema/src/plan/analyzer.rs
@@ -1,6 +1,6 @@
 //! Top-level analyzer params.
 
-use elide_core::primitive::{CountryCode, Languages};
+use elide_core::primitive::{CountryCode, Languages, OcrMode};
 use elide_core::recognition::ScopeMetadata;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -60,6 +60,18 @@ pub struct AnalyzerParams {
     /// slot to the modality's pipeline at compile time.
     #[serde(default)]
     pub annotations: AnyAnnotations,
+    /// How container formats that carry both a text layer and
+    /// page images (PDF today; DOCX, EPUB, TIFF as elide widens
+    /// coverage) treat OCR. See [`OcrMode`] for the three states.
+    ///
+    /// The default [`OcrMode::Auto`] matches the codec's built-in
+    /// behaviour — extract the text layer where present, render
+    /// missing pages for OCR. `Force { dpi }` rasterises every
+    /// page (real CPU / memory cost; opt-in when scanned pages
+    /// need OCR even alongside a text layer). `Never` skips
+    /// rendering entirely.
+    #[serde(default)]
+    pub ocr_mode: OcrMode,
 }
 
 /// Caller-asserted scope for one request.

--- a/crates/nvisy-schema/src/primitive.rs
+++ b/crates/nvisy-schema/src/primitive.rs
@@ -9,6 +9,6 @@
 
 pub use elide_core::primitive::{
     BoundingBox, Color, Confidence, ConfidenceThreshold, CountryCode, Dimensions, Dpi, Language,
-    LanguageProvenance, LanguageSpan, LanguageTag, Languages, PixelRegion, Point, Polygon,
+    LanguageProvenance, LanguageSpan, LanguageTag, Languages, OcrMode, PixelRegion, Point, Polygon,
     TimeSpan, UnitBoundingBox,
 };


### PR DESCRIPTION
## Summary

Callers can now pass an \`OcrMode\` on \`AnalyzerParams\` to override the codec's default text-layer-plus-render behaviour per request. Concretely, sending

\`\`\`json
{ \"ocrMode\": { \"kind\": \"force\", \"dpi\": 300 } }
\`\`\`

rasterises every page of a PDF and OCRs it, even where a text layer is present — the posture scanned-PDF workflows need. Also carries \`{\"kind\": \"never\"}\` for text-only, and \`{\"kind\": \"auto\"}\` (default) for the codec's built-in behaviour.

The mode is recorded on \`AuditContext\` so \`anonymize\` re-decodes the same document under the same codec configuration — otherwise entity offsets stored in the audit wouldn't line up against a differently-rendered second decode.

Bumps elide upstream (nvisycom/elide#178) which made \`OcrMode\` serialisable and moved it next to \`Dpi\` in \`elide-core::primitive\`.

## Wiring

- \`AnalyzerParams.ocr_mode: OcrMode\` (default \`Auto\`)
- \`AuditContext.ocr_mode: OcrMode\` (default \`Auto\`; recorded from spec)
- \`Engine::decode\` takes an \`OcrMode\` argument, uses the shared registry for \`Auto\` and rebuilds a per-request \`FormatRegistry\` with the PDF handler wired to the requested mode for non-default calls.

Feature-gated: the non-default path is only compiled with the \`codec-pdf-render\` feature (the only codec that honours \`OcrMode\` today). Without the feature, any non-default mode falls through to the shared registry.

\`OcrMode\` is re-exported from both \`nvisy-schema::primitive\` and \`nvisy-engine\` so callers don't need to reach into \`elide-core\`.

## Test plan

- [x] \`cargo test --workspace --all-features\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS=\"--cfg docsrs -D warnings\" cargo +nightly doc --workspace --no-deps --all-features\`
- [x] \`cargo +nightly fmt --all --check\`
- [x] \`cargo machete\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)