### PR TITLE
Derive a policy's label scope from its rules

### DIFF
--- a/crates/elide-governance/src/lib.rs
+++ b/crates/elide-governance/src/lib.rs
@@ -56,6 +56,5 @@ mod policy;
 pub mod redaction;
 
 pub use self::policy::{
-    LabelEntry, LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch,
-    TemplateOrigin,
+    LabelEntry, LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch, TemplateOrigin,
 };

--- a/crates/elide-governance/src/policy/label.rs
+++ b/crates/elide-governance/src/policy/label.rs
@@ -1,14 +1,6 @@
-//! Per-policy label catalog vocabulary and per-request named
-//! label groups.
+//! Per-request named label groups.
 //!
-//! Two shapes:
-//!
-//! - [`Labels`]: carried on each [`PolicyDefinition`]. Selects
-//!   builtins from elide-core's shipped set and adds inline
-//!   custom schemas. The engine unions every submitted policy's
-//!   `labels` into one `elide_core::entity::LabelCatalog` at
-//!   request-compile time.
-//! - [`LabelGroup`]: a named cluster of [`LabelRef`]s carried
+//! [`LabelGroup`] is a named cluster of [`LabelRef`]s carried
 //!   on the policy that declares it. Templates ship groups
 //!   (`"hipaa_18"`, `"gdpr_article_9"`, `"pci_chd"`); rules
 //!   inside the same policy reference groups by name via
@@ -19,37 +11,11 @@
 //! [`PolicyDefinition`]: super::PolicyDefinition
 //! [`Predicate::LabelInGroup`]: crate::Predicate::LabelInGroup
 
+use elide_core::entity::LabelRef;
 use elide_core::entity::audit::AttributionKind;
-use elide_core::entity::{Label, LabelRef};
 use hipstr::HipStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-/// Per-policy label-catalog selection.
-///
-/// Picks builtins by name + adds inline custom schemas.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct Labels {
-    /// Builtin label names to enable.
-    ///
-    /// E.g. `"email_address"`, `"phone_number"`. An unknown name
-    /// is rejected at request compile time: a typo fails loudly
-    /// rather than quietly dropping the label from the policy.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub builtins: Vec<LabelRef>,
-    /// Custom labels defined inline by the caller.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub custom: Vec<Label>,
-}
-
-impl Labels {
-    /// `true` when neither source contributes any label.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.builtins.is_empty() && self.custom.is_empty()
-    }
-}
 
 /// Named cluster of [`LabelRef`]s a policy's rules can reference
 /// by name via [`Predicate::LabelInGroup`].

--- a/crates/elide-governance/src/policy/mod.rs
+++ b/crates/elide-governance/src/policy/mod.rs
@@ -7,13 +7,14 @@ mod origin;
 mod predicate;
 mod rule;
 
+use elide_core::entity::{Label, LabelRef};
 use hipstr::HipStr;
 pub use predicate::Predicate;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub use self::label::{LabelGroup, Labels};
+pub use self::label::LabelGroup;
 pub use self::origin::TemplateOrigin;
 pub use self::rule::{LabelEntry, PolicyRule, RuleDispatch};
 use crate::redaction::ModalityRedactions;
