### PR TITLE
Detect language on every text-carrying modality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "elide-core",
  "futures",
@@ -1096,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "elide-docx"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "bytes",
  "hipstr",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "elide-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1123,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "elide-operator"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1228,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "elide-pdf"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "bytes",
  "hipstr",
@@ -1285,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#df3d7081263e7fe54a5deda037c1f0f8d8d418f3"
+source = "git+https://github.com/nvisycom/elide?branch=main#3ac996a3141bd314745a8c1e44dcd86737cb91f8"
 dependencies = [
  "async-trait",
  "elide-core",

--- a/crates/elide-pipeline/src/analyzer/enrichers.rs
+++ b/crates/elide-pipeline/src/analyzer/enrichers.rs
@@ -24,11 +24,11 @@ use elide_bento::ocr::BentoOcr;
 use elide_bento::stt::BentoStt;
 #[cfg(any(feature = "internal_image", feature = "internal_audio"))]
 use elide_core::Result;
+use elide_core::modality::TextRecognizable;
 #[cfg(feature = "internal_audio")]
 use elide_core::modality::audio::Audio;
 #[cfg(feature = "internal_image")]
 use elide_core::modality::image::Image;
-use elide_core::modality::text::Text;
 
 #[cfg(feature = "internal_image")]
 use crate::provider::ocr::OcrBackend;
@@ -37,11 +37,19 @@ use crate::provider::stt::SttBackend;
 
 /// Attach the lingua language-detection enricher.
 ///
-/// Text-modality only: writes the detected language into the
-/// per-request recognizer context, so pattern/NER/LLM downstream
-/// see what it wrote. The detector considers every language
-/// lingua was compiled with.
-pub(super) fn attach_language(analyzer: Analyzer<Text>) -> Analyzer<Text> {
+/// Writes the detected language into the per-request recognizer
+/// context, so pattern/NER/LLM downstream see what it wrote. The
+/// detector considers every language lingua was compiled with.
+///
+/// Generic over [`TextRecognizable`], the modalities whose payload
+/// is recognizable text: [`Text`] reads its body directly, and
+/// tabular reads each cell. A caller-asserted language on the
+/// request scope wins; the enricher skips detection entirely when
+/// one is present.
+///
+/// [`TextRecognizable`]: elide_core::modality::TextRecognizable
+/// [`Text`]: elide_core::modality::text::Text
+pub(super) fn attach_language<M: TextRecognizable>(analyzer: Analyzer<M>) -> Analyzer<M> {
     analyzer.with_enricher(LinguaEnricher::unrestricted())
 }
 

--- a/crates/elide-pipeline/src/analyzer/modality.rs
+++ b/crates/elide-pipeline/src/analyzer/modality.rs
@@ -58,12 +58,16 @@ pub(crate) fn compile_text(ner: &NerConfig, llm: &LlmConfig) -> Result<Analyzer<
 /// Compile a tabular-modality [`Analyzer`].
 ///
 /// Tabular runs Pattern and NER over each cell's text (cells
-/// are `TextRecognizable`). LLM has no `LlmModality` impl for
-/// Tabular in elide today.
+/// are `TextRecognizable`). Language detection attaches for the
+/// same reason it does on text: the recognizers downstream are
+/// language-scoped, so a cell would otherwise be analyzed with no
+/// language while the same value in a `.txt` had one. LLM has no
+/// `LlmModality` impl for Tabular in elide today.
 #[cfg(feature = "internal_tabular")]
 pub(crate) fn compile_tabular(ner: &NerConfig) -> Result<Analyzer<Tabular>> {
     let mut analyzer = Analyzer::<Tabular>::new();
 
+    analyzer = attach_language(analyzer);
     analyzer = attach_pattern(analyzer)?;
     analyzer = attach_ner_lineup(analyzer, ner)?;
 
@@ -74,7 +78,8 @@ pub(crate) fn compile_tabular(ner: &NerConfig) -> Result<Analyzer<Tabular>> {
 ///
 /// Image is the fullest non-text modality: Pattern and NER run
 /// over the OCR'd text (the OCR enricher stamps a `Layout` onto
-/// the recognizer artifacts upstream), and LLM is available
+/// the recognizer artifacts upstream), language detection reads
+/// that same text, and LLM is available
 /// image-natively for vision-language models. The OCR enricher
 /// attaches when the deployment wired one via
 /// [`Engine::with_ocr`].
@@ -92,6 +97,10 @@ pub(crate) fn compile_image(
         analyzer = attach_ocr(analyzer, ocr)?;
     }
 
+    // After OCR: image text lives in the artifacts the OCR
+    // enricher stamps, so detection reads an empty string until it
+    // has run.
+    analyzer = attach_language(analyzer);
     analyzer = attach_pattern(analyzer)?;
     analyzer = attach_ner_lineup(analyzer, ner)?;
     analyzer = attach_llm_lineup(analyzer, llm, AttachTo::Image)?;
@@ -101,11 +110,12 @@ pub(crate) fn compile_image(
 
 /// Compile an audio-modality [`Analyzer`].
 ///
-/// Audio runs Pattern and NER over the transcript text. The STT
-/// enricher stamps `TranscriptSegment`s onto the recognizer
-/// artifacts before recognition; it attaches when the deployment
-/// wired one via [`Engine::with_stt`]. LLM has no `LlmModality`
-/// impl for Audio in elide today.
+/// Audio runs Pattern, NER, and language detection over the
+/// transcript text. The STT enricher stamps `TranscriptSegment`s
+/// onto the recognizer artifacts before recognition; it attaches
+/// when the deployment wired one via [`Engine::with_stt`], and
+/// without it the transcript is empty so language detection is a
+/// no-op. LLM has no `LlmModality` impl for Audio in elide today.
 ///
 /// [`Engine::with_stt`]: crate::Engine::with_stt
 #[cfg(feature = "internal_audio")]
@@ -116,6 +126,9 @@ pub(crate) fn compile_audio(ner: &NerConfig, stt: Option<&SttBackend>) -> Result
         analyzer = attach_stt(analyzer, stt)?;
     }
 
+    // After STT, for the same reason as image: the transcript is an
+    // artifact, so language detection reads nothing before it lands.
+    analyzer = attach_language(analyzer);
     analyzer = attach_pattern(analyzer)?;
     analyzer = attach_ner_lineup(analyzer, ner)?;
 


### PR DESCRIPTION
## The bug

Only text got the lingua enricher. A name in a `.csv` cell was
analyzed with no language while the same name in a `.txt` had one, so
language-scoped recognizers behaved differently depending on the
container the data arrived in.

This could not be fixed here: `LinguaEnricher` implemented
`Enricher<Text>` only, so `attach_language` was typed
`Analyzer<Text> -> Analyzer<Text>` and `compile_tabular`
structurally could not call it.

## The fix

elide `3ac996a` generalises the enricher to
`impl<M: TextRecognizable> Enricher<M>`, reading the payload through
`M::as_text`. `attach_language` follows, and every text-carrying
modality now attaches it:

| Modality | Text source |
| --- | --- |
| text | the body |
| tabular | each cell |
| image | the OCR enricher's output |
| audio | the STT transcript |

### Ordering

Image and audio read their text from recognizer *artifacts*, not from
their own payload — `as_text` returns `""` until the producing
enricher has run. Language therefore attaches **after** the OCR and
STT attach, so detection sees real text.

Without a wired OCR or STT backend it is a no-op, which is correct:
there is no text to detect a language in.

A caller-asserted language on the request scope still wins
everywhere; the enricher skips detection when one is present.

## Test plan

- [x] `cargo +nightly fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] 74 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language detection support for tabular data, images, and audio.
  * Language detection now processes table cells, OCR text, and speech transcripts.
  * Added support for language enrichment across all supported text-bearing content types.
  * Documented supported content and language override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->