### PR TITLE
Add an all-modalities feature; bump bento and fix its repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deployment-owned NER, LLM, OCR, and STT recognizer/enricher lineups
   (deployment picks the providers; the wire only toggles them on or off).
 - HTTP client integration with the inference services shipped separately
-  from [nvisycom/bento](https://github.com/nvisycom/bento) via the
-  `elide-bento` git dependency.
+  from [nvisycom/elide-bento](https://github.com/nvisycom/elide-bento)
+  via the `elide-bento` git dependency.
+- `all-modalities` feature on `elide-pipeline` enabling every shipped
+  modality (tabular, image, audio, container documents) under one
+  toggle; `default` delegates to it. Text is unconditional and needs
+  no toggle. `codec-mp3` and `codec-pdf-render` stay opt-in: MP3
+  patent licensing may not be satisfiable downstream, and PDF
+  rasterisation pulls in a native rendering dependency.
+
+### Changed
+
+- The `elide-bento` dependency points at
+  [nvisycom/elide-bento](https://github.com/nvisycom/elide-bento),
+  matching the repository rename. The former `nvisycom/bento` URL
+  still redirects, so this names the canonical target rather than
+  fixing a break.
 
 ### Rust crates (`crates/`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "elide-bento"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/bento?branch=main#06be27c0e9f70c2e9ccb1101b13fefd947255644"
+source = "git+https://github.com/nvisycom/elide-bento?branch=main#543c2e554de73f0c5820a0d7b7cdac83e596671a"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ elide-operator = { git = "https://github.com/nvisycom/elide", branch = "main", d
 elide-stt = { git = "https://github.com/nvisycom/elide", branch = "main", default-features = false }
 
 # Elide extensions
-elide-bento = { git = "https://github.com/nvisycom/bento", branch = "main", default-features = false }
+elide-bento = { git = "https://github.com/nvisycom/elide-bento", branch = "main", default-features = false }
 
 # Internal crates
 elide-governance = { path = "./crates/elide-governance", version = "0.1.0" }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Elide Runtime
 
 [![Runtime](https://img.shields.io/github/actions/workflow/status/nvisycom/elide-runtime/build.yml?branch=main&label=runtime&style=flat-square)](https://github.com/nvisycom/elide-runtime/actions/workflows/build.yml)
-[![Inference](https://img.shields.io/github/actions/workflow/status/nvisycom/bento/build.yml?branch=main&label=inference&style=flat-square)](https://github.com/nvisycom/bento/actions/workflows/build.yml)
+[![Inference](https://img.shields.io/github/actions/workflow/status/nvisycom/elide-bento/build.yml?branch=main&label=inference&style=flat-square)](https://github.com/nvisycom/elide-bento/actions/workflows/build.yml)
 
 Multimodal redaction pipeline as a stateless Rust library.
 

--- a/crates/elide-pipeline/Cargo.toml
+++ b/crates/elide-pipeline/Cargo.toml
@@ -19,7 +19,17 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 
 [features]
-default = ["tabular", "image", "audio", "document"]
+default = ["all-modalities"]
+
+## Every modality this crate ships: tabular, image, audio, and the
+## container-document codecs. Text is unconditional, so it needs no
+## toggle. This is what `default` turns on.
+##
+## Deliberately excludes `codec-mp3` (MP3 patent licensing may not
+## be satisfiable downstream) and `codec-pdf-render` (drags in a
+## native rendering dep). Both stay opt-in: a caller asking for
+## every modality should not silently take on either.
+all-modalities = ["tabular", "image", "audio", "document"]
 
 ## Tabular modality (analyzer + anonymizer + redaction operators)
 ## plus every tabular codec elide ships (CSV, XLSX).

--- a/deny.toml
+++ b/deny.toml
@@ -76,5 +76,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # until their crates publish to crates.io. Scoped to these repos on purpose.
 allow-git = [
     "https://github.com/nvisycom/elide",
-    "https://github.com/nvisycom/bento",
+    "https://github.com/nvisycom/elide-bento",
 ]


### PR DESCRIPTION
## `all-modalities`

Callers wanting every modality had to spell out `tabular`, `image`,
`audio`, `document` and keep that list in sync as modalities are
added. One feature now names the set:

```toml
default = ["all-modalities"]

all-modalities = ["tabular", "image", "audio", "document"]
```

`default` delegates to it, so the two can no longer drift. Text is
unconditional and needs no toggle.

The feature set is byte-identical to the previous default, verified
by diffing `cargo tree -e features` before and after, so **nothing
changes about what ships**.

### What it deliberately excludes

`codec-mp3` and `codec-pdf-render` stay opt-in. Both are out of
defaults for reasons that do not evaporate when a caller asks for
every modality:

- **`codec-mp3`** carries MP3 patent licensing that may not be
  satisfiable downstream.
- **`codec-pdf-render`** drags in a native rendering dependency.

Neither should arrive silently on the back of a convenience feature.
Callers who want them keep asking for them by name.

## Bento

Pinned at `06be27c0` against the pre-rename `nvisycom/bento` URL.
Bumped to `543c2e55` and repointed at `nvisycom/elide-bento`. The old
URL still redirects, so this names the canonical target rather than
fixing a break. The README's inference badge pointed at the same
stale URL and follows.

**Elide needs no bump.** It is already pinned to `df3d708`, which is
`origin/main` as of this PR.

## Changelog

Both changes are recorded under `[Unreleased]`: `all-modalities` under
Added, with the reasoning for what it leaves out, and the repository
rename under a new Changed section. The existing bento link in Added
pointed at the pre-rename URL and follows.

## Test plan

- [x] `cargo +nightly fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] 74 tests pass
- [x] Builds under `--no-default-features`
- [x] Builds under `--no-default-features --features all-modalities`
- [x] Builds under defaults
- [x] `cargo tree -e features` diff empty vs. previous default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