@@ -50,16 +51,17 @@ pub struct PolicyDefinition {
     /// still matches. `None` means hand-authored.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub template: Option<TemplateOrigin>,
-    /// Vocabulary the policy operates over: builtins picked by
-    /// name plus caller-authored custom label schemas. Engine
-    /// unions every submitted policy's `labels` into a per-request
-    /// [`LabelCatalog`] used to drive recognizer dispatch and
-    /// tag-based [`Predicate::TagOneOf`] matching.
+    /// Caller-authored label schemas this policy introduces.
     ///
-    /// [`LabelCatalog`]: elide_core::entity::LabelCatalog
-    /// [`Predicate::TagOneOf`]: crate::Predicate::TagOneOf
-    #[serde(default, skip_serializing_if = "Labels::is_empty")]
-    pub labels: Labels,
+    /// Only for labels elide does not ship. Builtins are never
+    /// declared: a rule that targets one already names it, and
+    /// [`label_scope`] derives the policy's vocabulary from the
+    /// rules rather than from a second hand-maintained list that
+    /// could drift out of step with them.
+    ///
+    /// [`label_scope`]: Self::label_scope
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom: Vec<Label>,
     /// Named clusters of [`LabelRef`]s this policy's rules may
     /// reference by name via [`Predicate::LabelInGroup`]. Scoped
     /// to this policy: a rule can only name a group its own
@@ -80,4 +82,227 @@ pub struct PolicyDefinition {
     /// fallback per policy" at the type level.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback: Option<ModalityRedactions>,
+}
+
+impl PolicyDefinition {
+    /// Every label this policy operates over, derived from what
+    /// its rules actually target.
+    ///
+    /// Unions three sources:
+    ///
+    /// - every [`LabelGroup`]'s labels, since a rule referencing
+    ///   the group targets all of them;
+    /// - every [`RuleDispatch::Table`] entry's label;
+    /// - every [`Predicate::LabelOneOf`] leaf's labels, at any
+    ///   depth inside an `All` / `Any` / `Not` tree;
+    /// - plus [`custom`](Self::custom), whose schemas exist
+    ///   nowhere else.
+    ///
+    /// The engine unions this across every submitted policy into
+    /// the per-request `LabelCatalog` that drives recognizer
+    /// dispatch, and uses it again at match time so one policy
+    /// cannot act on an entity another policy pulled in.
+    ///
+    /// Deriving rather than declaring means the vocabulary cannot
+    /// drift from the rules: a label the rules target is always
+    /// detected, and a label nothing targets is never detected
+    /// only to pass through unredacted.
+    ///
+    /// [`Predicate::LabelOneOf`]: crate::Predicate::LabelOneOf
+    #[must_use]
+    pub fn label_scope(&self) -> Vec<LabelRef> {
+        let mut scope: Vec<LabelRef> = Vec::new();
+        let mut push = |label: &LabelRef| {
+            if !scope.contains(label) {
+                scope.push(label.clone());
+            }
+        };
+
+        for group in &self.groups {
+            for label in &group.labels {
+                push(label);
+            }
+        }
+        for rule in &self.rules {
+            match &rule.dispatch {
+                RuleDispatch::Table { operators } => {
+                    for entry in operators {
+                        push(&entry.label);
+                    }
+                }
+                RuleDispatch::Predicated { predicate, .. } => {
+                    collect_predicate_labels(predicate, &mut push);
+                }
+            }
+        }
+        for label in &self.custom {
+            push(&label.to_ref());
+        }
+        scope
+    }
+}
+
+/// Walk a [`Predicate`] tree, handing every [`LabelOneOf`] leaf's
+/// labels to `push`.
+///
+/// The other leaves name no label: `TagOneOf`, `Confidence`, and
+/// `CoRef` filter entities that recognition already produced, so
+/// they contribute nothing to what should be detected. A policy
+/// built only from those derives an empty scope and is inert.
+///
+/// [`LabelOneOf`]: crate::Predicate::LabelOneOf
+fn collect_predicate_labels(predicate: &Predicate, push: &mut impl FnMut(&LabelRef)) {
+    match predicate {
+        Predicate::LabelOneOf { labels } => {
+            for label in labels {
+                push(label);
+            }
+        }
+        Predicate::All { all } => {
+            for inner in all {
+                collect_predicate_labels(inner, push);
+            }
+        }
+        Predicate::Any { any } => {
+            for inner in any {
+                collect_predicate_labels(inner, push);
+            }
+        }
+        Predicate::Not { not } => collect_predicate_labels(not, push),
+        Predicate::TagOneOf { .. }
+        | Predicate::Confidence { .. }
+        | Predicate::LabelInGroup { .. }
+        | Predicate::CoRef { .. } => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use elide_core::entity::LabelRef;
+
+    use super::*;
+    use crate::redaction::{ModalityRedactions, TextRedaction};
+
+    fn policy(groups: Vec<LabelGroup>, rules: Vec<PolicyRule>) -> PolicyDefinition {
+        PolicyDefinition {
+            id: Uuid::nil(),
+            name: HipStr::borrowed("test"),
+            description: None,
+            template: None,
+            custom: Vec::new(),
+            groups,
+            rules,
+            fallback: None,
+        }
+    }
+
+    fn group(name: &'static str, labels: &[&'static str]) -> LabelGroup {
+        LabelGroup {
+            name: HipStr::borrowed(name),
+            description: None,
+            attribution: None,
+            labels: labels.iter().map(|l| LabelRef::from_static(l)).collect(),
+        }
+    }
+
+    fn predicated(predicate: Predicate) -> PolicyRule {
+        PolicyRule {
+            id: Uuid::nil(),
+            name: HipStr::borrowed("r"),
+            description: None,
+            attribution: None,
+            dispatch: RuleDispatch::Predicated {
+                predicate,
+                action: Box::new(ModalityRedactions::text(TextRedaction::Erase)),
+            },
+        }
+    }
+
+    fn scope_of(policy: &PolicyDefinition) -> Vec<String> {
+        let mut v: Vec<String> = policy
+            .label_scope()
+            .iter()
+            .map(|l| l.as_str().to_owned())
+            .collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn groups_contribute_their_labels() {
+        let p = policy(
+            vec![group("g", &["email_address", "phone_number"])],
+            Vec::new(),
+        );
+        assert_eq!(scope_of(&p), ["email_address", "phone_number"]);
+    }
+
+    #[test]
+    fn table_entries_contribute_their_labels() {
+        let rule = PolicyRule {
+            id: Uuid::nil(),
+            name: HipStr::borrowed("t"),
+            description: None,
+            attribution: None,
+            dispatch: RuleDispatch::Table {
+                operators: vec![LabelEntry {
+                    label: LabelRef::from_static("age"),
+                    action: ModalityRedactions::text(TextRedaction::Erase),
+                }],
+            },
+        };
+        assert_eq!(scope_of(&policy(Vec::new(), vec![rule])), ["age"]);
+    }
+
+    #[test]
+    fn label_one_of_contributes_at_any_predicate_depth() {
+        // Nested inside All/Not so a shallow walk would miss it.
+        let p = policy(
+            Vec::new(),
+            vec![predicated(Predicate::All {
+                all: vec![Predicate::Not {
+                    not: Box::new(Predicate::LabelOneOf {
+                        labels: vec![LabelRef::from_static("iban")],
+                    }),
+                }],
+            })],
+        );
+        assert_eq!(scope_of(&p), ["iban"]);
+    }
+
+    #[test]
+    fn label_less_predicates_contribute_nothing() {
+        // Tag, confidence, and coref filter entities recognition
+        // already produced; they cannot say what to detect. Such a
+        // policy derives an empty scope and is inert rather than an
+        // error.
+        for predicate in [
+            Predicate::TagOneOf {
+                tags: vec!["financial".to_owned()],
+            },
+            Predicate::Confidence {
+                min: 0.8_f32.try_into().expect("0.8 is a valid threshold"),
+            },
+            Predicate::CoRef {
+                coref: "subject-1".to_owned(),
+            },
+        ] {
+            let p = policy(Vec::new(), vec![predicated(predicate)]);
+            assert!(p.label_scope().is_empty());
+        }
+    }
+
+    #[test]
+    fn a_label_reached_twice_appears_once() {
+        let p = policy(
+            vec![
+                group("a", &["email_address"]),
+                group("b", &["email_address"]),
+            ],
+            vec![predicated(Predicate::LabelOneOf {
+                labels: vec![LabelRef::from_static("email_address")],
+            })],
+        );
+        assert_eq!(scope_of(&p), ["email_address"]);
+    }
 }

--- a/crates/elide-pipeline/src/analyzer/catalog.rs
+++ b/crates/elide-pipeline/src/analyzer/catalog.rs
@@ -1,7 +1,7 @@
 //! Compile a slice of [`PolicyDefinition`] into an
 //! [`elide_core::entity::LabelCatalog`].
 //!
-//! Walks every policy's [`labels`] block and unions the builtin
+//! Walks every policy's [`label_scope`] and unions the builtin
 //! selections and the inline custom schemas into one catalog. The
 //! union is strict: an unknown builtin name, two policies
 //! contributing a custom [`Label`] with the same id but different
@@ -22,36 +22,37 @@
 //!
 //! [`Label`]: elide_core::entity::Label
 //! [`PolicyDefinition`]: elide_governance::PolicyDefinition
-//! [`labels`]: elide_governance::PolicyDefinition::labels
+//! [`label_scope`]: elide_governance::PolicyDefinition::label_scope
 //! [`Predicate::LabelInGroup`]: elide_governance::Predicate::LabelInGroup
 //! [`Predicate::TagOneOf`]: elide_governance::Predicate::TagOneOf
 
 use std::sync::OnceLock;
 
-use elide_core::entity::{Label, LabelCatalog, LabelRef};
+use elide_core::entity::LabelCatalog;
 use elide_core::{Error, ErrorKind, Result};
 use elide_governance::PolicyDefinition;
 
 /// Compile the label catalog for a request from its policy set.
 ///
-/// Every policy contributes its [`labels`] block; builtins are
-/// resolved once against the cached full builtin catalog, custom
-/// labels are inserted as-is.
+/// Every policy contributes its derived [`label_scope`]: the labels
+/// its groups and rules actually target. Each is resolved against
+/// the cached full builtin catalog, and the policy's own `custom`
+/// schemas are inserted as-is.
 ///
 /// Rejects the request as a [`Configuration`](ErrorKind::Configuration)
 /// error if:
 ///
-/// - a `labels.builtins` entry names a label the shipped elide
-///   catalog does not know about (typo caught at request compile,
-///   not silent underfire at apply time);
-/// - a `labels.custom` id equals a shipped builtin id (silent
-///   builtin shadowing would strip elide's carefully-curated
-///   `pii` / `phi` / `pci` tags for every rule in the request);
-/// - two policies contribute a `labels.custom` [`Label`] with the
-///   same id but structurally different contents (byte-identical
+/// - a targeted label is neither a shipped builtin nor one of the
+///   policy's own customs (a typo in a group or rule, caught at
+///   request compile rather than underfiring silently at apply);
+/// - a `custom` id equals a shipped builtin id (silent builtin
+///   shadowing would strip elide's carefully-curated `pii` / `phi`
+///   / `pci` tags for every rule in the request);
+/// - two policies contribute a `custom` [`Label`] with the same id
+///   but structurally different contents (byte-identical
 ///   redeclaration across templates is fine).
 ///
-/// [`labels`]: elide_governance::PolicyDefinition::labels
+/// [`label_scope`]: elide_governance::PolicyDefinition::label_scope
 /// [`Label`]: elide_core::entity::Label
 pub(crate) fn compile_catalog(policies: &[PolicyDefinition]) -> Result<LabelCatalog> {
     let mut catalog = LabelCatalog::new();
@@ -63,21 +64,10 @@ pub(crate) fn compile_catalog(policies: &[PolicyDefinition]) -> Result<LabelCata
 
 fn insert_params(catalog: &mut LabelCatalog, policy: &PolicyDefinition) -> Result<()> {
     let builtins = builtin_catalog();
-    for label_ref in &policy.labels.builtins {
-        let label = builtins.get(label_ref).ok_or_else(|| {
-            Error::new(
-                ErrorKind::Configuration,
-                format!(
-                    "policy `{}` declares builtin label `{}` that no elide-shipped \
-                     catalog entry provides",
-                    policy.id,
-                    label_ref.as_str(),
-                ),
-            )
-        })?;
-        catalog.insert(label.clone());
-    }
-    for label in &policy.labels.custom {
+    // Customs first: a derived ref may name one, and it has to be
+    // in the catalog before the builtin lookup below rejects it as
+    // unknown.
+    for label in &policy.custom {
         if builtins.contains(&label.to_ref()) {
             return Err(Error::new(
                 ErrorKind::Configuration,
@@ -104,6 +94,27 @@ fn insert_params(catalog: &mut LabelCatalog, policy: &PolicyDefinition) -> Resul
         }
         catalog.insert(label.clone());
     }
+    // Then every label the rules actually target. A ref that is
+    // neither a shipped builtin nor one of this policy's customs is
+    // a typo in a rule or group, caught here rather than silently
+    // underfiring at apply time.
+    for label_ref in policy.label_scope() {
+        if catalog.contains(&label_ref) {
+            continue;
+        }
+        let label = builtins.get(&label_ref).ok_or_else(|| {
+            Error::new(
+                ErrorKind::Configuration,
+                format!(
+                    "policy `{}` targets label `{}`, which is neither a shipped \
+                     elide builtin nor one of the policy's own custom labels",
+                    policy.id,
+                    label_ref.as_str(),
+                ),
+            )
+        })?;
+        catalog.insert(label.clone());
+    }
     Ok(())
 }
 
@@ -118,26 +129,10 @@ fn builtin_catalog() -> &'static LabelCatalog {
     BUILTINS.get_or_init(LabelCatalog::with_builtins)
 }
 
-/// The set of [`LabelRef`]s a policy declares in its [`labels`]
-/// block, materialised for per-policy scoping at match time. Every
-/// predicate the selector compiles filters by whether the
-/// candidate entity's label is in this set: a policy that lists
-/// only `email_address` cannot fire on a `phone_number` entity
-/// another policy pulled into the request's recognition pass.
-///
-/// [`labels`]: elide_governance::PolicyDefinition::labels
-pub(crate) fn policy_label_scope(policy: &PolicyDefinition) -> Vec<LabelRef> {
-    let mut scope: Vec<LabelRef> =
-        Vec::with_capacity(policy.labels.builtins.len() + policy.labels.custom.len());
-    scope.extend(policy.labels.builtins.iter().cloned());
-    scope.extend(policy.labels.custom.iter().map(Label::to_ref));
-    scope
-}
-
 #[cfg(test)]
 mod tests {
     use elide_core::entity::{Label, LabelRef};
-    use elide_governance::{LabelGroup, Labels, PolicyDefinition};
+    use elide_governance::{LabelGroup, PolicyDefinition};
     use hipstr::HipStr;
     use uuid::Uuid;
 
@@ -146,21 +141,44 @@ mod tests {
     const POLICY_A: Uuid = Uuid::from_u128(0x01234567_89ab_7000_8000_000000000010_u128);
     const POLICY_B: Uuid = Uuid::from_u128(0x01234567_89ab_7000_8000_000000000011_u128);
 
-    fn policy_named(id: Uuid, labels: Labels, groups: Vec<LabelGroup>) -> PolicyDefinition {
+    fn policy_named(id: Uuid, custom: Vec<Label>, groups: Vec<LabelGroup>) -> PolicyDefinition {
         PolicyDefinition {
             id,
             name: HipStr::from("test"),
             description: None,
             template: None,
-            labels,
+            custom,
             groups,
             rules: Vec::new(),
             fallback: None,
         }
     }
 
-    fn policy_with_labels(labels: Labels) -> PolicyDefinition {
-        policy_named(POLICY_A, labels, Vec::new())
+    /// A policy whose vocabulary is derived from one group naming
+    /// `builtins`, plus any inline `custom` schemas.
+    fn policy_with_labels(builtins: Vec<LabelRef>, custom: Vec<Label>) -> PolicyDefinition {
+        let groups = if builtins.is_empty() {
+            Vec::new()
+        } else {
+            vec![LabelGroup {
+                name: HipStr::from("scope"),
+                description: None,
+                attribution: None,
+                labels: builtins,
+            }]
+        };
+        policy_named(POLICY_A, custom, groups)
+    }
+
+    /// A one-label group, so a policy's derived vocabulary
+    /// contains exactly `builtin`.
+    fn scope_group(builtin: &'static str) -> LabelGroup {
+        LabelGroup {
+            name: HipStr::from("scope"),
+            description: None,
+            attribution: None,
+            labels: vec![LabelRef::new(builtin)],
+        }
     }
 
     #[test]
@@ -170,10 +188,7 @@ mod tests {
 
     #[test]
     fn builtin_names_land_in_the_catalog() {
-        let p = policy_with_labels(Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        });
+        let p = policy_with_labels(vec![LabelRef::new("email_address")], Vec::new());
         let catalog = compile_catalog(std::slice::from_ref(&p)).unwrap();
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert_eq!(catalog.len(), 1);
@@ -181,10 +196,10 @@ mod tests {
 
     #[test]
     fn unknown_builtin_name_fails_the_request() {
-        let p = policy_with_labels(Labels {
-            builtins: vec![LabelRef::new("definitely_not_a_real_label")],
-            custom: Vec::new(),
-        });
+        let p = policy_with_labels(
+            vec![LabelRef::new("definitely_not_a_real_label")],
+            Vec::new(),
+        );
         let err = compile_catalog(std::slice::from_ref(&p))
             .expect_err("unknown builtin must reject the request");
         assert!(err.to_string().contains("definitely_not_a_real_label"));
@@ -193,32 +208,15 @@ mod tests {
 
     #[test]
     fn custom_labels_land_in_the_catalog() {
-        let p = policy_with_labels(Labels {
-            builtins: Vec::new(),
-            custom: vec![Label::new("project_code", "Project code")],
-        });
+        let p = policy_with_labels(Vec::new(), vec![Label::new("project_code", "Project code")]);
         let catalog = compile_catalog(std::slice::from_ref(&p)).unwrap();
         assert!(catalog.contains(&LabelRef::new("project_code")));
     }
 
     #[test]
     fn multiple_policies_union_their_labels() {
-        let a = policy_named(
-            POLICY_A,
-            Labels {
-                builtins: vec![LabelRef::new("email_address")],
-                custom: Vec::new(),
-            },
-            Vec::new(),
-        );
-        let b = policy_named(
-            POLICY_B,
-            Labels {
-                builtins: vec![LabelRef::new("phone_number")],
-                custom: Vec::new(),
-            },
-            Vec::new(),
-        );
+        let a = policy_named(POLICY_A, Vec::new(), vec![scope_group("email_address")]);
+        let b = policy_named(POLICY_B, Vec::new(), vec![scope_group("phone_number")]);
         let catalog = compile_catalog(&[a, b]).unwrap();
         assert!(catalog.contains(&LabelRef::new("email_address")));
         assert!(catalog.contains(&LabelRef::new("phone_number")));
@@ -231,10 +229,10 @@ mod tests {
         // declares a custom label with that id would silently strip
         // elide's `contact_info`/`pii` tags for every rule in the
         // request. Reject it.
-        let p = policy_with_labels(Labels {
-            builtins: Vec::new(),
-            custom: vec![Label::new("email_address", "Adresse électronique")],
-        });
+        let p = policy_with_labels(
+            Vec::new(),
+            vec![Label::new("email_address", "Adresse électronique")],
+        );
         let err = compile_catalog(std::slice::from_ref(&p))
             .expect_err("shadowing a builtin must reject the request");
         assert!(err.to_string().contains("email_address"));
@@ -247,22 +245,8 @@ mod tests {
         // both declare the same custom label with byte-identical
         // contents represent a shared vocabulary. Union cleanly.
         let label = Label::new("project_code", "Project code");
-        let a = policy_named(
-            POLICY_A,
-            Labels {
-                builtins: Vec::new(),
-                custom: vec![label.clone()],
-            },
-            Vec::new(),
-        );
-        let b = policy_named(
-            POLICY_B,
-            Labels {
-                builtins: Vec::new(),
-                custom: vec![label],
-            },
-            Vec::new(),
-        );
+        let a = policy_named(POLICY_A, vec![label.clone()], Vec::new());
+        let b = policy_named(POLICY_B, vec![label], Vec::new());
         let catalog = compile_catalog(&[a, b]).unwrap();
         assert!(catalog.contains(&LabelRef::new("project_code")));
         assert_eq!(catalog.len(), 1);
@@ -276,18 +260,12 @@ mod tests {
         // templates) and picking a winner would silently misredact.
         let a = policy_named(
             POLICY_A,
-            Labels {
-                builtins: Vec::new(),
-                custom: vec![Label::new("project_code", "Project code")],
-            },
+            vec![Label::new("project_code", "Project code")],
             Vec::new(),
         );
         let b = policy_named(
             POLICY_B,
-            Labels {
-                builtins: Vec::new(),
-                custom: vec![Label::new("project_code", "Legacy code")],
-            },
+            vec![Label::new("project_code", "Legacy code")],
             Vec::new(),
         );
         let err = compile_catalog(&[a, b])
@@ -307,14 +285,7 @@ mod tests {
             attribution: None,
             labels: vec![LabelRef::new("email_address")],
         };
-        let p = policy_named(
-            POLICY_A,
-            Labels {
-                builtins: vec![LabelRef::new("email_address")],
-                custom: Vec::new(),
-            },
-            vec![group],
-        );
+        let p = policy_named(POLICY_A, Vec::new(), vec![group]);
         let catalog = compile_catalog(std::slice::from_ref(&p)).unwrap();
         let stamped = catalog.get(&LabelRef::new("email_address")).unwrap();
         assert!(
@@ -334,15 +305,15 @@ mod tests {
     }
 
     #[test]
-    fn policy_label_scope_unions_builtins_and_customs() {
-        let p = policy_with_labels(Labels {
-            builtins: vec![
+    fn label_scope_unions_group_labels_and_customs() {
+        let p = policy_with_labels(
+            vec![
                 LabelRef::new("email_address"),
                 LabelRef::new("phone_number"),
             ],
-            custom: vec![Label::new("project_code", "Project code")],
-        });
-        let scope = policy_label_scope(&p);
+            vec![Label::new("project_code", "Project code")],
+        );
+        let scope = p.label_scope();
         assert!(scope.contains(&LabelRef::new("email_address")));
         assert!(scope.contains(&LabelRef::new("phone_number")));
         assert!(scope.contains(&LabelRef::new("project_code")));

--- a/crates/elide-pipeline/src/analyzer/mod.rs
+++ b/crates/elide-pipeline/src/analyzer/mod.rs
@@ -31,7 +31,7 @@ mod layer;
 mod modality;
 mod recognizers;
 
-pub(crate) use self::catalog::{compile_catalog, policy_label_scope};
+pub(crate) use self::catalog::compile_catalog;
 #[cfg(feature = "internal_audio")]
 pub(crate) use self::modality::compile_audio;
 #[cfg(feature = "internal_image")]

--- a/crates/elide-pipeline/src/anonymizer/compile/selector.rs
+++ b/crates/elide-pipeline/src/anonymizer/compile/selector.rs
@@ -4,8 +4,9 @@
 //!
 //! Every predicate compiles into a closure passed to
 //! [`Rule::predicate`]. A rule declared inside policy A can only
-//! fire on entities whose label is in `policy.labels` (its own
-//! declared vocabulary), and any [`Predicate::LabelInGroup`] leaf
+//! fire on entities whose label is in `policy.label_scope()`,
+//! derived from what its own groups and rules target, and any
+//! [`Predicate::LabelInGroup`] leaf
 //! resolves against `policy.groups`, not the shared label catalog.
 //! There is no request-shared string namespace (like a synthetic
 //! `group:*` tag) that another policy's [`Predicate::TagOneOf`]
@@ -44,23 +45,21 @@ use elide_core::operator::Operator;
 use elide_governance::{LabelGroup, PolicyDefinition, PolicyRule, Predicate};
 use uuid::Uuid;
 
-use crate::analyzer::policy_label_scope;
-
 /// Per-policy scoping context threaded into every predicate the
 /// selector compiles. Built once per policy at attach time; every
 /// rule inside that policy shares the same reference-counted copy.
 ///
-/// - `label_scope`: the [`LabelRef`]s the policy declares in its
-///   [`labels`] block. Every predicate filters by whether the
+/// - `label_scope`: the [`LabelRef`]s the policy's own groups and
+///   rules target. Every predicate filters by whether the
 ///   candidate entity's label is in this set, so a policy that
-///   lists only `email_address` never fires on a `phone_number`
+///   only reaches `email_address` never fires on a `phone_number`
 ///   another policy pulled into the request's recognition pass.
 /// - `groups`: resolved group name → labelset lookup, materialised
 ///   from the policy's [`groups`] block once. A rule can only
 ///   name a group its own policy declared (validated separately
 ///   in `pipeline::orchestrator::validate_group_references`).
 ///
-/// [`labels`]: elide_governance::PolicyDefinition::labels
+/// [`label_scope`]: elide_governance::PolicyDefinition::label_scope
 /// [`groups`]: elide_governance::PolicyDefinition::groups
 #[derive(Clone)]
 pub(in crate::anonymizer) struct PolicyContext {
@@ -80,10 +79,10 @@ impl PolicyContext {
     /// Materialise a policy's scoping context from its
     /// [`labels`] and [`groups`] blocks.
     ///
-    /// [`labels`]: elide_governance::PolicyDefinition::labels
+    /// [`label_scope`]: elide_governance::PolicyDefinition::label_scope
     /// [`groups`]: elide_governance::PolicyDefinition::groups
     pub(in crate::anonymizer) fn from_policy(policy: &PolicyDefinition) -> Self {
-        let label_scope: HashSet<LabelRef> = policy_label_scope(policy).into_iter().collect();
+        let label_scope: HashSet<LabelRef> = policy.label_scope().into_iter().collect();
         let groups: HashMap<String, HashSet<LabelRef>> =
             policy.groups.iter().map(group_lookup_entry).collect();
         Self {
@@ -93,10 +92,9 @@ impl PolicyContext {
         }
     }
 
-    /// Whether the enclosing policy declared vocabulary for
-    /// `label`. The gate every predicate: including the policy
-    /// fallback: passes through before any per-predicate logic
-    /// evaluates.
+    /// Whether the enclosing policy's rules reach `label`. The
+    /// gate every predicate, including the policy fallback,
+    /// passes through before any per-predicate logic evaluates.
     pub(in crate::anonymizer) fn label_scope_contains(&self, label: &LabelRef) -> bool {
         self.label_scope.contains(label)
     }
@@ -198,7 +196,7 @@ where
 ///
 /// Compiles the predicate into a closure that filters by
 /// `context.label_scope` before evaluating the tree; a rule
-/// cannot fire on labels its policy did not declare.
+/// cannot fire on labels its policy does not reach.
 ///
 /// [`Predicate`]: elide_governance::Predicate
 pub(super) fn attach<M, O>(

--- a/crates/elide-pipeline/src/pipeline/mod.rs
+++ b/crates/elide-pipeline/src/pipeline/mod.rs
@@ -255,7 +255,7 @@ impl Engine {
     /// modality tag via its [`EntityGroup`] variant.
     ///
     /// `policies` contributes the label catalog (each
-    /// [`PolicyDefinition::labels`] unions in) that drives
+    /// [`PolicyDefinition::label_scope`] unions in) that drives
     /// recognizer dispatch. Every policy carries its own
     /// [`LabelGroup`]s in [`PolicyDefinition::groups`]; a
     /// [`LabelInGroup`] predicate can only name a group its own
@@ -292,7 +292,7 @@ impl Engine {
     /// [`EntityGroup`]: crate::entity::EntityGroup
     /// [`LabelGroup`]: elide_governance::LabelGroup
     /// [`LabelInGroup`]: elide_governance::Predicate::LabelInGroup
-    /// [`PolicyDefinition::labels`]: elide_governance::PolicyDefinition::labels
+    /// [`PolicyDefinition::label_scope`]: elide_governance::PolicyDefinition::label_scope
     /// [`PolicyDefinition::groups`]: elide_governance::PolicyDefinition::groups
     pub async fn analyze(
         &self,

--- a/crates/elide-pipeline/src/pipeline/orchestrator.rs
+++ b/crates/elide-pipeline/src/pipeline/orchestrator.rs
@@ -84,7 +84,7 @@ impl Engine {
     /// request-scoped [`Scope`].
     ///
     /// The label catalog is derived from `policies`: every
-    /// submitted [`PolicyDefinition::labels`] unions into one
+    /// submitted [`PolicyDefinition::label_scope`] unions into one
     /// [`LabelCatalog`] used to drive recognizer dispatch and
     /// tag-based selector matching.
     ///
@@ -96,7 +96,7 @@ impl Engine {
     ///
     /// [`Scope`]: elide::recognition::Scope
     /// [`LabelCatalog`]: elide_core::entity::LabelCatalog
-    /// [`PolicyDefinition::labels`]: elide_governance::PolicyDefinition::labels
+    /// [`PolicyDefinition::label_scope`]: elide_governance::PolicyDefinition::label_scope
     pub(super) fn build_analyze_orchestrator(
         &self,
         spec: &AnalyzerParams,

--- a/crates/elide-pipeline/tests/multimodal.rs
+++ b/crates/elide-pipeline/tests/multimodal.rs
@@ -8,9 +8,8 @@ mod fixtures;
 use std::io::{Cursor, Read};
 
 use bytes::Bytes;
-use elide_core::entity::LabelRef;
+use elide_governance::PolicyDefinition;
 use elide_governance::redaction::{ModalityRedactions, TextRedaction};
-use elide_governance::{Labels, PolicyDefinition};
 use elide_pipeline::entity::Review;
 use elide_pipeline::provider::{OcrBackend, OcrConfig, OcrEnricherConfig};
 use elide_pipeline::{Audit, AuditContext, Engine, EntityGroup};
@@ -103,7 +102,7 @@ async fn anonymize_redacts_targeted_entity_and_preserves_other_parts() {
         name: "review-authority".into(),
         description: None,
         template: None,
-        labels: Labels::default(),
+        custom: Vec::new(),
         groups: Vec::new(),
         rules: Vec::new(),
         fallback: None,
@@ -197,10 +196,7 @@ async fn anonymize_succeeds_when_policies_supply_catalog_afresh() {
         name: "test".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: Vec::new(),
         rules: Vec::new(),
         fallback: None,
@@ -264,7 +260,7 @@ async fn analyze_rejects_policy_that_references_unknown_group() {
         name: "unknown-group".into(),
         description: None,
         template: None,
-        labels: Labels::default(),
+        custom: Vec::new(),
         groups: Vec::new(),
         rules: vec![rule],
         fallback: None,

--- a/crates/elide-pipeline/tests/policy_shapes.rs
+++ b/crates/elide-pipeline/tests/policy_shapes.rs
@@ -10,7 +10,7 @@ use elide_core::entity::LabelRef;
 use elide_core::entity::audit::AuditKind;
 use elide_governance::redaction::{ModalityRedactions, TextRedaction};
 use elide_governance::{
-    LabelEntry, LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch,
+    LabelEntry, LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch,
 };
 use elide_pipeline::entity::Review;
 use elide_pipeline::{Audit, Engine, EntityGroup};
@@ -85,13 +85,7 @@ async fn table_rule_dispatches_per_label_under_one_identity() {
         name: "contact-info".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![
-                LabelRef::new("email_address"),
-                LabelRef::new("phone_number"),
-            ],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: Vec::new(),
         rules: vec![table],
         fallback: None,
@@ -172,13 +166,7 @@ async fn label_in_group_predicate_fires_on_grouped_labels() {
         name: "sweep".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![
-                LabelRef::new("email_address"),
-                LabelRef::new("phone_number"),
-            ],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![group],
         rules: vec![PolicyRule {
             id: uuid::Uuid::now_v7(),
@@ -237,11 +225,16 @@ async fn per_policy_label_scoping_blocks_cross_policy_tag_bleed() {
         name: "email-only".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        },
-        groups: Vec::new(),
+        custom: Vec::new(),
+        // A `TagOneOf` rule names no label, so the policy's
+        // vocabulary comes from this group: it is what bounds which
+        // entities the tag rule can reach.
+        groups: vec![LabelGroup {
+            name: "scope".into(),
+            description: None,
+            attribution: None,
+            labels: vec![LabelRef::new("email_address")],
+        }],
         rules: vec![PolicyRule {
             id: uuid::Uuid::now_v7(),
             name: "erase-pii".into(),
@@ -264,12 +257,15 @@ async fn per_policy_label_scoping_blocks_cross_policy_tag_bleed() {
         name: "phone-only-no-rules".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("phone_number")],
-            custom: Vec::new(),
-        },
-        groups: Vec::new(),
-        // No rules: policy B only contributes vocabulary.
+        custom: Vec::new(),
+        // No rules: policy B only contributes vocabulary, which a
+        // group carries now that a policy declares no label list.
+        groups: vec![LabelGroup {
+            name: "scope".into(),
+            description: None,
+            attribution: None,
+            labels: vec![LabelRef::new("phone_number")],
+        }],
         rules: Vec::new(),
         fallback: None,
     };
@@ -312,10 +308,7 @@ async fn coarse_fallback_does_not_shadow_specific_later_rule() {
         name: "coarse-baseline".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: Vec::new(),
         rules: Vec::new(),
         fallback: Some(ModalityRedactions {
@@ -329,10 +322,7 @@ async fn coarse_fallback_does_not_shadow_specific_later_rule() {
         name: "specific-refinement".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: Vec::new(),
         rules: vec![PolicyRule {
             id: uuid::Uuid::now_v7(),
@@ -389,10 +379,7 @@ async fn cross_policy_group_reference_fails_the_request() {
         name: "borrower".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         // No groups declared here.
         groups: Vec::new(),
         rules: vec![PolicyRule {
@@ -417,10 +404,7 @@ async fn cross_policy_group_reference_fails_the_request() {
         name: "declares-group".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![LabelGroup {
             name: "contact_info".into(),
             description: None,
@@ -456,10 +440,7 @@ async fn override_naming_unknown_policy_fails_the_request() {
         name: "authorising".into(),
         description: None,
         template: None,
-        labels: Labels {
-            builtins: vec![LabelRef::new("email_address")],
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: Vec::new(),
         rules: Vec::new(),
         fallback: None,

--- a/crates/elide-template/src/template/ccpa.rs
+++ b/crates/elide-template/src/template/ccpa.rs
@@ -25,7 +25,7 @@
 
 use elide_core::entity::LabelRef;
 use elide_governance::redaction::{ModalityRedactions, TextRedaction};
-use elide_governance::{LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
+use elide_governance::{LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
 use jiff::civil::Date;
 use semver::Version;
 use uuid::{Uuid, uuid};
@@ -177,10 +177,7 @@ fn policy() -> PolicyDefinition {
                 .into(),
         ),
         template: Some(origin("ccpa", Version::new(1, 0, 0))),
-        labels: Labels {
-            builtins: CCPA_LABELS.to_vec(),
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![group()],
         rules: vec![erase_rule()],
         fallback: None,

--- a/crates/elide-template/src/template/gdpr/erase.rs
+++ b/crates/elide-template/src/template/gdpr/erase.rs
@@ -1,5 +1,5 @@
 use elide_governance::redaction::{ModalityRedactions, TextRedaction};
-use elide_governance::{LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
+use elide_governance::{LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
 use semver::Version;
 
 use super::super::{cited, derived_id, origin};
@@ -40,10 +40,7 @@ fn policy(scope: GdprSensitiveScope) -> PolicyDefinition {
                 .into(),
         ),
         template: Some(origin("gdpr_article_9_erase", Version::new(1, 0, 0))),
-        labels: Labels {
-            builtins: scope.labels(),
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![group(scope)],
         rules: vec![rule(scope)],
         fallback: None,

--- a/crates/elide-template/src/template/gdpr/pseudonymize.rs
+++ b/crates/elide-template/src/template/gdpr/pseudonymize.rs
@@ -1,5 +1,5 @@
 use elide_governance::redaction::{ModalityRedactions, TextRedaction};
-use elide_governance::{LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
+use elide_governance::{LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
 use semver::Version;
 
 use super::super::{cited, derived_id, origin};
@@ -44,10 +44,7 @@ fn policy(scope: GdprSensitiveScope) -> PolicyDefinition {
                 .into(),
         ),
         template: Some(origin("gdpr_article_9_pseudonymize", Version::new(1, 0, 0))),
-        labels: Labels {
-            builtins: scope.labels(),
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![group(scope)],
         rules: vec![rule(scope)],
         fallback: None,

--- a/crates/elide-template/src/template/hipaa/expert_determination.rs
+++ b/crates/elide-template/src/template/hipaa/expert_determination.rs
@@ -1,13 +1,13 @@
 use elide_core::entity::LabelRef;
 use elide_governance::redaction::{ClampBucket, ModalityRedactions, TextRedaction};
 use elide_governance::{
-    LabelEntry, LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch,
+    LabelEntry, LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch,
 };
 use elide_operator::operators::{DateGranularity, DateStyle};
 use semver::Version;
 
 use super::super::{cited, derived_id, origin};
-use super::safe_harbor::{SAFE_HARBOR_TABLE_LABELS, labels as safe_harbor_labels};
+use super::safe_harbor::labels as safe_harbor_labels;
 use super::{EFFECTIVE_DATE, HipaaAccountNumbers, Template, template_id};
 
 /// Group name Expert Determination's bulk-pseudonymize rule
@@ -58,13 +58,7 @@ fn expert_determination_policy(accounts: HipaaAccountNumbers) -> PolicyDefinitio
             "hipaa_deid_expert_determination",
             Version::new(1, 0, 0),
         )),
-        labels: Labels {
-            builtins: safe_harbor_labels(accounts)
-                .into_iter()
-                .chain(SAFE_HARBOR_TABLE_LABELS.iter().cloned())
-                .collect(),
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![ed_group(accounts)],
         rules: vec![ed_table_rule(accounts), ed_bulk_pseudonymize_rule(accounts)],
         fallback: None,

--- a/crates/elide-template/src/template/hipaa/limited_data_set.rs
+++ b/crates/elide-template/src/template/hipaa/limited_data_set.rs
@@ -1,6 +1,6 @@
 use elide_core::entity::LabelRef;
 use elide_governance::redaction::{ModalityRedactions, TextRedaction};
-use elide_governance::{LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
+use elide_governance::{LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
 use semver::Version;
 
 use super::super::{cited, derived_id, origin};
@@ -101,10 +101,7 @@ fn limited_data_set_policy(accounts: HipaaAccountNumbers) -> PolicyDefinition {
                 .into(),
         ),
         template: Some(origin("hipaa_deid_limited_data_set", Version::new(1, 0, 0))),
-        labels: Labels {
-            builtins: labels(accounts),
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![lds_group(accounts)],
         rules: vec![lds_bulk_erase_rule(accounts)],
         fallback: None,

--- a/crates/elide-template/src/template/hipaa/mod.rs
+++ b/crates/elide-template/src/template/hipaa/mod.rs
@@ -252,19 +252,17 @@ mod tests {
                 assert!(
                     extended
                         .policy
-                        .labels
-                        .builtins
+                        .label_scope()
                         .iter()
                         .any(|l| l.as_str() == want),
-                    "{method:?} Extended must carry `{want}` in policy builtins",
+                    "{method:?} Extended must reach `{want}`",
                 );
             }
             let standard = template(method, HipaaAccountNumbers::Standard);
             assert!(
                 !standard
                     .policy
-                    .labels
-                    .builtins
+                    .label_scope()
                     .iter()
                     .any(|l| l.as_str() == "crypto_address"),
                 "{method:?} Standard must not carry `crypto_address`",

--- a/crates/elide-template/src/template/hipaa/safe_harbor.rs
+++ b/crates/elide-template/src/template/hipaa/safe_harbor.rs
@@ -1,7 +1,7 @@
 use elide_core::entity::LabelRef;
 use elide_governance::redaction::{ClampBucket, ModalityRedactions, TextRedaction};
 use elide_governance::{
-    LabelEntry, LabelGroup, Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch,
+    LabelEntry, LabelGroup, PolicyDefinition, PolicyRule, Predicate, RuleDispatch,
 };
 use elide_operator::operators::{DateGranularity, DateStyle};
 use semver::Version;
@@ -82,6 +82,7 @@ pub(super) const SAFE_HARBOR_LABELS: &[LabelRef] = &[
 /// related to an individual*; generic `date_time` (invoice
 /// dates, meeting timestamps) shouldn't be generalized. Elide's
 /// `individual_date` label is the narrower fit.
+#[cfg(test)]
 pub(super) const SAFE_HARBOR_TABLE_LABELS: &[LabelRef] = &[
     LabelRef::from_static("age"),
     LabelRef::from_static("date_of_birth"),
@@ -123,13 +124,7 @@ fn safe_harbor_policy(accounts: HipaaAccountNumbers) -> PolicyDefinition {
                 .into(),
         ),
         template: Some(origin("hipaa_deid_safe_harbor", Version::new(1, 0, 0))),
-        labels: Labels {
-            builtins: labels(accounts)
-                .into_iter()
-                .chain(SAFE_HARBOR_TABLE_LABELS.iter().cloned())
-                .collect(),
-            custom: Vec::new(),
-        },
+        custom: Vec::new(),
         groups: vec![safe_harbor_group(accounts)],
         rules: vec![
             safe_harbor_table_rule(accounts),

--- a/crates/elide-template/src/template/pci.rs
+++ b/crates/elide-template/src/template/pci.rs
@@ -52,7 +52,7 @@
 
 use elide_core::entity::LabelRef;
 use elide_governance::redaction::{ModalityRedactions, TextRedaction};
-use elide_governance::{Labels, PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
+use elide_governance::{PolicyDefinition, PolicyRule, Predicate, RuleDispatch};
 use elide_operator::operators::Sha2Algorithm;
 use jiff::civil::Date;
 use schemars::JsonSchema;
@@ -209,10 +209,7 @@ fn pan_template(render: PciPanRender) -> Template {
             name: spec.policy_name.into(),
             description: Some(spec.policy_description.into()),
             template: Some(origin(spec.id, Version::new(1, 0, 0))),
-            labels: Labels {
-                builtins: vec![PAN_LABEL.clone()],
-                custom: Vec::new(),
-            },
+            custom: Vec::new(),
             groups: Vec::new(),
             rules: vec![spec.rule],
             fallback: None,
@@ -388,10 +385,7 @@ fn sav_template() -> Template {
                  posture: it must be erased."
                     .into(),
             ),
-            labels: Labels {
-                builtins: SAV_LABELS.to_vec(),
-                custom: Vec::new(),
-            },
+            custom: Vec::new(),
             groups: Vec::new(),
             rules: vec![sav_rule()],
             fallback: None,


### PR DESCRIPTION
## The problem

`PolicyDefinition` carried a `labels` block listing every label the
policy operates over, alongside groups and rules that named the same
labels again. CCPA wrote its 49 labels twice, verbatim:

```rust
labels: Labels { builtins: CCPA_LABELS.to_vec(), custom: vec![] },
groups: vec![LabelGroup { labels: CCPA_LABELS.to_vec(), .. }],
```

Nothing reconciled the two lists, so they could drift in either
direction, and both failures are silent:

| Mistake | What happens |
| --- | --- |
| Label in a group, missing from `labels` | Never detected, so the rule never fires. The policy looks correct and redacts nothing. |
| Label in `labels`, claimed by no rule | Detected, recorded in the audit as found, and passes through **unredacted**. |

Validation would only report these. Deriving the list makes them
unrepresentable.

## The change

`PolicyDefinition::label_scope()` unions what the rules actually
target:

- every `LabelGroup`'s labels;
- every `RuleDispatch::Table` entry's label;
- every `Predicate::LabelOneOf` leaf, at any depth inside an
  `All` / `Any` / `Not` tree;
- plus `custom`, whose schemas exist nowhere else.

`Labels` is removed. The policy keeps only `custom: Vec<Label>`: a
caller-authored schema cannot be derived from a `LabelRef` in a rule,
so it stays declared. Every shipped template sets it empty.

## Verification

The derived scope matches the old declarations **exactly** for every
shipped template, before and after:

| Template | Scope |
| --- | --- |
| `hipaa_deid_safe_harbor` | 34 |
| `hipaa_deid_safe_harbor_extended_accounts` | 35 |
| `gdpr_article_9_erase` | 17 |
| `ccpa` | 49 |
| `pci_dss_sav_erase` | 3 |

The `labels` block was pure redundancy.

## Label-less policies

`TagOneOf`, `Confidence`, and `CoRef` name no labels, so a policy
built only from those derives an empty scope and is inert. That is
left as-is rather than made an error: those predicates filter
entities recognition already produced, and detecting nothing is the
honest consequence of naming nothing. The one fixture relying on the
old behaviour now carries a group, which is what bounded it before.

## Incidental

`SAFE_HARBOR_TABLE_LABELS` becomes test-only. It existed to widen
`labels` past the bulk-erase group so `age` and the dates would still
be detected; the table rule names them directly, so derivation covers
it. The invariant test keeping them out of the group stays.

Also removes the `policy_label_scope` free function, a one-line
delegate once the method existed.

## Test plan

- [x] `cargo +nightly fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] 79 tests pass (5 new: group / table / nested-predicate
      derivation, label-less predicates, dedup)
- [x] Derived scope byte-identical to previous declarations across
      all five shipped templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Policy label scopes are now derived automatically from configured groups, rules, predicates, and custom labels.
  - Custom labels can be defined directly on policies.
  - Duplicate labels are consolidated while preserving their order and metadata.

- **Bug Fixes**
  - Unknown label references now produce clear configuration errors.
  - Label targeting is more accurately limited to labels reachable by each policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->