### PR TITLE
Restore FormatRegistry re-export and nvisy_engine::plan

### DIFF
--- a/crates/nvisy-engine/src/lib.rs
+++ b/crates/nvisy-engine/src/lib.rs
@@ -44,12 +44,18 @@ mod pipeline;
 pub mod provider;
 
 #[doc(inline)]
+pub use elide::codec::FormatRegistry;
+#[doc(inline)]
 pub use elide::redaction::operators::KeyProvider;
 #[doc(inline)]
 pub use elide_core::primitive::OcrMode;
 pub use elide_core::{Error, ErrorKind, Result};
 #[doc(inline)]
 pub use nvisy_schema::file::{Document, FileMetadata};
+/// Authored recognition plan: `AnalyzerParams`, caller-inlined
+/// pattern extras, scope, region annotations.
+#[doc(inline)]
+pub use nvisy_schema::plan;
 /// Authored redaction governance: policies, rules, predicates,
 /// operators.
 #[doc(inline)]


### PR DESCRIPTION
Follow-up to #386. Server touches both:

- **\`FormatRegistry\`** — the server registers custom codecs at startup and needs the type reachable at the crate root next to \`KeyProvider\`.
- **\`plan::*\`** — \`AnalyzerParams\` and friends. Re-exported as a submodule via \`pub use nvisy_schema::plan\`, matching the existing \`policy\` / \`template\` pattern.

Both were dropped in #386 as unused-by-anyone-in-this-workspace; the server (out-of-workspace consumer) actually needs them.

## Test plan

- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)